### PR TITLE
Fixed UBSAN issues

### DIFF
--- a/upb/encode.c
+++ b/upb/encode.c
@@ -25,8 +25,8 @@ static size_t upb_encode_varint(uint64_t val, char *buf) {
   return i;
 }
 
-static uint32_t upb_zzencode_32(int32_t n) { return (n << 1) ^ (n >> 31); }
-static uint64_t upb_zzencode_64(int64_t n) { return (n << 1) ^ (n >> 63); }
+static uint32_t upb_zzencode_32(int32_t n) { return ((uint32_t)n << 1) ^ (n >> 31); }
+static uint64_t upb_zzencode_64(int64_t n) { return ((uint64_t)n << 1) ^ (n >> 63); }
 
 typedef struct {
   upb_alloc *alloc;

--- a/upb/msg.c
+++ b/upb/msg.c
@@ -5,7 +5,7 @@
 
 #include "upb/port_def.inc"
 
-#define VOIDPTR_AT(msg, ofs) (void*)((char*)msg + ofs)
+#define VOIDPTR_AT(msg, ofs) (void*)((char*)msg + (int)ofs)
 
 /* Internal members of a upb_msg.  We can change this without breaking binary
  * compatibility.  We put these before the user's data.  The user's upb_msg*

--- a/upb/pb/compile_decoder.c
+++ b/upb/pb/compile_decoder.c
@@ -149,7 +149,7 @@ static int32_t getofs(uint32_t instruction) {
 
 static void setofs(uint32_t *instruction, int32_t ofs) {
   if (op_has_longofs(*instruction)) {
-    *instruction = getop(*instruction) | ofs << 8;
+    *instruction = getop(*instruction) | (uint32_t)ofs << 8;
   } else {
     *instruction = (*instruction & ~0xff00) | ((ofs & 0xff) << 8);
   }

--- a/upb/pb/varint.int.h
+++ b/upb/pb/varint.int.h
@@ -46,8 +46,12 @@ UPB_INLINE int32_t upb_zzdec_32(uint32_t n) {
 UPB_INLINE int64_t upb_zzdec_64(uint64_t n) {
   return (n >> 1) ^ -(int64_t)(n & 1);
 }
-UPB_INLINE uint32_t upb_zzenc_32(int32_t n) { return (n << 1) ^ (n >> 31); }
-UPB_INLINE uint64_t upb_zzenc_64(int64_t n) { return (n << 1) ^ (n >> 63); }
+UPB_INLINE uint32_t upb_zzenc_32(int32_t n) {
+  return ((uint32_t)n << 1) ^ (n >> 31);
+}
+UPB_INLINE uint64_t upb_zzenc_64(int64_t n) {
+  return ((uint64_t)n << 1) ^ (n >> 63);
+}
 
 /* Decoding *******************************************************************/
 


### PR DESCRIPTION
Fixed all UBSAN issues when running tests with ubsan configuration. This PR fixes the following errors.

```
$ blaze run --config=ubsan :test_varint :test_decoder :test_cpp :test_table :test_conformance_upb
upb/msg.c:39:10: runtime error: addition of unsigned offset to 0x613000000cc0 overflowed to 0x613000000ca0
upb/pb/compile_decoder.c:152:46: runtime error: left shift of negative value -3
upb/pb/varint.int.h:49:57: runtime error: left shift of negative value -66
upb/encode.c:51:56: runtime error: left shift of negative value -2147483648
upb/encode.c:52:56: runtime error: left shift of negative value -9223372036854775808
```