### PR TITLE
Use memcpy to perform unaligned reads

### DIFF
--- a/upb/table.c
+++ b/upb/table.c
@@ -756,7 +756,8 @@ uint32_t upb_murmur_hash2(const void *key, size_t len, uint32_t seed) {
   /* Mix 4 bytes at a time into the hash */
   const uint8_t * data = (const uint8_t *)key;
   while(len >= 4) {
-    uint32_t k = *(uint32_t *)data;
+    uint32_t k;
+    memcpy(&k, data, sizeof(k));
 
     k *= m;
     k ^= k >> r;


### PR DESCRIPTION
Creating and reading from unaligned pointers is UB and I'm trying to
run upb on a platform (GraalVM) that is sensitive to that unfortunately.
Recent compilers are smart enough to fold the memcpy down to a simple
memory load on platforms that support it, so this should mostly be a
aesthetic change.