### PR TITLE
Clean up MSVC port for vsnprintf

### DIFF
--- a/upb/port_def.inc
+++ b/upb/port_def.inc
@@ -77,13 +77,19 @@
 #define UPB_NORETURN
 #endif
 
-#if defined(_WIN32) || defined(WIN32)
-/* Windows versions */
+#if __STDC_VERSION__ >= 199901L || __cplusplus >= 201103L
+/* C99/C++11 versions. */
+#include <stdio.h>
+#define _upb_snprintf snprintf
+#define _upb_vsnprintf vsnprintf
+#define _upb_va_copy(a, b) va_copy(a, b)
+#elif defined(_MSC_VER)
+/* Microsoft C/C++ versions. */
 #include <stdarg.h>
 #include <stdio.h>
-#if defined(_MSC_VER) && _MSC_VER < 1900
-int msvc_vsnprintf(char* s, size_t n, const char* format, va_list arg);
+#if _MSC_VER < 1900
 int msvc_snprintf(char* s, size_t n, const char* format, ...);
+int msvc_vsnprintf(char* s, size_t n, const char* format, va_list arg);
 #define UPB_MSVC_VSNPRINTF
 #define _upb_snprintf msvc_snprintf
 #define _upb_vsnprintf msvc_vsnprintf
@@ -91,13 +97,6 @@ int msvc_snprintf(char* s, size_t n, const char* format, ...);
 #define _upb_snprintf snprintf
 #define _upb_vsnprintf vsnprintf
 #endif
-#define _upb_va_copy(a, b) va_copy(a, b)
-#else
-#if __STDC_VERSION__ >= 199901L || __cplusplus >= 201103L
-/* C99/C++11 versions. */
-#include <stdio.h>
-#define _upb_snprintf snprintf
-#define _upb_vsnprintf vsnprintf
 #define _upb_va_copy(a, b) va_copy(a, b)
 #elif defined __GNUC__
 /* A few hacky workarounds for functions not in C89.
@@ -110,7 +109,6 @@ int msvc_snprintf(char* s, size_t n, const char* format, ...);
 #define _upb_va_copy(a, b) __va_copy(a, b)
 #else
 #error Need implementations of [v]snprintf and va_copy
-#endif
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
Reorganize the macro block to hit standard version first even for MSVC because the latest version of MSVC returns __cplusplus properly. [ref](https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/)