### PR TITLE
Make UPB_LIKELY compatible with non-GNUC

### DIFF
--- a/upb/port_def.inc
+++ b/upb/port_def.inc
@@ -52,7 +52,13 @@
 #endif
 
 /* Hints to the compiler about likely/unlikely branches. */
+#ifdef __GNUC__
 #define UPB_LIKELY(x) __builtin_expect((x),1)
+#define UPB_UNLIKELY(x) __builtin_expect((x),0)
+#else
+#define UPB_LIKELY(x) (x)
+#define UPB_UNLIKELY(x) (x)
+#endif
 
 /* Define UPB_BIG_ENDIAN manually if you're on big endian and your compiler
  * doesn't provide these preprocessor symbols. */


### PR DESCRIPTION
Visual C++ doesn't have __builtin_expect so it will be enabled only when building with GNUC.
UPB_UNLIKELY is added for future use.