### PR TITLE
Fixed typographical error, changed aggresive to aggressive in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Other useful targets:
 
 Unleaded tries to stay very small, but also aims to support
 lots of different formats.  We reconcile these goals by
-being *aggresively modular*.  The source tree and the build
+being *aggressively modular*.  The source tree and the build
 artifacts both reflect this organization:
 
 * **upb**: the core library of handlers and defs (schemas)


### PR DESCRIPTION
@google, I've corrected a typographical error in the documentation of the [upb](https://github.com/google/upb) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
