### PR TITLE
Fixed ubsan error on memmove

### DIFF
--- a/upb/encode.c
+++ b/upb/encode.c
@@ -48,7 +48,9 @@ static bool upb_encode_growbuffer(upb_encstate *e, size_t bytes) {
   CHK(new_buf);
 
   /* We want previous data at the end, realloc() put it at the beginning. */
-  memmove(new_buf + new_size - old_size, e->buf, old_size);
+  if (old_size > 0) {
+    memmove(new_buf + new_size - old_size, e->buf, old_size);
+  }
 
   e->ptr = new_buf + new_size - (e->limit - e->ptr);
   e->limit = new_buf + new_size;


### PR DESCRIPTION
Fixed the following UBSAN error.

```
external/upb/upb/encode.c:51:42: runtime error: null pointer passed as argument 2, which is declared to never be null
/usr/include/string.h:47:14: note: nonnull attribute specified here
    #0 0x7f5d31a128bb in upb_encode_growbuffer /proc/self/cwd/external/upb/upb/encode.c:51:3
    #1 0x7f5d31a12020 in upb_encode_reserve /proc/self/cwd/external/upb/upb/encode.c:62:3
    #2 0x7f5d31a11940 in upb_put_varint /proc/self/cwd/external/upb/upb/encode.c:89:3
    #3 0x7f5d31a0ffc0 in upb_encode_scalarfield /proc/self/cwd/external/upb/upb/encode.c:260:7
    #4 0x7f5d31a0bb6f in upb_encode_message /proc/self/cwd/external/upb/upb/encode.c:338:7
    #5 0x7f5d31a1158e in upb_encode /proc/self/cwd/external/upb/upb/encode.c:360:8
```