### PR TITLE
A few build fixes

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -55,13 +55,24 @@ config_setting(
 # Public C/C++ libraries #######################################################
 
 cc_library(
+    name = "port",
+    textual_hdrs = [
+        "upb/port_def.inc",
+        "upb/port_undef.inc",
+    ],
+    srcs = [
+        "upb/port.c",
+    ],
+)
+
+cc_library(
     name = "upb",
     srcs = [
         "upb/decode.c",
         "upb/encode.c",
         "upb/generated_util.h",
         "upb/msg.c",
-        "upb/port.c",
+        "upb/msg.h",
         "upb/table.c",
         "upb/table.int.h",
         "upb/upb.c",
@@ -69,9 +80,6 @@ cc_library(
     hdrs = [
         "upb/decode.h",
         "upb/encode.h",
-        "upb/msg.h",
-        "upb/port_def.inc",
-        "upb/port_undef.inc",
         "upb/upb.h",
     ],
     copts = select({
@@ -79,6 +87,7 @@ cc_library(
         "//conditions:default": COPTS
     }),
     visibility = ["//visibility:public"],
+    deps = [":port"],
 )
 
 # Common support routines used by generated code.  This library has no
@@ -97,12 +106,11 @@ cc_library(
         ":windows": [],
         "//conditions:default": COPTS
     }),
-    textual_hdrs = [
-        "upb/port_def.inc",
-        "upb/port_undef.inc",
-    ],
     visibility = ["//visibility:public"],
-    deps = [":upb"],
+    deps = [
+        ":port",
+        ":upb",
+    ],
 )
 
 upb_proto_library(
@@ -138,7 +146,10 @@ cc_library(
 cc_library(
     name = "table",
     hdrs = ["upb/table.int.h"],
-    deps = [":upb"],
+    deps = [
+        ":port",
+        ":upb",
+    ],
 )
 
 # Legacy C/C++ Libraries (not recommended for new code) ########################
@@ -146,6 +157,7 @@ cc_library(
 cc_library(
     name = "legacy_msg_reflection",
     srcs = [
+        "upb/msg.h",
         "upb/legacy_msg_reflection.c",
     ],
     hdrs = ["upb/legacy_msg_reflection.h"],
@@ -154,6 +166,7 @@ cc_library(
         "//conditions:default": COPTS
     }),
     deps = [
+        ":port",
         ":table",
         ":upb",
     ],
@@ -563,6 +576,7 @@ upb_amalgamation(
         ":descriptor_upbproto",
         ":reflection",
         ":handlers",
+        ":port",
         ":upb_pb",
         ":upb_json",
     ],

--- a/BUILD
+++ b/BUILD
@@ -61,10 +61,7 @@ cc_library(
         "upb/encode.c",
         "upb/generated_util.h",
         "upb/msg.c",
-        "upb/msg.h",
         "upb/port.c",
-        "upb/port_def.inc",
-        "upb/port_undef.inc",
         "upb/table.c",
         "upb/table.int.h",
         "upb/upb.c",
@@ -72,6 +69,9 @@ cc_library(
     hdrs = [
         "upb/decode.h",
         "upb/encode.h",
+        "upb/msg.h",
+        "upb/port_def.inc",
+        "upb/port_undef.inc",
         "upb/upb.h",
     ],
     copts = select({
@@ -286,6 +286,11 @@ cc_binary(
 
 # C/C++ tests ##################################################################
 
+upb_proto_reflection_library(
+    name = "descriptor_upbreflection",
+    deps = ["@com_google_protobuf//:descriptor_proto"],
+)
+
 cc_binary(
     name = "benchmark",
     testonly = 1,
@@ -431,11 +436,6 @@ cc_binary(
 )
 
 # copybara:strip_for_google3_begin
-upb_proto_reflection_library(
-    name = "descriptor_upbreflection",
-    deps = ["@com_google_protobuf//:descriptor_proto"],
-)
-
 cc_test(
     name = "test_encoder",
     srcs = ["tests/pb/test_encoder.cc"],

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,23 +60,25 @@ endif()
 
 enable_testing()
 
+add_library(port
+  upb/port.c)
 add_library(upb
   upb/decode.c
   upb/encode.c
   upb/generated_util.h
   upb/msg.c
   upb/msg.h
-  upb/port.c
-  upb/port_def.inc
-  upb/port_undef.inc
   upb/table.c
   upb/table.int.h
   upb/upb.c
   upb/decode.h
   upb/encode.h
   upb/upb.h)
+target_link_libraries(upb
+  port)
 add_library(generated_code_support__only_for_generated_code_do_not_use__i_give_permission_to_break_me INTERFACE)
 target_link_libraries(generated_code_support__only_for_generated_code_do_not_use__i_give_permission_to_break_me INTERFACE
+  port
   upb)
 add_library(reflection
   upb/def.c
@@ -89,11 +91,14 @@ target_link_libraries(reflection
   upb)
 add_library(table INTERFACE)
 target_link_libraries(table INTERFACE
+  port
   upb)
 add_library(legacy_msg_reflection
+  upb/msg.h
   upb/legacy_msg_reflection.c
   upb/legacy_msg_reflection.h)
 target_link_libraries(legacy_msg_reflection
+  port
   table
   upb)
 add_library(handlers

--- a/upb/port.c
+++ b/upb/port.c
@@ -1,5 +1,4 @@
 
-#include "upb/upb.h"
 #include "upb/port_def.inc"
 
 #ifdef UPB_MSVC_VSNPRINTF

--- a/upb/port_def.inc
+++ b/upb/port_def.inc
@@ -20,9 +20,7 @@
 *
 * This file is private and must not be included by users!
 */
-#ifndef UINTPTR_MAX
-#error must include stdint.h first
-#endif
+#include <stdint.h>
 
 #if UINTPTR_MAX == 0xffffffff
 #define UPB_SIZE(size32, size64) size32


### PR DESCRIPTION
1. Do not strip `upb:descriptor_upbreflection` since it is used by `upb:benchmark target`.

Also a few changes copied from @haberman 's work-in-process pr at https://github.com/protocolbuffers/upb/compare/master...haberman:google3?expand=1:

2. Add upb/msg.h to :legacy_msg_reflection target.
3. Create :port target.

CMakeLists.txt updated using `bazel-bin/make_cmakelists CMakeLists.txt`

Tested with
`bazel test //:all --keep_going`
Also ran `bazel test examples/bazel:test_binary` but I had to replace `#include "foo.upb.h"` with `#include "examples/bazel/foo.upb.h"` to get it working (I did not include this change in the PR).