### PR TITLE
A memory safety fix, found by ASAN.

### DIFF
--- a/upb/table.c
+++ b/upb/table.c
@@ -276,7 +276,8 @@ static upb_tabkey strcopy(lookupkey_t k2, upb_alloc *a) {
   char *str = upb_malloc(a, k2.str.len + sizeof(uint32_t) + 1);
   if (str == NULL) return 0;
   memcpy(str, &len, sizeof(uint32_t));
-  memcpy(str + sizeof(uint32_t), k2.str.str, k2.str.len + 1);
+  memcpy(str + sizeof(uint32_t), k2.str.str, k2.str.len);
+  str[sizeof(uint32_t) + k2.str.len] = '\0';
   return (uintptr_t)str;
 }
 


### PR DESCRIPTION
We cannot assume that the input string is NULL-terminated,
or read past "len."  Instead we manually NULL-terminate it.