### PR TITLE
Add failing unit test

### DIFF
--- a/tests/tests.c
+++ b/tests/tests.c
@@ -67,6 +67,30 @@ static void test_upb_symtab() {
   upb_def_unref(def2);
 }
 
+static void test_upb_two_fielddefs() {
+  upb_fielddef *f1 = upb_fielddef_new();
+  upb_fielddef *f2 = upb_fielddef_new();
+
+  ASSERT(upb_fielddef_ismutable(f1));
+  upb_fielddef_setname(f1, "");
+  upb_fielddef_setnumber(f1, 1937);
+  upb_fielddef_settype(f1, UPB_TYPE(FIXED64));
+  upb_fielddef_setlabel(f1, UPB_LABEL(REPEATED));
+  upb_fielddef_settypename(f1, "");
+  ASSERT(upb_fielddef_number(f1) == 1937);
+
+  ASSERT(upb_fielddef_ismutable(f2));
+  upb_fielddef_setname(f2, "");
+  upb_fielddef_setnumber(f2, 1572);
+  upb_fielddef_settype(f2, UPB_TYPE(BYTES));
+  upb_fielddef_setlabel(f2, UPB_LABEL(REPEATED));
+  upb_fielddef_settypename(f2, "");
+  ASSERT(upb_fielddef_number(f2) == 1572);
+
+  upb_fielddef_unref(f1);
+  upb_fielddef_unref(f2);
+}
+
 int main()
 {
 #define TEST(func) do { \
@@ -78,6 +102,7 @@ int main()
 
   TEST(test_upb_symtab);
   TEST(test_upb_jit);
+  TEST(test_upb_two_fielddefs);
   printf("All tests passed (%d assertions).\n", num_assertions);
   return 0;
 }


### PR DESCRIPTION
This might actually just bring to light my misuse of the upb_fielddef
functions. The test assertions are fine, but an assertion in upb/upb.h
fails:

```
./upb/upb.h:181: upb_value_getptr: Assertion `val.type == 33' failed.
```

I tried to shrink the test case into something quite small.
