### PR TITLE
Make upb build with MSVC 2015+ using CMake

### DIFF
--- a/generated_for_cmake/upb/json/parser.c
+++ b/generated_for_cmake/upb/json/parser.c
@@ -949,7 +949,6 @@ static bool parse_number_from_buffer(upb_json_parser *p, const char *buf,
   upb_fieldtype_t type = upb_fielddef_type(p->top->f);
   double val;
   double dummy;
-  double inf = 1.0 / 0.0;  /* C89 does not have an INFINITY macro. */
 
   errno = 0;
 
@@ -1017,10 +1016,9 @@ static bool parse_number_from_buffer(upb_json_parser *p, const char *buf,
   }
 
   if (len == strlen("Infinity") && strcmp(buf, "Infinity") == 0) {
-    /* C89 does not have an INFINITY macro. */
-    val = inf;
+    val = UPB_INFINITY;
   } else if (len == strlen("-Infinity") && strcmp(buf, "-Infinity") == 0) {
-    val = -inf;
+    val = -UPB_INFINITY;
   } else {
     val = strtod(buf, &end);
     if (errno == ERANGE || end != bufend) {
@@ -1051,7 +1049,7 @@ static bool parse_number_from_buffer(upb_json_parser *p, const char *buf,
       upb_sink_putdouble(p->top->sink, parser_getsel(p), val);
       return true;
     case UPB_TYPE_FLOAT:
-      if ((val > FLT_MAX || val < -FLT_MAX) && val != inf && val != -inf) {
+      if ((val > FLT_MAX || val < -FLT_MAX) && val != UPB_INFINITY && val != -UPB_INFINITY) {
         return false;
       } else {
         upb_sink_putfloat(p->top->sink, parser_getsel(p), val);
@@ -2586,11 +2584,11 @@ static bool does_fieldmask_end(upb_json_parser *p) {
  * final state once, when the closing '"' is seen. */
 
 
-#line 2791 "upb/json/parser.rl"
+#line 2789 "upb/json/parser.rl"
 
 
 
-#line 2594 "upb/json/parser.c"
+#line 2592 "upb/json/parser.c"
 static const char _json_actions[] = {
 	0, 1, 0, 1, 1, 1, 3, 1, 
 	4, 1, 6, 1, 7, 1, 8, 1, 
@@ -2845,7 +2843,7 @@ static const int json_en_value_machine = 78;
 static const int json_en_main = 1;
 
 
-#line 2794 "upb/json/parser.rl"
+#line 2792 "upb/json/parser.rl"
 
 size_t parse(void *closure, const void *hd, const char *buf, size_t size,
              const upb_bufhandle *handle) {
@@ -2868,7 +2866,7 @@ size_t parse(void *closure, const void *hd, const char *buf, size_t size,
   capture_resume(parser, buf);
 
   
-#line 2872 "upb/json/parser.c"
+#line 2870 "upb/json/parser.c"
 	{
 	int _klen;
 	unsigned int _trans;
@@ -2943,147 +2941,147 @@ _match:
 		switch ( *_acts++ )
 		{
 	case 1:
-#line 2599 "upb/json/parser.rl"
+#line 2597 "upb/json/parser.rl"
 	{ p--; {cs = stack[--top]; goto _again;} }
 	break;
 	case 2:
-#line 2601 "upb/json/parser.rl"
+#line 2599 "upb/json/parser.rl"
 	{ p--; {stack[top++] = cs; cs = 23;goto _again;} }
 	break;
 	case 3:
-#line 2605 "upb/json/parser.rl"
+#line 2603 "upb/json/parser.rl"
 	{ start_text(parser, p); }
 	break;
 	case 4:
-#line 2606 "upb/json/parser.rl"
+#line 2604 "upb/json/parser.rl"
 	{ CHECK_RETURN_TOP(end_text(parser, p)); }
 	break;
 	case 5:
-#line 2612 "upb/json/parser.rl"
+#line 2610 "upb/json/parser.rl"
 	{ start_hex(parser); }
 	break;
 	case 6:
-#line 2613 "upb/json/parser.rl"
+#line 2611 "upb/json/parser.rl"
 	{ hexdigit(parser, p); }
 	break;
 	case 7:
-#line 2614 "upb/json/parser.rl"
+#line 2612 "upb/json/parser.rl"
 	{ CHECK_RETURN_TOP(end_hex(parser)); }
 	break;
 	case 8:
-#line 2620 "upb/json/parser.rl"
+#line 2618 "upb/json/parser.rl"
 	{ CHECK_RETURN_TOP(escape(parser, p)); }
 	break;
 	case 9:
-#line 2626 "upb/json/parser.rl"
+#line 2624 "upb/json/parser.rl"
 	{ p--; {cs = stack[--top]; goto _again;} }
 	break;
 	case 10:
-#line 2631 "upb/json/parser.rl"
+#line 2629 "upb/json/parser.rl"
 	{ start_year(parser, p); }
 	break;
 	case 11:
-#line 2632 "upb/json/parser.rl"
+#line 2630 "upb/json/parser.rl"
 	{ CHECK_RETURN_TOP(end_year(parser, p)); }
 	break;
 	case 12:
-#line 2636 "upb/json/parser.rl"
+#line 2634 "upb/json/parser.rl"
 	{ start_month(parser, p); }
 	break;
 	case 13:
-#line 2637 "upb/json/parser.rl"
+#line 2635 "upb/json/parser.rl"
 	{ CHECK_RETURN_TOP(end_month(parser, p)); }
 	break;
 	case 14:
-#line 2641 "upb/json/parser.rl"
+#line 2639 "upb/json/parser.rl"
 	{ start_day(parser, p); }
 	break;
 	case 15:
-#line 2642 "upb/json/parser.rl"
+#line 2640 "upb/json/parser.rl"
 	{ CHECK_RETURN_TOP(end_day(parser, p)); }
 	break;
 	case 16:
-#line 2646 "upb/json/parser.rl"
+#line 2644 "upb/json/parser.rl"
 	{ start_hour(parser, p); }
 	break;
 	case 17:
-#line 2647 "upb/json/parser.rl"
+#line 2645 "upb/json/parser.rl"
 	{ CHECK_RETURN_TOP(end_hour(parser, p)); }
 	break;
 	case 18:
-#line 2651 "upb/json/parser.rl"
+#line 2649 "upb/json/parser.rl"
 	{ start_minute(parser, p); }
 	break;
 	case 19:
-#line 2652 "upb/json/parser.rl"
+#line 2650 "upb/json/parser.rl"
 	{ CHECK_RETURN_TOP(end_minute(parser, p)); }
 	break;
 	case 20:
-#line 2656 "upb/json/parser.rl"
+#line 2654 "upb/json/parser.rl"
 	{ start_second(parser, p); }
 	break;
 	case 21:
-#line 2657 "upb/json/parser.rl"
+#line 2655 "upb/json/parser.rl"
 	{ CHECK_RETURN_TOP(end_second(parser, p)); }
 	break;
 	case 22:
-#line 2662 "upb/json/parser.rl"
+#line 2660 "upb/json/parser.rl"
 	{ start_duration_base(parser, p); }
 	break;
 	case 23:
-#line 2663 "upb/json/parser.rl"
+#line 2661 "upb/json/parser.rl"
 	{ CHECK_RETURN_TOP(end_duration_base(parser, p)); }
 	break;
 	case 24:
-#line 2665 "upb/json/parser.rl"
+#line 2663 "upb/json/parser.rl"
 	{ p--; {cs = stack[--top]; goto _again;} }
 	break;
 	case 25:
-#line 2670 "upb/json/parser.rl"
+#line 2668 "upb/json/parser.rl"
 	{ start_timestamp_base(parser); }
 	break;
 	case 26:
-#line 2672 "upb/json/parser.rl"
+#line 2670 "upb/json/parser.rl"
 	{ start_timestamp_fraction(parser, p); }
 	break;
 	case 27:
-#line 2673 "upb/json/parser.rl"
+#line 2671 "upb/json/parser.rl"
 	{ CHECK_RETURN_TOP(end_timestamp_fraction(parser, p)); }
 	break;
 	case 28:
-#line 2675 "upb/json/parser.rl"
+#line 2673 "upb/json/parser.rl"
 	{ start_timestamp_zone(parser, p); }
 	break;
 	case 29:
-#line 2676 "upb/json/parser.rl"
+#line 2674 "upb/json/parser.rl"
 	{ CHECK_RETURN_TOP(end_timestamp_zone(parser, p)); }
 	break;
 	case 30:
-#line 2678 "upb/json/parser.rl"
+#line 2676 "upb/json/parser.rl"
 	{ p--; {cs = stack[--top]; goto _again;} }
 	break;
 	case 31:
-#line 2683 "upb/json/parser.rl"
+#line 2681 "upb/json/parser.rl"
 	{ start_fieldmask_path_text(parser, p); }
 	break;
 	case 32:
-#line 2684 "upb/json/parser.rl"
+#line 2682 "upb/json/parser.rl"
 	{ end_fieldmask_path_text(parser, p); }
 	break;
 	case 33:
-#line 2689 "upb/json/parser.rl"
+#line 2687 "upb/json/parser.rl"
 	{ start_fieldmask_path(parser); }
 	break;
 	case 34:
-#line 2690 "upb/json/parser.rl"
+#line 2688 "upb/json/parser.rl"
 	{ end_fieldmask_path(parser); }
 	break;
 	case 35:
-#line 2696 "upb/json/parser.rl"
+#line 2694 "upb/json/parser.rl"
 	{ p--; {cs = stack[--top]; goto _again;} }
 	break;
 	case 36:
-#line 2701 "upb/json/parser.rl"
+#line 2699 "upb/json/parser.rl"
 	{
         if (is_wellknown_msg(parser, UPB_WELLKNOWN_TIMESTAMP)) {
           {stack[top++] = cs; cs = 47;goto _again;}
@@ -3097,11 +3095,11 @@ _match:
       }
 	break;
 	case 37:
-#line 2714 "upb/json/parser.rl"
+#line 2712 "upb/json/parser.rl"
 	{ p--; {stack[top++] = cs; cs = 78;goto _again;} }
 	break;
 	case 38:
-#line 2719 "upb/json/parser.rl"
+#line 2717 "upb/json/parser.rl"
 	{
         if (is_wellknown_msg(parser, UPB_WELLKNOWN_ANY)) {
           start_any_member(parser, p);
@@ -3111,11 +3109,11 @@ _match:
       }
 	break;
 	case 39:
-#line 2726 "upb/json/parser.rl"
+#line 2724 "upb/json/parser.rl"
 	{ CHECK_RETURN_TOP(end_membername(parser)); }
 	break;
 	case 40:
-#line 2729 "upb/json/parser.rl"
+#line 2727 "upb/json/parser.rl"
 	{
         if (is_wellknown_msg(parser, UPB_WELLKNOWN_ANY)) {
           end_any_member(parser, p);
@@ -3125,7 +3123,7 @@ _match:
       }
 	break;
 	case 41:
-#line 2740 "upb/json/parser.rl"
+#line 2738 "upb/json/parser.rl"
 	{
         if (is_wellknown_msg(parser, UPB_WELLKNOWN_ANY)) {
           start_any_object(parser, p);
@@ -3135,7 +3133,7 @@ _match:
       }
 	break;
 	case 42:
-#line 2749 "upb/json/parser.rl"
+#line 2747 "upb/json/parser.rl"
 	{
         if (is_wellknown_msg(parser, UPB_WELLKNOWN_ANY)) {
           CHECK_RETURN_TOP(end_any_object(parser, p));
@@ -3145,54 +3143,54 @@ _match:
       }
 	break;
 	case 43:
-#line 2761 "upb/json/parser.rl"
+#line 2759 "upb/json/parser.rl"
 	{ CHECK_RETURN_TOP(start_array(parser)); }
 	break;
 	case 44:
-#line 2765 "upb/json/parser.rl"
+#line 2763 "upb/json/parser.rl"
 	{ end_array(parser); }
 	break;
 	case 45:
-#line 2770 "upb/json/parser.rl"
+#line 2768 "upb/json/parser.rl"
 	{ CHECK_RETURN_TOP(start_number(parser, p)); }
 	break;
 	case 46:
-#line 2771 "upb/json/parser.rl"
+#line 2769 "upb/json/parser.rl"
 	{ CHECK_RETURN_TOP(end_number(parser, p)); }
 	break;
 	case 47:
-#line 2773 "upb/json/parser.rl"
+#line 2771 "upb/json/parser.rl"
 	{ CHECK_RETURN_TOP(start_stringval(parser)); }
 	break;
 	case 48:
-#line 2774 "upb/json/parser.rl"
+#line 2772 "upb/json/parser.rl"
 	{ CHECK_RETURN_TOP(end_stringval(parser)); }
 	break;
 	case 49:
-#line 2776 "upb/json/parser.rl"
+#line 2774 "upb/json/parser.rl"
 	{ CHECK_RETURN_TOP(end_bool(parser, true)); }
 	break;
 	case 50:
-#line 2778 "upb/json/parser.rl"
+#line 2776 "upb/json/parser.rl"
 	{ CHECK_RETURN_TOP(end_bool(parser, false)); }
 	break;
 	case 51:
-#line 2780 "upb/json/parser.rl"
+#line 2778 "upb/json/parser.rl"
 	{ CHECK_RETURN_TOP(end_null(parser)); }
 	break;
 	case 52:
-#line 2782 "upb/json/parser.rl"
+#line 2780 "upb/json/parser.rl"
 	{ CHECK_RETURN_TOP(start_subobject_full(parser)); }
 	break;
 	case 53:
-#line 2783 "upb/json/parser.rl"
+#line 2781 "upb/json/parser.rl"
 	{ end_subobject_full(parser); }
 	break;
 	case 54:
-#line 2788 "upb/json/parser.rl"
+#line 2786 "upb/json/parser.rl"
 	{ p--; {cs = stack[--top]; goto _again;} }
 	break;
-#line 3196 "upb/json/parser.c"
+#line 3194 "upb/json/parser.c"
 		}
 	}
 
@@ -3209,32 +3207,32 @@ _again:
 	while ( __nacts-- > 0 ) {
 		switch ( *__acts++ ) {
 	case 0:
-#line 2597 "upb/json/parser.rl"
+#line 2595 "upb/json/parser.rl"
 	{ p--; {cs = stack[--top]; 	if ( p == pe )
 		goto _test_eof;
 goto _again;} }
 	break;
 	case 46:
-#line 2771 "upb/json/parser.rl"
+#line 2769 "upb/json/parser.rl"
 	{ CHECK_RETURN_TOP(end_number(parser, p)); }
 	break;
 	case 49:
-#line 2776 "upb/json/parser.rl"
+#line 2774 "upb/json/parser.rl"
 	{ CHECK_RETURN_TOP(end_bool(parser, true)); }
 	break;
 	case 50:
-#line 2778 "upb/json/parser.rl"
+#line 2776 "upb/json/parser.rl"
 	{ CHECK_RETURN_TOP(end_bool(parser, false)); }
 	break;
 	case 51:
-#line 2780 "upb/json/parser.rl"
+#line 2778 "upb/json/parser.rl"
 	{ CHECK_RETURN_TOP(end_null(parser)); }
 	break;
 	case 53:
-#line 2783 "upb/json/parser.rl"
+#line 2781 "upb/json/parser.rl"
 	{ end_subobject_full(parser); }
 	break;
-#line 3238 "upb/json/parser.c"
+#line 3236 "upb/json/parser.c"
 		}
 	}
 	}
@@ -3242,7 +3240,7 @@ goto _again;} }
 	_out: {}
 	}
 
-#line 2816 "upb/json/parser.rl"
+#line 2814 "upb/json/parser.rl"
 
   if (p != pe) {
     upb_status_seterrf(parser->status, "Parse error at '%.*s'\n", pe - p, p);
@@ -3285,13 +3283,13 @@ static void json_parser_reset(upb_json_parser *p) {
 
   /* Emit Ragel initialization of the parser. */
   
-#line 3289 "upb/json/parser.c"
+#line 3287 "upb/json/parser.c"
 	{
 	cs = json_start;
 	top = 0;
 	}
 
-#line 2858 "upb/json/parser.rl"
+#line 2856 "upb/json/parser.rl"
   p->current_state = cs;
   p->parser_top = top;
   accumulate_clear(p);

--- a/upb/json/parser.rl
+++ b/upb/json/parser.rl
@@ -947,7 +947,6 @@ static bool parse_number_from_buffer(upb_json_parser *p, const char *buf,
   upb_fieldtype_t type = upb_fielddef_type(p->top->f);
   double val;
   double dummy;
-  double inf = 1.0 / 0.0;  /* C89 does not have an INFINITY macro. */
 
   errno = 0;
 
@@ -1015,10 +1014,9 @@ static bool parse_number_from_buffer(upb_json_parser *p, const char *buf,
   }
 
   if (len == strlen("Infinity") && strcmp(buf, "Infinity") == 0) {
-    /* C89 does not have an INFINITY macro. */
-    val = inf;
+    val = UPB_INFINITY;
   } else if (len == strlen("-Infinity") && strcmp(buf, "-Infinity") == 0) {
-    val = -inf;
+    val = -UPB_INFINITY;
   } else {
     val = strtod(buf, &end);
     if (errno == ERANGE || end != bufend) {
@@ -1049,7 +1047,7 @@ static bool parse_number_from_buffer(upb_json_parser *p, const char *buf,
       upb_sink_putdouble(p->top->sink, parser_getsel(p), val);
       return true;
     case UPB_TYPE_FLOAT:
-      if ((val > FLT_MAX || val < -FLT_MAX) && val != inf && val != -inf) {
+      if ((val > FLT_MAX || val < -FLT_MAX) && val != UPB_INFINITY && val != -UPB_INFINITY) {
         return false;
       } else {
         upb_sink_putfloat(p->top->sink, parser_getsel(p), val);

--- a/upb/json/printer.c
+++ b/upb/json/printer.c
@@ -181,11 +181,11 @@ const char neginf[] = "\"-Infinity\"";
 const char inf[] = "\"Infinity\"";
 
 static size_t fmt_double(double val, char* buf, size_t length) {
-  if (val == (1.0 / 0.0)) {
+  if (val == UPB_INFINITY) {
     CHKLENGTH(length >= strlen(inf));
     strcpy(buf, inf);
     return strlen(inf);
-  } else if (val == (-1.0 / 0.0)) {
+  } else if (val == -UPB_INFINITY) {
     CHKLENGTH(length >= strlen(neginf));
     strcpy(buf, neginf);
     return strlen(neginf);

--- a/upb/port_def.inc
+++ b/upb/port_def.inc
@@ -73,12 +73,15 @@
 
 #if __STDC_VERSION__ >= 199901L || __cplusplus >= 201103L
 /* C99/C++11 versions. */
+#include <math.h>
 #include <stdio.h>
 #define _upb_snprintf snprintf
 #define _upb_vsnprintf vsnprintf
 #define _upb_va_copy(a, b) va_copy(a, b)
+
+#define UPB_INFINITY INFINITY
 #elif defined __GNUC__
-/* A few hacky workarounds for functions not in C89.
+/* A few hacky workarounds for symbols not in C89.
  * For internal use only!
  * TODO(haberman): fix these by including our own implementations, or finding
  * another workaround.
@@ -86,8 +89,20 @@
 #define _upb_snprintf __builtin_snprintf
 #define _upb_vsnprintf __builtin_vsnprintf
 #define _upb_va_copy(a, b) __va_copy(a, b)
+
+/* C89 does not have an INFINITY macro. */
+#define UPB_INFINITY (1.0 / 0.0)
+#elif defined _MSC_VER && _MSC_VER >= 1900
+#include <math.h>
+#include <stdarg.h>
+#include <stdio.h>
+#define _upb_snprintf snprintf
+#define _upb_vsnprintf vsnprintf
+#define _upb_va_copy(a, b) va_copy(a, b)
+
+#define UPB_INFINITY INFINITY
 #else
-#error Need implementations of [v]snprintf and va_copy
+#error Need implementations of [v]snprintf, va_copy, and INFINITY
 #endif
 
 #ifdef __cplusplus

--- a/upb/port_undef.inc
+++ b/upb/port_undef.inc
@@ -17,3 +17,4 @@
 #undef _upb_snprintf
 #undef _upb_vsnprintf
 #undef _upb_va_copy
+#undef UPB_INFINITY


### PR DESCRIPTION
upb should be compatible with MSVC 2015 and later, as those versions
implement C99. This commit gets the CMake-based build working with MSVC
2015 and newer.

* UPB_INFINITY added to port_def.inc as MSVC doesn't like the
  (1.0 / 0.0) idiom. Instead, we use the C99 INFINITY value.
* Added MSVC definitions of _upb_snprintf, _upb_vsnprintf, and
  _upb_va_copy to port_def.inc.

This does not add CMake-based code gen, so it is not a full fix for
https://github.com/protocolbuffers/upb/issues/94

Fixes https://github.com/protocolbuffers/upb/issues/189

Tested by building with CMake against:

* MSVC 2019
* MSVC 2017
* MSVC 2015
* Clang 6.0.0 on Ubuntu 18.04
* GCC 7.4.0 on Ubuntu 18.04