### PR TITLE
Compatibility with Bazel 0.25.2 and 0.24.1.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -543,8 +543,8 @@ genrule(
     name = "generate_json_ragel",
     srcs = ["upb/json/parser.rl"],
     outs = ["upb/json/parser.c"],
-    cmd = "$(location @ragel//:ragel) -C -o upb/json/parser.c $< && mv upb/json/parser.c $@",
-    tools = ["@ragel"],
+    cmd = "$(location @ragel//:ragelc) -C -o upb/json/parser.c $< && mv upb/json/parser.c $@",
+    tools = ["@ragel//:ragelc"],
 )
 
 genrule(

--- a/BUILD
+++ b/BUILD
@@ -350,45 +350,45 @@ cc_test(
     copts = CPPOPTS,
 )
 
-#upb_proto_library(
-#    name = "conformance_proto_upb",
-#    deps = ["@com_google_protobuf//:conformance_proto"],
-#)
+upb_proto_library(
+    name = "conformance_proto_upb",
+    deps = ["@com_google_protobuf//:conformance_proto"],
+)
 
-#upb_proto_library(
-#    name = "test_messages_proto3_proto_upb",
-#    deps = ["@com_google_protobuf//:test_messages_proto3_proto"],
-#)
+upb_proto_library(
+    name = "test_messages_proto3_proto_upb",
+    deps = ["@com_google_protobuf//:test_messages_proto3_proto"],
+)
 
-#cc_binary(
-#    name = "conformance_upb",
-#    srcs = [
-#        "tests/conformance_upb.c",
-#    ],
-#    copts = COPTS + ["-Ibazel-out/k8-fastbuild/bin"],
-#    deps = [
-#        ":conformance_proto_upb",
-#        ":test_messages_proto3_proto_upb",
-#        ":upb",
-#    ],
-#)
-#
-#make_shell_script(
-#    name = "gen_test_conformance_upb",
-#    out = "test_conformance_upb.sh",
-#    contents = "$(rlocation com_google_protobuf/conformance_test_runner) $(rlocation upb/conformance_upb)",
-#)
-#
-#sh_test(
-#    name = "test_conformance_upb",
-#    srcs = ["test_conformance_upb.sh"],
-#    data = [
-#        "tests/conformance_upb_failures.txt",
-#        ":conformance_upb",
-#        "@bazel_tools//tools/bash/runfiles",
-#        "@com_google_protobuf//:conformance_test_runner",
-#    ],
-#)
+cc_binary(
+    name = "conformance_upb",
+    srcs = [
+        "tests/conformance_upb.c",
+    ],
+    copts = COPTS + ["-Ibazel-out/k8-fastbuild/bin"],
+    deps = [
+        ":conformance_proto_upb",
+        ":test_messages_proto3_proto_upb",
+        ":upb",
+    ],
+)
+
+make_shell_script(
+    name = "gen_test_conformance_upb",
+    out = "test_conformance_upb.sh",
+    contents = "$(rlocation com_google_protobuf/conformance_test_runner) $(rlocation upb/conformance_upb)",
+)
+
+sh_test(
+    name = "test_conformance_upb",
+    srcs = ["test_conformance_upb.sh"],
+    data = [
+        "tests/conformance_upb_failures.txt",
+        ":conformance_upb",
+        "@bazel_tools//tools/bash/runfiles",
+        "@com_google_protobuf//:conformance_test_runner",
+    ],
+)
 
 # Amalgamation #################################################################
 

--- a/BUILD
+++ b/BUILD
@@ -350,45 +350,45 @@ cc_test(
     copts = CPPOPTS,
 )
 
-upb_proto_library(
-    name = "conformance_proto_upb",
-    deps = ["@com_google_protobuf//:conformance_proto"],
-)
+#upb_proto_library(
+#    name = "conformance_proto_upb",
+#    deps = ["@com_google_protobuf//:conformance_proto"],
+#)
 
-upb_proto_library(
-    name = "test_messages_proto3_proto_upb",
-    deps = ["@com_google_protobuf//:test_messages_proto3_proto"],
-)
+#upb_proto_library(
+#    name = "test_messages_proto3_proto_upb",
+#    deps = ["@com_google_protobuf//:test_messages_proto3_proto"],
+#)
 
-cc_binary(
-    name = "conformance_upb",
-    srcs = [
-        "tests/conformance_upb.c",
-    ],
-    copts = COPTS + ["-Ibazel-out/k8-fastbuild/bin"],
-    deps = [
-        ":conformance_proto_upb",
-        ":test_messages_proto3_proto_upb",
-        ":upb",
-    ],
-)
-
-make_shell_script(
-    name = "gen_test_conformance_upb",
-    out = "test_conformance_upb.sh",
-    contents = "$(rlocation com_google_protobuf/conformance_test_runner) $(rlocation upb/conformance_upb)",
-)
-
-sh_test(
-    name = "test_conformance_upb",
-    srcs = ["test_conformance_upb.sh"],
-    data = [
-        "tests/conformance_upb_failures.txt",
-        ":conformance_upb",
-        "@bazel_tools//tools/bash/runfiles",
-        "@com_google_protobuf//:conformance_test_runner",
-    ],
-)
+#cc_binary(
+#    name = "conformance_upb",
+#    srcs = [
+#        "tests/conformance_upb.c",
+#    ],
+#    copts = COPTS + ["-Ibazel-out/k8-fastbuild/bin"],
+#    deps = [
+#        ":conformance_proto_upb",
+#        ":test_messages_proto3_proto_upb",
+#        ":upb",
+#    ],
+#)
+#
+#make_shell_script(
+#    name = "gen_test_conformance_upb",
+#    out = "test_conformance_upb.sh",
+#    contents = "$(rlocation com_google_protobuf/conformance_test_runner) $(rlocation upb/conformance_upb)",
+#)
+#
+#sh_test(
+#    name = "test_conformance_upb",
+#    srcs = ["test_conformance_upb.sh"],
+#    data = [
+#        "tests/conformance_upb_failures.txt",
+#        ":conformance_upb",
+#        "@bazel_tools//tools/bash/runfiles",
+#        "@com_google_protobuf//:conformance_test_runner",
+#    ],
+#)
 
 # Amalgamation #################################################################
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,7 @@ target_link_libraries(upb_pb
   table
   upb)
 add_library(upb_json
+  generated_for_cmake/upb/json/parser.c
   upb/json/printer.c
   upb/json/parser.h
   upb/json/printer.h)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,11 +22,8 @@ http_archive(
 
 git_repository(
     name = "com_google_protobuf",
-    # TODO(haberman): update to protobuf branch oncd this is merged:
-    #   https://github.com/protocolbuffers/protobuf/pull/6126
-    #remote = "https://github.com/protocolbuffers/protobuf.git",
-    commit = "2996da4d817dd006cd8599c74ad2364a897d6107",
-    remote = "https://github.com/haberman/protobuf.git",
+    remote = "https://github.com/protocolbuffers/protobuf.git",
+    commit = "78ca77ac8799f67fda7b9a01cc691cd9fe526f25",
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,6 +3,11 @@ workspace(name = "upb")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load(":repository_defs.bzl", "bazel_version_repository")
+
+bazel_version_repository(
+    name = "bazel_version"
+)
 
 http_archive(
     name = "lua",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,8 +17,11 @@ http_archive(
 
 git_repository(
     name = "com_google_protobuf",
-    commit = "ec1a70913e5793a7d0a7b5fbf7e0e4f75409dd41",
-    remote = "https://github.com/protocolbuffers/protobuf.git",
+    # TODO(haberman): update to protobuf branch oncd this is merged:
+    #   https://github.com/protocolbuffers/protobuf/pull/6126
+    #remote = "https://github.com/protocolbuffers/protobuf.git",
+    commit = "2996da4d817dd006cd8599c74ad2364a897d6107",
+    remote = "https://github.com/haberman/protobuf.git",
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -45,8 +45,7 @@ http_archive(
 )
 
 http_archive(
-    name = "bazel_skylib",
-    sha256 = "bbccf674aa441c266df9894182d80de104cabd19be98be002f6d478aaa31574d",
-    strip_prefix = "bazel-skylib-2169ae1c374aab4a09aa90e65efe1a3aad4e279b",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/archive/2169ae1c374aab4a09aa90e65efe1a3aad4e279b.tar.gz"],
+   name = "bazel_skylib",
+   strip_prefix = "bazel-skylib-master",
+   urls = ["https://github.com/bazelbuild/bazel-skylib/archive/master.tar.gz"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,11 +17,16 @@ http_archive(
 
 git_repository(
     name = "com_google_protobuf",
-    commit = "25feb59620627b673df76813dfd66e3f565765e7",
-    #sha256 = "d7a221b3d4fb4f05b7473795ccea9e05dab3b8721f6286a95fffbffc2d926f8b",
-    remote = "https://github.com/haberman/protobuf.git",
-    shallow_since = "1541281400 -0700"
-    #tag = "conformance-build-tag",
+    commit = "ec1a70913e5793a7d0a7b5fbf7e0e4f75409dd41",
+    remote = "https://github.com/protocolbuffers/protobuf.git",
+)
+
+http_archive(
+    name = "zlib",
+    build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
+    sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
+    strip_prefix = "zlib-1.2.11",
+    urls = ["https://zlib.net/zlib-1.2.11.tar.gz"],
 )
 
 git_repository(

--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -285,7 +285,7 @@ def cc_library_func(ctx, hdrs, srcs, deps):
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
     )
-    compilation_info = cc_common.compile(
+    (compilation_context, compilation_outputs) = cc_common.compile(
         actions = ctx.actions,
         feature_configuration = feature_configuration,
         cc_toolchain = toolchain,
@@ -294,18 +294,18 @@ def cc_library_func(ctx, hdrs, srcs, deps):
         public_hdrs = hdrs,
         compilation_contexts = compilation_contexts,
     )
-    linking_info = cc_common.link(
+    (linking_context, linking_outputs) = cc_common.create_linking_context_from_compilation_outputs(
         actions = ctx.actions,
         name = "upb_lib",
         feature_configuration = feature_configuration,
         cc_toolchain = toolchain,
-        cc_compilation_outputs = compilation_info.cc_compilation_outputs,
+        compilation_outputs = compilation_outputs,
         linking_contexts = linking_contexts,
     )
 
     return CcInfo(
-        compilation_context = compilation_info.compilation_context,
-        linking_context = linking_info.linking_context,
+        compilation_context = compilation_context,
+        linking_context = linking_context,
     )
 
 def _compile_upb_protos(ctx, proto_info, proto_sources, ext):

--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -272,7 +272,7 @@ def filter_none(elems):
 
 # upb_proto_library() rule
 
-def cc_library_func(ctx, hdrs, srcs, deps):
+def cc_library_func(ctx, name, hdrs, srcs, deps):
     compilation_contexts = []
     linking_contexts = []
     for dep in deps:
@@ -289,14 +289,14 @@ def cc_library_func(ctx, hdrs, srcs, deps):
         actions = ctx.actions,
         feature_configuration = feature_configuration,
         cc_toolchain = toolchain,
-        name = "upb_lib",
+        name = name,
         srcs = srcs,
         public_hdrs = hdrs,
         compilation_contexts = compilation_contexts,
     )
     (linking_context, linking_outputs) = cc_common.create_linking_context_from_compilation_outputs(
         actions = ctx.actions,
-        name = "upb_lib",
+        name = name,
         feature_configuration = feature_configuration,
         cc_toolchain = toolchain,
         compilation_outputs = compilation_outputs,
@@ -356,6 +356,7 @@ def _upb_proto_aspect_impl(target, ctx):
     files = _compile_upb_protos(ctx, proto_info, proto_info.direct_sources, ctx.attr._ext)
     cc_info = cc_library_func(
         ctx = ctx,
+        name = ctx.rule.attr.name,
         hdrs = files.hdrs,
         srcs = files.srcs,
         deps = ctx.rule.attr.deps + [ctx.attr._upb],

--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -1,3 +1,7 @@
+
+load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+
 _shell_find_runfiles = """
   # --- begin runfiles.bash initialization ---
   # Copy-pasted from Bazel's Bash runfiles library (tools/bash/runfiles/runfiles.bash).
@@ -22,10 +26,6 @@ _shell_find_runfiles = """
   fi
   # --- end runfiles.bash initialization ---
 """
-
-load("@bazel_skylib//lib:paths.bzl", "paths")
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
-load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "CPP_LINK_STATIC_LIBRARY_ACTION_NAME")
 
 def _librule(name):
     return name + "_lib"
@@ -286,15 +286,17 @@ def cc_library_func(ctx, hdrs, srcs, deps):
         unsupported_features = ctx.disabled_features,
     )
     compilation_info = cc_common.compile(
-        ctx = ctx,
+        actions = ctx.actions,
         feature_configuration = feature_configuration,
         cc_toolchain = toolchain,
+        name = "upb_lib",
         srcs = srcs,
-        hdrs = hdrs,
+        public_hdrs = hdrs,
         compilation_contexts = compilation_contexts,
     )
     linking_info = cc_common.link(
-        ctx = ctx,
+        actions = ctx.actions,
+        name = "upb_lib",
         feature_configuration = feature_configuration,
         cc_toolchain = toolchain,
         cc_compilation_outputs = compilation_info.cc_compilation_outputs,

--- a/ragel.BUILD
+++ b/ragel.BUILD
@@ -4,7 +4,7 @@ package(
 )
 
 cc_binary(
-    name = "ragel",
+    name = "ragelc",
     srcs = [
         "ragel/rubycodegen.cpp",
         "ragel/goipgoto.h",

--- a/repository_defs.bzl
+++ b/repository_defs.bzl
@@ -1,0 +1,16 @@
+
+# A hacky way to work around the fact that native.bazel_version is only
+# available from WORKSPACE macros, not BUILD macros or rules.
+#
+# Hopefully we can remove this if/when this is fixed:
+#   https://github.com/bazelbuild/bazel/issues/8305
+
+def _impl(repository_ctx):
+    s = "bazel_version = \"" + native.bazel_version + "\""
+    repository_ctx.file("bazel_version.bzl", s)
+    repository_ctx.file("BUILD", "")
+
+bazel_version_repository = repository_rule(
+    implementation=_impl,
+    local=True,
+)

--- a/tools/make_cmakelists.py
+++ b/tools/make_cmakelists.py
@@ -175,6 +175,9 @@ class WorkspaceFileFunctions(object):
   def git_repository(self, **kwargs):
     pass
 
+  def bazel_version_repository(self, **kwargs):
+    pass
+
 
 class Converter(object):
   def __init__(self):

--- a/tools/make_cmakelists.py
+++ b/tools/make_cmakelists.py
@@ -43,8 +43,8 @@ class BuildFileFunctions(object):
     for file in files:
         if os.path.isfile(file):
             found_files.append(file)
-        elif os.path.isfile("generated/" + file):
-            found_files.append("generated/" + file)
+        elif os.path.isfile("generated_for_cmake/" + file):
+            found_files.append("generated_for_cmake/" + file)
         else:
             print("Warning: no such file: " + file)
 


### PR DESCRIPTION
Bazel 0.25.2 and 0.24.1 are the only two supported versions of upb at the moment.