### PR TITLE
Removed -std=c89 option

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -32,7 +32,6 @@ CPPOPTS = [
 COPTS = CPPOPTS + [
     # copybara:strip_for_google3_begin
     "-pedantic",
-    "-std=c89",
     "-Wstrict-prototypes",
     # copybara:strip_end
 ]

--- a/upb/port_def.inc
+++ b/upb/port_def.inc
@@ -114,7 +114,7 @@ int msvc_vsnprintf(char* s, size_t n, const char* format, va_list arg);
 #ifdef __cplusplus
 #if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__) || \
     (defined(_MSC_VER) && _MSC_VER >= 1900)
-// C++11 is present
+/* C++11 is present */
 #else
 #error upb requires C++11 for C++ support
 #endif


### PR DESCRIPTION
UPB is not strictly C89 compatible because it uses `stdbool.h` introduced with C99. The latest version of clang with `-Wc99-extensions` option throws an error saying it's not allowed with C89. So this PR removes the option.

```
# cat a.c
#include <stdbool.h>

int main() {
  bool a;
  return 0;
}

# clang a.c -std=c89

# clang a.c -std=c89 -Wc99-extensions
a.c:4:3: warning: '_Bool' is a C99 extension [-Wc99-extensions]
  bool a;
  ^
/usr/lib/llvm-10/lib/clang/10.0.0/include/stdbool.h:15:14: 
  note: expanded from macro 'bool'
#define bool _Bool
             ^
1 warning generated.

# clang a.c -std=c99 -Wc99-extensions
```

Fixes #212