### PR TITLE
Add "-Wstrict-prototypes" option

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -33,6 +33,7 @@ COPTS = CPPOPTS + [
     # copybara:strip_for_google3_begin
     "-pedantic",
     "-std=c89",
+    "-Wstrict-prototypes",
     # copybara:strip_end
 ]
 

--- a/generated_for_cmake/upb/json/parser.c
+++ b/generated_for_cmake/upb/json/parser.c
@@ -3395,7 +3395,7 @@ const upb_byteshandler *upb_json_parsermethod_inputhandler(
   return &m->input_handler_;
 }
 
-upb_json_codecache *upb_json_codecache_new() {
+upb_json_codecache *upb_json_codecache_new(void) {
   upb_alloc *alloc;
   upb_json_codecache *c;
 

--- a/tests/conformance_upb.c
+++ b/tests/conformance_upb.c
@@ -119,7 +119,7 @@ void DoTest(
   return;
 }
 
-bool DoTestIo() {
+bool DoTestIo(void) {
   upb_arena *arena;
   upb_alloc *alloc;
   upb_status status;
@@ -168,7 +168,7 @@ bool DoTestIo() {
   return true;
 }
 
-int main() {
+int main(void) {
   while (1) {
     if (!DoTestIo()) {
       fprintf(stderr, "conformance_upb: received EOF from test runner "

--- a/tests/pb/test_varint.c
+++ b/tests/pb/test_varint.c
@@ -101,7 +101,7 @@ static void test_varint_decoder(upb_decoderet (*decoder)(const char*)) {
   upb_decoderet _upb_vdecode_ ## decoder(const char *p) { \
     return upb_vdecode_ ## decoder(p); \
   } \
-  void test_ ## decoder() { \
+  void test_ ## decoder(void) { \
     test_varint_decoder(&_upb_vdecode_ ## decoder); \
   } \
 

--- a/upb/def.c
+++ b/upb/def.c
@@ -1633,7 +1633,7 @@ void upb_symtab_free(upb_symtab *s) {
   upb_gfree(s);
 }
 
-upb_symtab *upb_symtab_new() {
+upb_symtab *upb_symtab_new(void) {
   upb_symtab *s = upb_gmalloc(sizeof(*s));
   upb_alloc *alloc;
 

--- a/upb/def.h
+++ b/upb/def.h
@@ -837,7 +837,7 @@ class upb::FileDefPtr {
 extern "C" {
 #endif
 
-upb_symtab *upb_symtab_new();
+upb_symtab *upb_symtab_new(void);
 void upb_symtab_free(upb_symtab* s);
 const upb_msgdef *upb_symtab_lookupmsg(const upb_symtab *s, const char *sym);
 const upb_msgdef *upb_symtab_lookupmsg2(

--- a/upb/json/parser.h
+++ b/upb/json/parser.h
@@ -113,7 +113,7 @@ typedef struct upb_json_codecache upb_json_codecache;
 extern "C" {
 #endif
 
-upb_json_codecache *upb_json_codecache_new();
+upb_json_codecache *upb_json_codecache_new(void);
 void upb_json_codecache_free(upb_json_codecache *cache);
 const upb_json_parsermethod* upb_json_codecache_get(upb_json_codecache* cache,
                                                     const upb_msgdef* md);

--- a/upb/json/parser.rl
+++ b/upb/json/parser.rl
@@ -2958,7 +2958,7 @@ const upb_byteshandler *upb_json_parsermethod_inputhandler(
   return &m->input_handler_;
 }
 
-upb_json_codecache *upb_json_codecache_new() {
+upb_json_codecache *upb_json_codecache_new(void) {
   upb_alloc *alloc;
   upb_json_codecache *c;
 

--- a/upb/legacy_msg_reflection.c
+++ b/upb/legacy_msg_reflection.c
@@ -349,7 +349,7 @@ struct upb_mapiter {
   upb_fieldtype_t key_type;
 };
 
-size_t upb_mapiter_sizeof() {
+size_t upb_mapiter_sizeof(void) {
   return sizeof(upb_mapiter);
 }
 

--- a/upb/legacy_msg_reflection.h
+++ b/upb/legacy_msg_reflection.h
@@ -173,7 +173,7 @@ bool upb_map_del(upb_map *map, upb_msgval key);
  * and if you keep invalidating the iterator during iteration, the program may
  * enter an infinite loop. */
 
-size_t upb_mapiter_sizeof();
+size_t upb_mapiter_sizeof(void);
 
 void upb_mapiter_begin(upb_mapiter *i, const upb_map *t);
 upb_mapiter *upb_mapiter_new(const upb_map *t, upb_alloc *a);

--- a/upb/pb/compile_decoder.c
+++ b/upb/pb/compile_decoder.c
@@ -69,7 +69,7 @@ static void freegroup(mgroup *g) {
   upb_gfree(g);
 }
 
-mgroup *newgroup() {
+mgroup *newgroup(void) {
   mgroup *g = upb_gmalloc(sizeof(*g));
   upb_inttable_init(&g->methods, UPB_CTYPE_PTR);
   g->bytecode = NULL;

--- a/upb/pb/encoder.c
+++ b/upb/pb/encoder.c
@@ -524,7 +524,7 @@ void upb_pb_encoder_reset(upb_pb_encoder *e) {
 
 /* public API *****************************************************************/
 
-upb_handlercache *upb_pb_encoder_newcache() {
+upb_handlercache *upb_pb_encoder_newcache(void) {
   return upb_handlercache_new(newhandlers_callback, NULL);
 }
 

--- a/upb/pb/encoder.h
+++ b/upb/pb/encoder.h
@@ -45,7 +45,7 @@ upb_pb_encoder* upb_pb_encoder_create(upb_arena* a, const upb_handlers* h,
 
 /* Lazily builds and caches handlers that will push encoded data to a bytessink.
  * Any msgdef objects used with this object must outlive it. */
-upb_handlercache *upb_pb_encoder_newcache();
+upb_handlercache *upb_pb_encoder_newcache(void);
 
 #ifdef __cplusplus
 }  /* extern "C" { */

--- a/upb/pb/textprinter.c
+++ b/upb/pb/textprinter.c
@@ -329,7 +329,7 @@ upb_textprinter *upb_textprinter_create(upb_arena *arena, const upb_handlers *h,
   return p;
 }
 
-upb_handlercache *upb_textprinter_newcache() {
+upb_handlercache *upb_textprinter_newcache(void) {
   return upb_handlercache_new(&onmreg, NULL);
 }
 

--- a/upb/pb/textprinter.h
+++ b/upb/pb/textprinter.h
@@ -31,7 +31,7 @@ upb_textprinter *upb_textprinter_create(upb_arena *arena, const upb_handlers *h,
                                         upb_bytessink output);
 void upb_textprinter_setsingleline(upb_textprinter *p, bool single_line);
 upb_sink upb_textprinter_input(upb_textprinter *p);
-upb_handlercache *upb_textprinter_newcache();
+upb_handlercache *upb_textprinter_newcache(void);
 
 #ifdef __cplusplus
 }  /* extern "C" */

--- a/upb/upb.h
+++ b/upb/upb.h
@@ -222,7 +222,7 @@ UPB_INLINE void *upb_arena_realloc(upb_arena *a, void *ptr, size_t oldsize,
   return upb_realloc(upb_arena_alloc(a), ptr, oldsize, size);
 }
 
-UPB_INLINE upb_arena *upb_arena_new() {
+UPB_INLINE upb_arena *upb_arena_new(void) {
   return upb_arena_init(NULL, 0, &upb_alloc_global);
 }
 
@@ -287,7 +287,7 @@ template <int N> class upb::InlinedArena : public upb::Arena {
 /* Constants ******************************************************************/
 
 /* Generic function type. */
-typedef void upb_func();
+typedef void upb_func(void);
 
 /* A list of types as they are encoded on-the-wire. */
 typedef enum {


### PR DESCRIPTION
To make upb more compatible with other projects, strict-prototypes warning option is turned on.