### PR TITLE
bazel: use canonical repository name for absl

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -259,9 +259,9 @@ cc_library(
         "//conditions:default": CPPOPTS
     }),
     deps = [
-        "@absl//absl/base:core_headers",
-        "@absl//absl/container:flat_hash_map",
-        "@absl//absl/strings",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/strings",
         "@com_google_protobuf//:protobuf",
         "@com_google_protobuf//:protoc_lib",
     ],

--- a/bazel/workspace_deps.bzl
+++ b/bazel/workspace_deps.bzl
@@ -9,7 +9,7 @@ def upb_deps():
     )
 
     git_repository(
-        name = "absl",
+        name = "com_google_absl",
         commit = "070f6e47b33a2909d039e620c873204f78809492",
         remote = "https://github.com/abseil/abseil-cpp.git",
         shallow_since = "1541627663 -0500",


### PR DESCRIPTION
https://github.com/abseil/abseil-cpp/blob/master/WORKSPACE#L17