### PR TITLE
Use github.com as a zlib repo

### DIFF
--- a/bazel/workspace_deps.bzl
+++ b/bazel/workspace_deps.bzl
@@ -30,7 +30,7 @@ def upb_deps():
     http_archive(
         name = "zlib",
         build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
-        sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
+        sha256 = "629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff",
         strip_prefix = "zlib-1.2.11",
-        urls = ["https://zlib.net/zlib-1.2.11.tar.gz"],
+        url = "https://github.com/madler/zlib/archive/v1.2.11.tar.gz",
     )


### PR DESCRIPTION
Often CI cannot download zlib archive from `zlib.net` so let's replace it with `github.com` which is considered better in terms of availability.