### PR TITLE
Fix lua bindings linking for Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -472,9 +472,9 @@ upb/bindings/lua/upb/table_c.so: upb/bindings/lua/upb/table.c lib/libupb_pic.a
 	$(E) CC upb/bindings/lua/upb/table.c
 	$(Q) $(CC) $(OPT) $(CSTD) $(WARNFLAGS) $(CPPFLAGS) $(CFLAGS) -fpic -shared -o $@ $< $(LUA_LDFLAGS)
 
-upb/bindings/lua/upb/pb_c.so: upb/bindings/lua/upb/pb.c $(LUA_LIB_DEPS)
+upb/bindings/lua/upb/pb_c.so: upb/bindings/lua/upb/pb.c $(LUA_LIB_DEPS) upb/bindings/lua/upb_c.so
 	$(E) CC upb/bindings/lua/upb/pb.c
-	$(Q) $(CC) $(OPT) $(CSTD) $(WARNFLAGS) $(CPPFLAGS) $(CFLAGS) -fpic -shared -o $@ $< $(LUA_LDFLAGS)
+	$(Q) $(CC) $(OPT) $(CSTD) $(WARNFLAGS) $(CPPFLAGS) $(CFLAGS) -fpic -shared -o $@ $< upb/bindings/lua/upb_c.so $(LUA_LDFLAGS)
 
 
 # Python extension #############################################################


### PR DESCRIPTION
This fixes an issue (#41) in Linux where lua could not lode the upd.pb_c
module due to an undefined symbol.  This update resolves the issue by
linking pb_c.so with upb_c.so that defines the symbol.

I've tested this on both Linux amd64 (Ubuntu, gcc) and Mac OS X Yosemite (LLVM).

I have signed the Google CLA previously.
