### PR TITLE
Add port dependencies

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -63,7 +63,6 @@ cc_library(
     srcs = [
         "upb/port.c",
     ],
-    visibility = ["//visibility:public"],
 )
 
 cc_library(
@@ -109,7 +108,6 @@ cc_library(
     }),
     visibility = ["//visibility:public"],
     deps = [
-        ":port",
         ":upb",
     ],
 )

--- a/BUILD
+++ b/BUILD
@@ -101,6 +101,8 @@ cc_library(
     hdrs = [
         "upb/generated_util.h",
         "upb/msg.h",
+        "upb/port_def.inc",
+        "upb/port_undef.inc",
     ],
     copts = select({
         ":windows": [],

--- a/BUILD
+++ b/BUILD
@@ -63,6 +63,7 @@ cc_library(
     srcs = [
         "upb/port.c",
     ],
+    visibility = ["//visibility:public"],
 )
 
 cc_library(

--- a/BUILD
+++ b/BUILD
@@ -136,6 +136,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":descriptor_upbproto",
+        ":port",
         ":table",
         ":upb",
     ],
@@ -189,6 +190,7 @@ cc_library(
     }),
     deps = [
         ":reflection",
+        ":port",
         ":table",
         ":upb",
     ],
@@ -218,6 +220,7 @@ cc_library(
         ":descriptor_upbproto",
         ":handlers",
         ":reflection",
+        ":port",
         ":table",
         ":upb",
     ],
@@ -253,6 +256,7 @@ cc_library(
     deps = [
         ":descriptor_upbproto",
         ":handlers",
+        ":port",
         ":upb",
     ],
 )
@@ -331,6 +335,7 @@ cc_library(
     }),
     deps = [
         ":handlers",
+        ":port",
         ":upb",
     ],
 )
@@ -346,6 +351,7 @@ cc_test(
         "//conditions:default": COPTS
     }),
     deps = [
+        ":port",
         ":upb",
         ":upb_pb",
         ":upb_test",
@@ -376,6 +382,7 @@ cc_test(
     }),
     deps = [
         ":handlers",
+        ":port",
         ":test_decoder_upbproto",
         ":upb",
         ":upb_pb",
@@ -404,6 +411,7 @@ cc_test(
     }),
     deps = [
         ":handlers",
+        ":port",
         ":reflection",
         ":test_cpp_upbproto",
         ":upb",
@@ -420,6 +428,7 @@ cc_test(
         "//conditions:default": CPPOPTS
     }),
     deps = [
+        ":port",
         ":table",
         ":upb",
         ":upb_test",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ add_library(reflection
   upb/msgfactory.h)
 target_link_libraries(reflection
   descriptor_upbproto
+  port
   table
   upb)
 add_library(table INTERFACE)
@@ -109,6 +110,7 @@ add_library(handlers
   upb/sink.h)
 target_link_libraries(handlers
   reflection
+  port
   table
   upb)
 add_library(upb_pb
@@ -126,6 +128,7 @@ target_link_libraries(upb_pb
   descriptor_upbproto
   handlers
   reflection
+  port
   table
   upb)
 add_library(upb_json
@@ -140,6 +143,7 @@ add_library(upb_cc_bindings INTERFACE)
 target_link_libraries(upb_cc_bindings INTERFACE
   descriptor_upbproto
   handlers
+  port
   upb)
 add_library(upb_test
   tests/testmain.cc
@@ -147,6 +151,7 @@ add_library(upb_test
   tests/upb_test.h)
 target_link_libraries(upb_test
   handlers
+  port
   upb)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,6 @@ target_link_libraries(upb
   port)
 add_library(generated_code_support__only_for_generated_code_do_not_use__i_give_permission_to_break_me INTERFACE)
 target_link_libraries(generated_code_support__only_for_generated_code_do_not_use__i_give_permission_to_break_me INTERFACE
-  port
   upb)
 add_library(reflection
   upb/def.c

--- a/bazel/upb_proto_library.bzl
+++ b/bazel/upb_proto_library.bzl
@@ -238,7 +238,8 @@ _upb_proto_library_aspect = aspect(
         ),
         "_upb": attr.label_list(default = [
             "//:generated_code_support__only_for_generated_code_do_not_use__i_give_permission_to_break_me",
-            "//:upb"
+            "//:port",
+            "//:upb",
         ]),
         "_ext": attr.string(default = ".upb"),
     }),
@@ -279,6 +280,7 @@ _upb_proto_reflection_library_aspect = aspect(
         ),
         "_upb": attr.label_list(
             default = [
+                "//:port",
                 "//:upb",
                 "//:reflection",
             ],

--- a/bazel/upb_proto_library.bzl
+++ b/bazel/upb_proto_library.bzl
@@ -279,7 +279,7 @@ _upb_proto_reflection_library_aspect = aspect(
         ),
         "_upb": attr.label_list(
             default = [
-                "//third_party/upb:generated_code_support__only_for_generated_code_do_not_use__i_give_permission_to_break_me",
+                "//:generated_code_support__only_for_generated_code_do_not_use__i_give_permission_to_break_me",
                 "//:upb",
                 "//:reflection",
             ],

--- a/bazel/upb_proto_library.bzl
+++ b/bazel/upb_proto_library.bzl
@@ -238,7 +238,6 @@ _upb_proto_library_aspect = aspect(
         ),
         "_upb": attr.label_list(default = [
             "//:generated_code_support__only_for_generated_code_do_not_use__i_give_permission_to_break_me",
-            "//:port",
             "//:upb",
         ]),
         "_ext": attr.string(default = ".upb"),
@@ -280,7 +279,7 @@ _upb_proto_reflection_library_aspect = aspect(
         ),
         "_upb": attr.label_list(
             default = [
-                "//:port",
+                "//third_party/upb:generated_code_support__only_for_generated_code_do_not_use__i_give_permission_to_break_me",
                 "//:upb",
                 "//:reflection",
             ],


### PR DESCRIPTION
1. Add :port dependencies to libraries that include it.
2. Add upb/port_def.inc and upb/port_undef.inc to generated_code_support__only_for_generated_code_do_not_use__i_give_permission_to_break_me.
3. Added :generated_code_support__only_for_generated_code_do_not_use__i_give_permission_to_break_me dependency to _upb_proto_reflection_library_aspect.
