### PR TITLE
Fix compiler error on Windows

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -62,6 +62,7 @@ cc_library(
         "upb/generated_util.h",
         "upb/msg.c",
         "upb/msg.h",
+        "upb/port.c",
         "upb/port_def.inc",
         "upb/port_undef.inc",
         "upb/table.c",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ add_library(upb
   upb/generated_util.h
   upb/msg.c
   upb/msg.h
+  upb/port.c
   upb/port_def.inc
   upb/port_undef.inc
   upb/table.c

--- a/generated_for_cmake/upb/json/parser.c
+++ b/generated_for_cmake/upb/json/parser.c
@@ -949,7 +949,7 @@ static bool parse_number_from_buffer(upb_json_parser *p, const char *buf,
   upb_fieldtype_t type = upb_fielddef_type(p->top->f);
   double val;
   double dummy;
-  double inf = 1.0 / 0.0;  /* C89 does not have an INFINITY macro. */
+  double inf = UPB_INFINITY;
 
   errno = 0;
 

--- a/upb/json/parser.rl
+++ b/upb/json/parser.rl
@@ -947,7 +947,7 @@ static bool parse_number_from_buffer(upb_json_parser *p, const char *buf,
   upb_fieldtype_t type = upb_fielddef_type(p->top->f);
   double val;
   double dummy;
-  double inf = 1.0 / 0.0;  /* C89 does not have an INFINITY macro. */
+  double inf = UPB_INFINITY;
 
   errno = 0;
 

--- a/upb/json/printer.c
+++ b/upb/json/printer.c
@@ -181,11 +181,11 @@ const char neginf[] = "\"-Infinity\"";
 const char inf[] = "\"Infinity\"";
 
 static size_t fmt_double(double val, char* buf, size_t length) {
-  if (val == (1.0 / 0.0)) {
+  if (val == UPB_INFINITY) {
     CHKLENGTH(length >= strlen(inf));
     strcpy(buf, inf);
     return strlen(inf);
-  } else if (val == (-1.0 / 0.0)) {
+  } else if (val == -UPB_INFINITY) {
     CHKLENGTH(length >= strlen(neginf));
     strcpy(buf, neginf);
     return strlen(neginf);

--- a/upb/port.c
+++ b/upb/port.c
@@ -1,0 +1,27 @@
+
+#include "upb/upb.h"
+#include "upb/port_def.inc"
+
+#ifdef UPB_MSVC_VSNPRINTF
+/* Visual C++ earlier than 2015 doesn't have standard C99 snprintf and
+ * vsnprintf. To support them, missing functions are manually implemented
+ * using the existing secure functions. */
+int msvc_vsnprintf(char* s, size_t n, const char* format, va_list arg) {
+  if (!s) {
+    return _vscprintf(format, arg);
+  }
+  int ret = _vsnprintf_s(s, n, _TRUNCATE, format, arg);
+  if (ret < 0) {
+	ret = _vscprintf(format, arg);
+  }
+  return ret;
+}
+
+int msvc_snprintf(char* s, size_t n, const char* format, ...) {
+  va_list arg;
+  va_start(arg, format);
+  int ret = msvc_vsnprintf(s, n, format, arg);
+  va_end(arg);
+  return ret;
+}
+#endif

--- a/upb/port_def.inc
+++ b/upb/port_def.inc
@@ -75,8 +75,13 @@
 /* Windows versions */
 #include <stdarg.h>
 #include <stdio.h>
-#define _upb_snprintf _snprintf_s
-#define _upb_vsnprintf _vsnprintf_s
+#if defined(_MSC_VER) && _MSC_VER < 1900
+#define _upb_snprintf _snprintf
+#define _upb_vsnprintf _vsnprintf
+#else
+#define _upb_snprintf snprintf
+#define _upb_vsnprintf vsnprintf
+#endif
 #define _upb_va_copy(a, b) va_copy(a, b)
 #else
 #if __STDC_VERSION__ >= 199901L || __cplusplus >= 201103L

--- a/upb/port_def.inc
+++ b/upb/port_def.inc
@@ -76,8 +76,11 @@
 #include <stdarg.h>
 #include <stdio.h>
 #if defined(_MSC_VER) && _MSC_VER < 1900
-#define _upb_snprintf _snprintf
-#define _upb_vsnprintf _vsnprintf
+int msvc_vsnprintf(char* s, size_t n, const char* format, va_list arg);
+int msvc_snprintf(char* s, size_t n, const char* format, ...);
+#define UPB_MSVC_VSNPRINTF
+#define _upb_snprintf msvc_snprintf
+#define _upb_vsnprintf msvc_vsnprintf
 #else
 #define _upb_snprintf snprintf
 #define _upb_vsnprintf vsnprintf
@@ -134,4 +137,12 @@
 #define UPB_UNREACHABLE() do { assert(0); __builtin_unreachable(); } while(0)
 #else
 #define UPB_UNREACHABLE() do { assert(0); } while(0)
+#endif
+
+/* UPB_INFINITY representing floating-point positive infinity. */
+#include <math.h>
+#ifdef INFINITY
+#define UPB_INFINITY INFINITY
+#else
+#define UPB_INFINITY (1.0 / 0.0)
 #endif

--- a/upb/port_undef.inc
+++ b/upb/port_undef.inc
@@ -14,6 +14,8 @@
 #undef UPB_ASSERT
 #undef UPB_ASSERT_DEBUGVAR
 #undef UPB_UNREACHABLE
+#undef UPB_INFINITY
+#undef UPB_MSVC_VSNPRINTF
 #undef _upb_snprintf
 #undef _upb_vsnprintf
 #undef _upb_va_copy


### PR DESCRIPTION
Since _snprintf_s and _vsnprintf_s require 1 more parameter, compiler error would be thrown like

```
third_party\upb\upb\upb.c(54): error C2198: 
'_vsnprintf_s': too few arguments for call [third_party\upb\upb.vcxproj]
```

To fix the problem, let it use standard C99 snprintf and vsnprintf with Visual Studio 2015 or newer. Otherwise, use platform specific _snprintf and _vsnprintf which do similar behavior but not in the same way.