### PR TITLE
bazel: prefix bazel_version repository

### DIFF
--- a/bazel/upb_proto_library.bzl
+++ b/bazel/upb_proto_library.bzl
@@ -8,7 +8,7 @@ load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 
 # copybara:strip_for_google3_begin
 load("@bazel_skylib//lib:versions.bzl", "versions")
-load("@bazel_version//:bazel_version.bzl", "bazel_version")
+load("@upb_bazel_version//:bazel_version.bzl", "bazel_version")
 # copybara:strip_end
 
 # Generic support code #########################################################

--- a/bazel/workspace_deps.bzl
+++ b/bazel/workspace_deps.bzl
@@ -5,7 +5,7 @@ load("//bazel:repository_defs.bzl", "bazel_version_repository")
 
 def upb_deps():
     bazel_version_repository(
-        name = "bazel_version",
+        name = "upb_bazel_version",
     )
 
     git_repository(


### PR DESCRIPTION
To avoid conflicts with other dependencies.