### PR TITLE
Amalgamated distribution (upb.c/upb.h) tool.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 # Threading:
 # * -DUPB_THREAD_UNSAFE: remove all thread-safety.
 
-.PHONY: all lib clean tests test benchmark descriptorgen
+.PHONY: all lib clean tests test benchmark descriptorgen amalgamate
 .PHONY: clean_leave_profile
 
 # Prevents the deletion of intermediate files.
@@ -462,3 +462,13 @@ $(RUBYEXT): upb/bindings/ruby/upb.c upb/bindings/ruby/Makefile
 
 rubytest: $(RUBYEXT) upb/descriptor/descriptor.pb
 	RUBYLIB="upb/bindings/ruby" ruby tests/bindings/ruby/upb.rb
+
+# Amalgamated source (upb.c/upb.h) ############################################
+
+AMALGAMATE_SRCS=$(upb_SRCS) $(upb_descriptor_SRCS) $(upb_pb_SRCS) $(upb_json_SRCS)
+
+amalgamate: upb.c upb.h
+
+upb.c upb.h: $(AMALGAMATE_SRCS)
+	$(E) AMALGAMATE $@
+	$(Q) ./tools/amalgamate.py "" "" $^

--- a/tools/amalgamate.py
+++ b/tools/amalgamate.py
@@ -1,0 +1,47 @@
+#!/usr/bin/python
+
+import sys
+import re
+
+INCLUDE_RE = re.compile('^#include "([^"]*)"$')
+
+def parse_include(line):
+  match = INCLUDE_RE.match(line)
+  return match.groups()[0] if match else None
+
+class Amalgamator:
+  def __init__(self, include_path, output_path):
+    self.include_path = include_path
+    self.included = set()
+    self.output_h = open(output_path + "upb.h", "w")
+    self.output_c = open(output_path + "upb.c", "w")
+
+    self.output_c.write("// Amalgamated source file\n")
+    self.output_c.write('#include "upb.h"\n')
+
+    self.output_h.write("// Amalgamated source file\n")
+
+  def _process_file(self, infile_name, outfile):
+    for line in open(infile_name):
+      include = parse_include(line)
+      if include is not None and include.startswith("upb"):
+        if include not in self.included:
+          self.included.add(include)
+          self._add_header(self.include_path + include)
+      else:
+        outfile.write(line)
+
+  def _add_header(self, filename):
+    self._process_file(filename, self.output_h)
+
+  def add_src(self, filename):
+    self._process_file(filename, self.output_c)
+
+# ---- main ----
+
+include_path = sys.argv[1]
+output_path = sys.argv[2]
+amalgamator = Amalgamator(include_path, output_path)
+
+for filename in sys.argv[3:]:
+  amalgamator.add_src(filename.strip())

--- a/upb/handlers.c
+++ b/upb/handlers.c
@@ -120,7 +120,7 @@ static int32_t trygetsel(upb_handlers *h, const upb_fielddef *f,
   return sel;
 }
 
-static upb_selector_t getsel(upb_handlers *h, const upb_fielddef *f,
+static upb_selector_t handlers_getsel(upb_handlers *h, const upb_fielddef *f,
                              upb_handlertype_t type) {
   int32_t sel = trygetsel(h, f, type);
   assert(sel >= 0);
@@ -129,7 +129,7 @@ static upb_selector_t getsel(upb_handlers *h, const upb_fielddef *f,
 
 static const void **returntype(upb_handlers *h, const upb_fielddef *f,
                                upb_handlertype_t type) {
-  return &h->table[getsel(h, f, type)].attr.return_closure_type_;
+  return &h->table[handlers_getsel(h, f, type)].attr.return_closure_type_;
 }
 
 static bool doset(upb_handlers *h, int32_t sel, const upb_fielddef *f,
@@ -213,18 +213,18 @@ const void *effective_closure_type(upb_handlers *h, const upb_fielddef *f,
   if (upb_fielddef_isseq(f) &&
       type != UPB_HANDLER_STARTSEQ &&
       type != UPB_HANDLER_ENDSEQ &&
-      h->table[sel = getsel(h, f, UPB_HANDLER_STARTSEQ)].func) {
+      h->table[sel = handlers_getsel(h, f, UPB_HANDLER_STARTSEQ)].func) {
     ret = upb_handlerattr_returnclosuretype(&h->table[sel].attr);
   }
 
   if (type == UPB_HANDLER_STRING &&
-      h->table[sel = getsel(h, f, UPB_HANDLER_STARTSTR)].func) {
+      h->table[sel = handlers_getsel(h, f, UPB_HANDLER_STARTSTR)].func) {
     ret = upb_handlerattr_returnclosuretype(&h->table[sel].attr);
   }
 
   // The effective type of the submessage; not used yet.
   // if (type == SUBMESSAGE &&
-  //     h->table[sel = getsel(h, f, UPB_HANDLER_STARTSUBMSG)].func) {
+  //     h->table[sel = handlers_getsel(h, f, UPB_HANDLER_STARTSUBMSG)].func) {
   //   ret = upb_handlerattr_returnclosuretype(&h->table[sel].attr);
   // }
 
@@ -237,7 +237,7 @@ const void *effective_closure_type(upb_handlers *h, const upb_fielddef *f,
 // the return closure type of this handler's attr.
 bool checkstart(upb_handlers *h, const upb_fielddef *f, upb_handlertype_t type,
                 upb_status *status) {
-  upb_selector_t sel = getsel(h, f, type);
+  upb_selector_t sel = handlers_getsel(h, f, type);
   if (h->table[sel].func) return true;
   const void *closure_type = effective_closure_type(h, f, type);
   const upb_handlerattr *attr = &h->table[sel].attr;
@@ -444,14 +444,18 @@ bool upb_handlers_freeze(upb_handlers *const*handlers, int n, upb_status *s) {
 
       if (upb_fielddef_issubmsg(f)) {
         bool hashandler = false;
-        if (upb_handlers_gethandler(h, getsel(h, f, UPB_HANDLER_STARTSUBMSG)) ||
-            upb_handlers_gethandler(h, getsel(h, f, UPB_HANDLER_ENDSUBMSG))) {
+        if (upb_handlers_gethandler(
+                h, handlers_getsel(h, f, UPB_HANDLER_STARTSUBMSG)) ||
+            upb_handlers_gethandler(
+                h, handlers_getsel(h, f, UPB_HANDLER_ENDSUBMSG))) {
           hashandler = true;
         }
 
         if (upb_fielddef_isseq(f) &&
-            (upb_handlers_gethandler(h, getsel(h, f, UPB_HANDLER_STARTSEQ)) ||
-             upb_handlers_gethandler(h, getsel(h, f, UPB_HANDLER_ENDSEQ)))) {
+            (upb_handlers_gethandler(
+                 h, handlers_getsel(h, f, UPB_HANDLER_STARTSEQ)) ||
+             upb_handlers_gethandler(
+                 h, handlers_getsel(h, f, UPB_HANDLER_ENDSEQ)))) {
           hashandler = true;
         }
 

--- a/upb/handlers.h
+++ b/upb/handlers.h
@@ -23,6 +23,7 @@
 #define UPB_HANDLERS_H
 
 #include "upb/def.h"
+#include "upb/table.int.h"
 
 #ifdef __cplusplus
 namespace upb {

--- a/upb/json/parser.c
+++ b/upb/json/parser.c
@@ -33,7 +33,7 @@
 
 #include "upb/json/parser.h"
 
-#define CHECK_RETURN(x) if (!(x)) return false
+#define PARSER_CHECK_RETURN(x) if (!(x)) return false
 
 static upb_selector_t getsel_for_handlertype(upb_json_parser *p,
                                              upb_handlertype_t type) {
@@ -43,7 +43,7 @@ static upb_selector_t getsel_for_handlertype(upb_json_parser *p,
   return sel;
 }
 
-static upb_selector_t getsel(upb_json_parser *p) {
+static upb_selector_t parser_getsel(upb_json_parser *p) {
   return getsel_for_handlertype(
       p, upb_handlers_getprimitivehandlertype(p->top->f));
 }
@@ -153,7 +153,7 @@ static void end_array(upb_json_parser *p) {
 
 static void clear_member(upb_json_parser *p) { p->top->f = NULL; }
 
-static bool putbool(upb_json_parser *p, bool val) {
+static bool parser_putbool(upb_json_parser *p, bool val) {
   if (upb_fielddef_type(p->top->f) != UPB_TYPE_BOOL) {
     upb_status_seterrf(p->status,
                        "Boolean value specified for non-bool field: %s",
@@ -161,7 +161,7 @@ static bool putbool(upb_json_parser *p, bool val) {
     return false;
   }
 
-  bool ok = upb_sink_putbool(&p->top->sink, getsel(p), val);
+  bool ok = upb_sink_putbool(&p->top->sink, parser_getsel(p), val);
   UPB_ASSERT_VAR(ok, ok);
   return true;
 }
@@ -297,7 +297,8 @@ static bool end_text(upb_json_parser *p, const char *ptr, bool is_num) {
     // This is a string field (as opposed to a member name).
     upb_selector_t sel = getsel_for_handlertype(p, UPB_HANDLER_STRING);
     if (upb_fielddef_type(p->top->f) == UPB_TYPE_BYTES) {
-      CHECK_RETURN(base64_push(p, sel, p->accumulated, p->accumulated_len));
+      PARSER_CHECK_RETURN(base64_push(p, sel, p->accumulated,
+                                      p->accumulated_len));
     } else {
       upb_sink_putstring(&p->top->sink, sel, p->accumulated, p->accumulated_len, NULL);
     }
@@ -313,7 +314,7 @@ static bool end_text(upb_json_parser *p, const char *ptr, bool is_num) {
     int32_t int_val = 0;
     if (upb_enumdef_ntoi(enumdef, p->accumulated, p->accumulated_len,
                          &int_val)) {
-      upb_selector_t sel = getsel(p);
+      upb_selector_t sel = parser_getsel(p);
       upb_sink_putint32(&p->top->sink, sel, int_val);
     } else {
       upb_status_seterrmsg(p->status, "Enum value name unknown");
@@ -379,7 +380,7 @@ static void end_number(upb_json_parser *p, const char *ptr) {
       if (val > INT32_MAX || val < INT32_MIN || errno == ERANGE || end != myend)
         assert(false);
       else
-        upb_sink_putint32(&p->top->sink, getsel(p), val);
+        upb_sink_putint32(&p->top->sink, parser_getsel(p), val);
       break;
     }
     case UPB_TYPE_INT64: {
@@ -387,7 +388,7 @@ static void end_number(upb_json_parser *p, const char *ptr) {
       if (val > INT64_MAX || val < INT64_MIN || errno == ERANGE || end != myend)
         assert(false);
       else
-        upb_sink_putint64(&p->top->sink, getsel(p), val);
+        upb_sink_putint64(&p->top->sink, parser_getsel(p), val);
       break;
     }
     case UPB_TYPE_UINT32: {
@@ -395,7 +396,7 @@ static void end_number(upb_json_parser *p, const char *ptr) {
       if (val > UINT32_MAX || errno == ERANGE || end != myend)
         assert(false);
       else
-        upb_sink_putuint32(&p->top->sink, getsel(p), val);
+        upb_sink_putuint32(&p->top->sink, parser_getsel(p), val);
       break;
     }
     case UPB_TYPE_UINT64: {
@@ -403,7 +404,7 @@ static void end_number(upb_json_parser *p, const char *ptr) {
       if (val > UINT64_MAX || errno == ERANGE || end != myend)
         assert(false);
       else
-        upb_sink_putuint64(&p->top->sink, getsel(p), val);
+        upb_sink_putuint64(&p->top->sink, parser_getsel(p), val);
       break;
     }
     case UPB_TYPE_DOUBLE: {
@@ -411,7 +412,7 @@ static void end_number(upb_json_parser *p, const char *ptr) {
       if (errno == ERANGE || end != myend)
         assert(false);
       else
-        upb_sink_putdouble(&p->top->sink, getsel(p), val);
+        upb_sink_putdouble(&p->top->sink, parser_getsel(p), val);
       break;
     }
     case UPB_TYPE_FLOAT: {
@@ -419,7 +420,7 @@ static void end_number(upb_json_parser *p, const char *ptr) {
       if (errno == ERANGE || end != myend)
         assert(false);
       else
-        upb_sink_putfloat(&p->top->sink, getsel(p), val);
+        upb_sink_putfloat(&p->top->sink, parser_getsel(p), val);
       break;
     }
     default:
@@ -505,11 +506,11 @@ static void hex(upb_json_parser *p, const char *end) {
 // What follows is the Ragel parser itself.  The language is specified in Ragel
 // and the actions call our C functions above.
 
-#line 595 "upb/json/parser.rl"
+#line 596 "upb/json/parser.rl"
 
 
 
-#line 513 "upb/json/parser.c"
+#line 514 "upb/json/parser.c"
 static const char _json_actions[] = {
 	0, 1, 0, 1, 2, 1, 3, 1, 
 	4, 1, 5, 1, 6, 1, 7, 1, 
@@ -662,7 +663,7 @@ static const int json_en_value_machine = 27;
 static const int json_en_main = 1;
 
 
-#line 598 "upb/json/parser.rl"
+#line 599 "upb/json/parser.rl"
 
 size_t parse(void *closure, const void *hd, const char *buf, size_t size,
              const upb_bufhandle *handle) {
@@ -679,7 +680,7 @@ size_t parse(void *closure, const void *hd, const char *buf, size_t size,
   const char *pe = buf + size;
 
   
-#line 683 "upb/json/parser.c"
+#line 684 "upb/json/parser.c"
 	{
 	int _klen;
 	unsigned int _trans;
@@ -754,114 +755,114 @@ _match:
 		switch ( *_acts++ )
 		{
 	case 0:
-#line 516 "upb/json/parser.rl"
+#line 517 "upb/json/parser.rl"
 	{ p--; {cs = stack[--top]; goto _again;} }
 	break;
 	case 1:
-#line 517 "upb/json/parser.rl"
+#line 518 "upb/json/parser.rl"
 	{ p--; {stack[top++] = cs; cs = 10; goto _again;} }
 	break;
 	case 2:
-#line 521 "upb/json/parser.rl"
+#line 522 "upb/json/parser.rl"
 	{ start_text(parser, p); }
 	break;
 	case 3:
-#line 522 "upb/json/parser.rl"
+#line 523 "upb/json/parser.rl"
 	{ CHECK_RETURN_TOP(end_text(parser, p, false)); }
 	break;
 	case 4:
-#line 528 "upb/json/parser.rl"
+#line 529 "upb/json/parser.rl"
 	{ start_hex(parser, p); }
 	break;
 	case 5:
-#line 529 "upb/json/parser.rl"
+#line 530 "upb/json/parser.rl"
 	{ hex(parser, p); }
 	break;
 	case 6:
-#line 535 "upb/json/parser.rl"
+#line 536 "upb/json/parser.rl"
 	{ escape(parser, p); }
 	break;
 	case 7:
-#line 538 "upb/json/parser.rl"
+#line 539 "upb/json/parser.rl"
 	{ {cs = stack[--top]; goto _again;} }
 	break;
 	case 8:
-#line 539 "upb/json/parser.rl"
+#line 540 "upb/json/parser.rl"
 	{ {stack[top++] = cs; cs = 19; goto _again;} }
 	break;
 	case 9:
-#line 541 "upb/json/parser.rl"
+#line 542 "upb/json/parser.rl"
 	{ p--; {stack[top++] = cs; cs = 27; goto _again;} }
 	break;
 	case 10:
-#line 546 "upb/json/parser.rl"
+#line 547 "upb/json/parser.rl"
 	{ start_member(parser); }
 	break;
 	case 11:
-#line 547 "upb/json/parser.rl"
+#line 548 "upb/json/parser.rl"
 	{ CHECK_RETURN_TOP(end_member(parser)); }
 	break;
 	case 12:
-#line 550 "upb/json/parser.rl"
+#line 551 "upb/json/parser.rl"
 	{ clear_member(parser); }
 	break;
 	case 13:
-#line 556 "upb/json/parser.rl"
+#line 557 "upb/json/parser.rl"
 	{ start_object(parser); }
 	break;
 	case 14:
-#line 559 "upb/json/parser.rl"
+#line 560 "upb/json/parser.rl"
 	{ end_object(parser); }
 	break;
 	case 15:
-#line 565 "upb/json/parser.rl"
+#line 566 "upb/json/parser.rl"
 	{ CHECK_RETURN_TOP(start_array(parser)); }
 	break;
 	case 16:
-#line 569 "upb/json/parser.rl"
+#line 570 "upb/json/parser.rl"
 	{ end_array(parser); }
 	break;
 	case 17:
-#line 574 "upb/json/parser.rl"
+#line 575 "upb/json/parser.rl"
 	{ start_number(parser, p); }
 	break;
 	case 18:
-#line 575 "upb/json/parser.rl"
+#line 576 "upb/json/parser.rl"
 	{ end_number(parser, p); }
 	break;
 	case 19:
-#line 577 "upb/json/parser.rl"
+#line 578 "upb/json/parser.rl"
 	{ CHECK_RETURN_TOP(start_stringval(parser)); }
 	break;
 	case 20:
-#line 578 "upb/json/parser.rl"
+#line 579 "upb/json/parser.rl"
 	{ end_stringval(parser); }
 	break;
 	case 21:
-#line 580 "upb/json/parser.rl"
-	{ CHECK_RETURN_TOP(putbool(parser, true)); }
+#line 581 "upb/json/parser.rl"
+	{ CHECK_RETURN_TOP(parser_putbool(parser, true)); }
 	break;
 	case 22:
-#line 582 "upb/json/parser.rl"
-	{ CHECK_RETURN_TOP(putbool(parser, false)); }
+#line 583 "upb/json/parser.rl"
+	{ CHECK_RETURN_TOP(parser_putbool(parser, false)); }
 	break;
 	case 23:
-#line 584 "upb/json/parser.rl"
+#line 585 "upb/json/parser.rl"
 	{ /* null value */ }
 	break;
 	case 24:
-#line 586 "upb/json/parser.rl"
+#line 587 "upb/json/parser.rl"
 	{ CHECK_RETURN_TOP(start_subobject(parser)); }
 	break;
 	case 25:
-#line 587 "upb/json/parser.rl"
+#line 588 "upb/json/parser.rl"
 	{ end_subobject(parser); }
 	break;
 	case 26:
-#line 592 "upb/json/parser.rl"
+#line 593 "upb/json/parser.rl"
 	{ p--; {cs = stack[--top]; goto _again;} }
 	break;
-#line 865 "upb/json/parser.c"
+#line 866 "upb/json/parser.c"
 		}
 	}
 
@@ -874,7 +875,7 @@ _again:
 	_out: {}
 	}
 
-#line 614 "upb/json/parser.rl"
+#line 615 "upb/json/parser.rl"
 
   if (p != pe) {
     upb_status_seterrf(parser->status, "Parse error at %s\n", p);
@@ -915,13 +916,13 @@ void upb_json_parser_reset(upb_json_parser *p) {
   int top;
   // Emit Ragel initialization of the parser.
   
-#line 919 "upb/json/parser.c"
+#line 920 "upb/json/parser.c"
 	{
 	cs = json_start;
 	top = 0;
 	}
 
-#line 654 "upb/json/parser.rl"
+#line 655 "upb/json/parser.rl"
   p->current_state = cs;
   p->parser_top = top;
   p->text_begin = NULL;

--- a/upb/json/printer.c
+++ b/upb/json/printer.c
@@ -421,7 +421,7 @@ static size_t repeated_bytes(void *closure, const void *handler_data,
   return len;
 }
 
-void sethandlers(const void *closure, upb_handlers *h) {
+void printer_sethandlers(const void *closure, upb_handlers *h) {
   UPB_UNUSED(closure);
 
   upb_handlerattr empty_attr = UPB_HANDLERATTR_INITIALIZER;
@@ -541,5 +541,5 @@ upb_sink *upb_json_printer_input(upb_json_printer *p) {
 
 const upb_handlers *upb_json_printer_newhandlers(const upb_msgdef *md,
                                                  const void *owner) {
-  return upb_handlers_newfrozen(md, owner, sethandlers, NULL);
+  return upb_handlers_newfrozen(md, owner, printer_sethandlers, NULL);
 }

--- a/upb/pb/encoder.c
+++ b/upb/pb/encoder.c
@@ -109,7 +109,7 @@ static bool reserve(upb_pb_encoder *e, size_t bytes) {
 
 // Call when "bytes" bytes have been writte at e->ptr.  The caller *must* have
 // previously called reserve() with at least this many bytes.
-static void advance(upb_pb_encoder *e, size_t bytes) {
+static void encoder_advance(upb_pb_encoder *e, size_t bytes) {
   assert((e->limit - e->ptr) >= bytes);
   e->ptr += bytes;
 }
@@ -137,7 +137,7 @@ static bool encode_bytes(upb_pb_encoder *e, const void *data, size_t len) {
   }
 
   memcpy(e->ptr, data, len);
-  advance(e, len);
+  encoder_advance(e, len);
   return true;
 }
 
@@ -274,7 +274,7 @@ static bool encode_varint(upb_pb_encoder *e, uint64_t val) {
     return false;
   }
 
-  advance(e, upb_vencode64(val, e->ptr));
+  encoder_advance(e, upb_vencode64(val, e->ptr));
   return true;
 }
 

--- a/upb/refcounted.c
+++ b/upb/refcounted.c
@@ -399,7 +399,7 @@ static upb_refcounted *pop(tarjan *t) {
   return r;
 }
 
-static void newgroup(tarjan *t) {
+static void tarjan_newgroup(tarjan *t) {
   uint32_t *group = malloc(sizeof(*group));
   if (!group) oom(t);
   // Push group and empty group leader (we'll fill in leader later).
@@ -493,7 +493,7 @@ static void do_tarjan(const upb_refcounted *obj, tarjan *t) {
   push(t, obj);
   visit(obj, tarjan_visit, t);
   if (lowlink(t, obj) == idx(t, obj)) {
-    newgroup(t);
+    tarjan_newgroup(t);
     while (pop(t) != obj)
       ;
   }

--- a/upb/symtab.c
+++ b/upb/symtab.c
@@ -43,9 +43,9 @@ static void upb_symtab_free(upb_refcounted *r) {
   free(s);
 }
 
-static const struct upb_refcounted_vtbl vtbl = {NULL, &upb_symtab_free};
 
 upb_symtab *upb_symtab_new(const void *owner) {
+  static const struct upb_refcounted_vtbl vtbl = {NULL, &upb_symtab_free};
   upb_symtab *s = malloc(sizeof(*s));
   upb_refcounted_init(UPB_UPCAST(s), &vtbl, owner);
   upb_strtable_init(&s->symtab, UPB_CTYPE_PTR);

--- a/upb/table.int.h
+++ b/upb/table.int.h
@@ -26,7 +26,7 @@
 #include <assert.h>
 #include <stdint.h>
 #include <string.h>
-#include "upb.h"
+#include "upb/upb.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
There are a number of tweaks to get this to work:
- The #include dependence graph wasn't quite complete, and I had to add
  a few #includes to get the tool to work.
- I had to change a number of symbol names to avoid conflicts between
  'static' definitions in different .c files. This could be avoided if
  the tool were smart enough to rename static symbols to have unique
  prefixes instead, but (i) this requires semantic understanding of C,
  and (ii) the macro-defined static functions (e.g., handlers for
  primitive types in several places) would probably trip this up.

Verified that the resulting upb.h/upb.c compiles and doesn't have any
unresolved references.
