### PR TITLE
Text format serializer for upb_msg

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -142,6 +142,20 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "textformat",
+    srcs = [
+        "upb/textencode.c",
+    ],
+    hdrs = [
+        "upb/textencode.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":reflection",
+    ],
+)
+
 # Internal C/C++ libraries #####################################################
 
 cc_library(
@@ -549,6 +563,7 @@ cc_binary(
         ":test_messages_proto2_upbdefs",
         ":test_messages_proto3_upbdefs",
         ":reflection",
+        ":textformat",
         ":upb",
     ],
 )

--- a/BUILD
+++ b/BUILD
@@ -537,6 +537,12 @@ upb_proto_library(
 )
 
 upb_proto_reflection_library(
+    name = "conformance_proto_upbdefs",
+    testonly = 1,
+    deps = ["@com_google_protobuf//:conformance_proto"],
+)
+
+upb_proto_reflection_library(
     name = "test_messages_proto2_upbdefs",
     testonly = 1,
     deps = ["@com_google_protobuf//:test_messages_proto2_proto"],
@@ -560,6 +566,7 @@ cc_binary(
     }) + ["-Ibazel-out/k8-fastbuild/bin"],
     deps = [
         ":conformance_proto_upb",
+        ":conformance_proto_upbdefs",
         ":test_messages_proto2_upbdefs",
         ":test_messages_proto3_upbdefs",
         ":reflection",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,11 @@ target_link_libraries(reflection
   port
   table
   upb)
+add_library(textformat
+  upb/textencode.c
+  upb/textencode.h)
+target_link_libraries(textformat
+  reflection)
 add_library(table INTERFACE)
 target_link_libraries(table INTERFACE
   port

--- a/upb/def.c
+++ b/upb/def.c
@@ -707,6 +707,11 @@ const upb_msglayout *upb_msgdef_layout(const upb_msgdef *m) {
   return m->layout;
 }
 
+const upb_fielddef *_upb_msgdef_field(const upb_msgdef *m, int i) {
+  if (i >= m->field_count) return NULL;
+  return &m->fields[i];
+}
+
 bool upb_msgdef_mapentry(const upb_msgdef *m) {
   return m->map_entry;
 }
@@ -951,7 +956,9 @@ static bool make_layout(const upb_symtab *symtab, const upb_msgdef *m) {
     }
 
     if (upb_fielddef_haspresence(f) && !upb_fielddef_containingoneof(f)) {
-      field->presence = (hasbit++);
+      /* We don't use hasbit 0, so that 0 can indicate "no presence" in the
+       * table. This wastes one hasbit, but we don't worry about it for now. */
+      field->presence = ++hasbit;
     } else {
       field->presence = 0;
     }

--- a/upb/def.c
+++ b/upb/def.c
@@ -610,6 +610,7 @@ bool upb_fielddef_hassubdef(const upb_fielddef *f) {
 bool upb_fielddef_haspresence(const upb_fielddef *f) {
   if (upb_fielddef_isseq(f)) return false;
   if (upb_fielddef_issubmsg(f)) return true;
+  if (upb_fielddef_containingoneof(f)) return true;
   return f->file->syntax == UPB_SYNTAX_PROTO2;
 }
 

--- a/upb/def.h
+++ b/upb/def.h
@@ -427,6 +427,7 @@ const upb_oneofdef *upb_msgdef_ntoo(const upb_msgdef *m, const char *name,
 int upb_msgdef_numfields(const upb_msgdef *m);
 int upb_msgdef_numoneofs(const upb_msgdef *m);
 const upb_msglayout *upb_msgdef_layout(const upb_msgdef *m);
+const upb_fielddef *_upb_msgdef_field(const upb_msgdef *m, int i);
 
 UPB_INLINE const upb_oneofdef *upb_msgdef_ntooz(const upb_msgdef *m,
                                                const char *name) {

--- a/upb/msg.c
+++ b/upb/msg.c
@@ -94,7 +94,7 @@ void upb_msg_addunknown(upb_msg *msg, const char *data, size_t len,
 }
 
 const char *upb_msg_getunknown(const upb_msg *msg, size_t *len) {
-  const upb_msg_internal* in = upb_msg_getinternal_const(msg);
+  const upb_msg_internal *in = upb_msg_getinternal_const(msg);
   *len = in->unknown_len;
   return in->unknown;
 }

--- a/upb/reflection.c
+++ b/upb/reflection.c
@@ -179,12 +179,13 @@ bool upb_msg_next(const upb_msg *msg, const upb_msgdef *m,
     if (upb_fielddef_haspresence(f)) {
       if (!upb_msg_has(msg, f)) continue;
     } else {
+      upb_msgval test = val;
       if (upb_fielddef_isstring(f) && !upb_fielddef_isseq(f)) {
         /* Clear string pointer, only size matters (ptr could be non-NULL). */
-        val.str_val.data = NULL;
+        test.str_val.data = NULL;
       }
       /* Continue if NULL or 0. */
-      if (memcmp(&val, &zero, sizeof(val)) == 0) continue;
+      if (memcmp(&test, &zero, sizeof(test)) == 0) continue;
     }
 
     *out_val = val;

--- a/upb/reflection.c
+++ b/upb/reflection.c
@@ -66,27 +66,36 @@ static uint32_t *oneofcase(const upb_msg *msg,
   return PTR_AT(msg, ~field->presence, uint32_t);
 }
 
+static upb_msgval _upb_msg_getraw(const upb_msg *msg, const upb_fielddef *f) {
+  const upb_msglayout_field *field = upb_fielddef_layout(f);
+  const char *mem = PTR_AT(msg, field->offset, char);
+  upb_msgval val = {0};
+  int size = upb_fielddef_isseq(f) ? sizeof(void *)
+                                   : field_size[field->descriptortype];
+  memcpy(&val, mem, size);
+  return val;
+}
+
 bool upb_msg_has(const upb_msg *msg, const upb_fielddef *f) {
   const upb_msglayout_field *field = upb_fielddef_layout(f);
-  UPB_ASSERT(field->presence);
   if (in_oneof(field)) {
     return *oneofcase(msg, field) == field->number;
-  } else {
+  } else if (field->presence > 0) {
     uint32_t hasbit = field->presence;
     return *PTR_AT(msg, hasbit / 8, char) | (1 << (hasbit % 8));
+  } else {
+    UPB_ASSERT(field->descriptortype == UPB_DESCRIPTOR_TYPE_MESSAGE ||
+               field->descriptortype == UPB_DESCRIPTOR_TYPE_GROUP);
+    return _upb_msg_getraw(msg, f).msg_val != NULL;
   }
 }
 
 upb_msgval upb_msg_get(const upb_msg *msg, const upb_fielddef *f) {
-  const upb_msglayout_field *field = upb_fielddef_layout(f);
-  const char *mem = PTR_AT(msg, field->offset, char);
-  upb_msgval val;
-  if (field->presence == 0 || upb_msg_has(msg, f)) {
-    int size = upb_fielddef_isseq(f) ? sizeof(void *)
-                                     : field_size[field->descriptortype];
-    memcpy(&val, mem, size);
+  if (!upb_fielddef_haspresence(f) || upb_msg_has(msg, f)) {
+    return _upb_msg_getraw(msg, f);
   } else {
     /* TODO(haberman): change upb_fielddef to not require this switch(). */
+    upb_msgval val = {0};
     switch (upb_fielddef_type(f)) {
       case UPB_TYPE_INT32:
       case UPB_TYPE_ENUM:
@@ -118,8 +127,8 @@ upb_msgval upb_msg_get(const upb_msg *msg, const upb_fielddef *f) {
         val.msg_val = NULL;
         break;
     }
+    return val;
   }
-  return val;
 }
 
 upb_mutmsgval upb_msg_mutable(upb_msg *msg, const upb_fielddef *f,
@@ -155,6 +164,36 @@ void upb_msg_set(upb_msg *msg, const upb_fielddef *f, upb_msgval val,
   if (in_oneof(field)) {
     *oneofcase(msg, field) = field->number;
   }
+}
+
+bool upb_msg_next(const upb_msg *msg, const upb_msgdef *m,
+                  const upb_symtab *ext_pool, const upb_fielddef **out_f,
+                  upb_msgval *out_val, size_t *iter) {
+  int i = *iter;
+  const upb_msgval zero = {0};
+  const upb_fielddef *f;
+  while ((f = _upb_msgdef_field(m, ++i)) != NULL) {
+    upb_msgval val = _upb_msg_getraw(msg, f);
+
+    /* Skip field if unset or empty. */
+    if (upb_fielddef_haspresence(f)) {
+      if (!upb_msg_has(msg, f)) continue;
+    } else {
+      if (upb_fielddef_isstring(f) && !upb_fielddef_isseq(f)) {
+        /* Clear string pointer, only size matters (ptr could be non-NULL). */
+        val.str_val.data = NULL;
+      }
+      /* Continue if NULL or 0. */
+      if (memcmp(&val, &zero, sizeof(val)) == 0) continue;
+    }
+
+    *out_val = val;
+    *out_f = f;
+    *iter = i;
+    return true;
+  }
+  *iter = i;
+  return false;
 }
 
 /** upb_array *****************************************************************/

--- a/upb/reflection.c
+++ b/upb/reflection.c
@@ -157,8 +157,6 @@ void upb_msg_set(upb_msg *msg, const upb_fielddef *f, upb_msgval val,
   }
 }
 
-#undef DEREF
-
 /** upb_array *****************************************************************/
 
 upb_array *upb_array_new(upb_arena *a, upb_fieldtype_t type) {

--- a/upb/reflection.h
+++ b/upb/reflection.h
@@ -52,6 +52,33 @@ void upb_msg_set(upb_msg *msg, const upb_fielddef *f, upb_msgval val,
 /* Clears any field presence and sets the value back to its default. */
 void upb_msg_clearfield(upb_msg *msg, const upb_fielddef *f);
 
+/* Iterate over present fields.
+ *
+ * size_t iter = UPB_MSG_BEGIN;
+ * const upb_fielddef *f;
+ * upb_msgval val;
+ * while (upb_msg_next(msg, m, ext_pool, &f, &val, &iter)) {
+ *   process_field(f, val);
+ * }
+ *
+ * If ext_pool is NULL, no extensions will be returned.  If the given symtab
+ * returns extensions that don't match what is in this message, those extensions
+ * will be skipped.
+ */
+
+#define UPB_MSG_BEGIN -1
+bool upb_msg_next(const upb_msg *msg, const upb_msgdef *m,
+                  const upb_symtab *ext_pool, const upb_fielddef **f,
+                  upb_msgval *val, size_t *iter);
+
+/* Adds unknown data (serialized protobuf data) to the given message.  The data
+ * is copied into the message instance. */
+void upb_msg_addunknown(upb_msg *msg, const char *data, size_t len,
+                        upb_arena *arena);
+
+/* Returns a reference to the message's unknown data. */
+const char *upb_msg_getunknown(const upb_msg *msg, size_t *len);
+
 /** upb_array *****************************************************************/
 
 /* Creates a new array on the given arena that holds elements of this type. */

--- a/upb/textencode.c
+++ b/upb/textencode.c
@@ -1,9 +1,3 @@
-/*
- * upb::pb::TextPrinter
- *
- * OPT: This is not optimized at all.  It uses printf() which parses the format
- * string every time, and it allocates memory for every put.
- */
 
 #include "upb/textencode.h"
 
@@ -19,56 +13,33 @@
 
 typedef struct {
   char *buf, *ptr, *end;
+  size_t overflow;
   int indent_depth;
   int options;
-  upb_alloc *alloc;
   const upb_symtab *ext_pool;
 } txtenc;
 
-static bool txtenc_msg(txtenc *e, const upb_msg *msg, const upb_msgdef *m);
+static void txtenc_msg(txtenc *e, const upb_msg *msg, const upb_msgdef *m);
 
 #define CHK(x) do { if (!(x)) { return false; } } while(0)
 
-static size_t txtenc_roundup(size_t bytes) {
-  size_t ret = 128;
-  while (ret < bytes) {
-    ret *= 2;
-  }
-  return ret;
-}
-
-static bool txtenc_growbuf(txtenc *e, size_t bytes) {
-  size_t ofs = e->ptr - e->buf;
-  size_t old_size = e->end - e->buf;
-  size_t new_size = txtenc_roundup(ofs + bytes);
-
-  e->buf = upb_realloc(e->alloc, e->buf, old_size, new_size);
-  CHK(e->buf);
-
-  e->ptr = e->buf + ofs;
-  e->end = e->buf + new_size;
-  UPB_ASSERT(e->end - e->ptr >= bytes);
-  return true;
-}
-
-static bool txtenc_reserve(txtenc *e, size_t bytes) {
+static void txtenc_putbytes(txtenc *e, const void *data, size_t len) {
   size_t have = e->end - e->ptr;
-  if (UPB_LIKELY(have >= bytes)) return true;
-  return txtenc_growbuf(e, bytes);
+  if (UPB_LIKELY(have >= len)) {
+    memcpy(e->ptr, data, len);
+    e->ptr += len;
+  } else {
+    memcpy(e->ptr, data, have);
+    e->ptr += have;
+    e->overflow += (len - have);
+  }
 }
 
-static bool txtenc_putbytes(txtenc *e, const void *data, size_t len) {
-  CHK(txtenc_reserve(e, len));
-  memcpy(e->ptr, data, len);
-  e->ptr += len;
-  return true;
+static void txtenc_putstr(txtenc *e, const char *str) {
+  txtenc_putbytes(e, str, strlen(str));
 }
 
-static bool txtenc_putstr(txtenc *e, const char *str) {
-  return txtenc_putbytes(e, str, strlen(str));
-}
-
-static bool txtenc_printf(txtenc *e, const char *fmt, ...) {
+static void txtenc_printf(txtenc *e, const char *fmt, ...) {
   size_t n;
   size_t have = e->end - e->ptr;
   va_list args;
@@ -77,52 +48,46 @@ static bool txtenc_printf(txtenc *e, const char *fmt, ...) {
   n = _upb_vsnprintf(e->ptr, have, fmt, args);
   va_end(args);
 
-  if (n >= have) {
-    CHK(txtenc_reserve(e, n + 1));
-    have = e->end - e->ptr;
-    va_start(args, fmt);
-    n = _upb_vsnprintf(e->ptr, have, fmt, args);
-    va_end(args);
+  if (UPB_LIKELY(have > n)) {
+    e->ptr += n;
+  } else {
+    e->ptr += have;
+    e->overflow += (n - have);
   }
-
-  UPB_ASSERT(e->end - e->ptr > n);
-  e->ptr += n;
-  return true;
 }
 
-static bool txtenc_indent(txtenc *e) {
+static void txtenc_indent(txtenc *e) {
   if ((e->options & UPB_TXTENC_SINGLELINE) == 0) {
     int i = e->indent_depth;
     while (i-- > 0) {
-      CHK(txtenc_putstr(e, "  "));
+      txtenc_putstr(e, "  ");
     }
   }
-  return true;
 }
 
-static bool txtenc_endfield(txtenc *e) {
+static void txtenc_endfield(txtenc *e) {
   if (e->options & UPB_TXTENC_SINGLELINE) {
-    return txtenc_putstr(e, " ");
+    txtenc_putstr(e, " ");
   } else {
-    return txtenc_putstr(e, "\n");
+    txtenc_putstr(e, "\n");
   }
 }
 
-static bool txtenc_enum(int32_t val, const upb_fielddef *f, txtenc *e) {
+static void txtenc_enum(int32_t val, const upb_fielddef *f, txtenc *e) {
   const upb_enumdef *e_def = upb_fielddef_enumsubdef(f);
   const char *name = upb_enumdef_iton(e_def, val);
 
   if (name) {
-    return txtenc_printf(e, "%s", name);
+    txtenc_printf(e, "%s", name);
   } else {
-    return txtenc_printf(e, "%" PRId32, val);
+    txtenc_printf(e, "%" PRId32, val);
   }
 }
 
-static bool txtenc_string(txtenc *e, upb_strview str, bool bytes) {
+static void txtenc_string(txtenc *e, upb_strview str, bool bytes) {
   const char *ptr = str.data;
   const char *end = ptr + str.size;
-  CHK(txtenc_putstr(e, "\""));
+  txtenc_putstr(e, "\"");
 
   while (ptr < end) {
     switch (*ptr) {
@@ -154,57 +119,55 @@ static bool txtenc_string(txtenc *e, upb_strview str, bool bytes) {
     ptr++;
   }
 
-  CHK(txtenc_putstr(e, "\""));
-  return true;
+  txtenc_putstr(e, "\"");
 }
 
-static bool txtenc_field(txtenc *e, upb_msgval val, const upb_fielddef *f) {
-  CHK(txtenc_indent(e));
-  CHK(txtenc_printf(e, "%s: ", upb_fielddef_name(f)));
+static void txtenc_field(txtenc *e, upb_msgval val, const upb_fielddef *f) {
+  txtenc_indent(e);
+  txtenc_printf(e, "%s: ", upb_fielddef_name(f));
 
   switch (upb_fielddef_type(f)) {
     case UPB_TYPE_BOOL:
-      CHK(txtenc_putstr(e, val.bool_val ? "true" : "false"));
+      txtenc_putstr(e, val.bool_val ? "true" : "false");
       break;
     case UPB_TYPE_FLOAT:
-      CHK(txtenc_printf(e, "%f", val.float_val));
+      txtenc_printf(e, "%f", val.float_val);
       break;
     case UPB_TYPE_DOUBLE:
-      CHK(txtenc_printf(e, "%f", val.double_val));
+      txtenc_printf(e, "%f", val.double_val);
       break;
     case UPB_TYPE_INT32:
-      CHK(txtenc_printf(e, "%" PRId32, val.int32_val));
+      txtenc_printf(e, "%" PRId32, val.int32_val);
       break;
     case UPB_TYPE_UINT32:
-      CHK(txtenc_printf(e, "%" PRIu32, val.uint32_val));
+      txtenc_printf(e, "%" PRIu32, val.uint32_val);
       break;
     case UPB_TYPE_INT64:
-      CHK(txtenc_printf(e, "%" PRId64, val.int64_val));
+      txtenc_printf(e, "%" PRId64, val.int64_val);
       break;
     case UPB_TYPE_UINT64:
-      CHK(txtenc_printf(e, "%" PRIu64, val.uint64_val));
+      txtenc_printf(e, "%" PRIu64, val.uint64_val);
       break;
     case UPB_TYPE_STRING:
-      CHK(txtenc_string(e, val.str_val, false));
+      txtenc_string(e, val.str_val, false);
       break;
     case UPB_TYPE_BYTES:
-      CHK(txtenc_string(e, val.str_val, true));
+      txtenc_string(e, val.str_val, true);
       break;
     case UPB_TYPE_ENUM:
-      CHK(txtenc_enum(val.int32_val, f, e));
+      txtenc_enum(val.int32_val, f, e);
       break;
     case UPB_TYPE_MESSAGE:
-      CHK(txtenc_putstr(e, "{"));
+      txtenc_putstr(e, "{");
       e->indent_depth++;
-      CHK(txtenc_msg(e, val.msg_val, upb_fielddef_msgsubdef(f)));
+      txtenc_msg(e, val.msg_val, upb_fielddef_msgsubdef(f));
       e->indent_depth--;
-      CHK(txtenc_indent(e));
-      CHK(txtenc_putstr(e, "}"));
+      txtenc_indent(e);
+      txtenc_putstr(e, "}");
       break;
   }
 
-  CHK(txtenc_endfield(e));
-  return true;
+  txtenc_endfield(e);
 }
 
 /*
@@ -214,16 +177,14 @@ static bool txtenc_field(txtenc *e, upb_msgval val, const upb_fielddef *f) {
  *    foo_field: 2
  *    foo_field: 3
  */
-static bool txtenc_array(txtenc *e, const upb_array *arr,
+static void txtenc_array(txtenc *e, const upb_array *arr,
                          const upb_fielddef *f) {
   size_t i;
   size_t size = upb_array_size(arr);
 
   for (i = 0; i < size; i++) {
-    CHK(txtenc_field(e, upb_array_get(arr, i), f));
+    txtenc_field(e, upb_array_get(arr, i), f);
   }
-
-  return true;
 }
 
 /*
@@ -238,7 +199,7 @@ static bool txtenc_array(txtenc *e, const upb_array *arr,
  *      value: 456
  *    }
  */
-static bool txtenc_map(txtenc *e, const upb_map *map, const upb_fielddef *f) {
+static void txtenc_map(txtenc *e, const upb_map *map, const upb_fielddef *f) {
   const upb_msgdef *entry = upb_fielddef_msgsubdef(f);
   const upb_fielddef *key_f = upb_msgdef_itof(entry, 1);
   const upb_fielddef *val_f = upb_msgdef_itof(entry, 2);
@@ -248,21 +209,19 @@ static bool txtenc_map(txtenc *e, const upb_map *map, const upb_fielddef *f) {
     upb_msgval key = upb_mapiter_key(map, iter);
     upb_msgval val = upb_mapiter_value(map, iter);
 
-    CHK(txtenc_indent(e));
-    CHK(txtenc_printf(e, "%s: {", upb_fielddef_name(f)));
-    CHK(txtenc_endfield(e));
+    txtenc_indent(e);
+    txtenc_printf(e, "%s: {", upb_fielddef_name(f));
+    txtenc_endfield(e);
     e->indent_depth++;
 
-    CHK(txtenc_field(e, key, key_f));
-    CHK(txtenc_field(e, val, val_f));
+    txtenc_field(e, key, key_f);
+    txtenc_field(e, val, val_f);
 
     e->indent_depth++;
-    CHK(txtenc_indent(e));
-    CHK(txtenc_putstr(e, "}"));
-    CHK(txtenc_endfield(e));
+    txtenc_indent(e);
+    txtenc_putstr(e, "}");
+    txtenc_endfield(e);
   }
-
-  return true;
 }
 
 static const char *txtenc_parsevarint(const char *ptr, const char *limit,
@@ -302,19 +261,18 @@ static const char *txtenc_unknown(txtenc *e, const char *ptr, const char *end,
     tag = tag_64;
 
     if ((tag & 7) == UPB_WIRE_TYPE_END_GROUP) {
-      /* We assume/require that the unknown fields are valid/balanced. */
       CHK((tag >> 3) == groupnum);
       return ptr;
     }
 
-    CHK(txtenc_indent(e));
-    CHK(txtenc_printf(e, "%d: ", (int)(tag >> 3)));
+    txtenc_indent(e);
+    txtenc_printf(e, "%d: ", (int)(tag >> 3));
 
     switch (tag & 7) {
       case UPB_WIRE_TYPE_VARINT: {
         uint64_t val;
         CHK(ptr = txtenc_parsevarint(ptr, end, &val));
-        CHK(txtenc_printf(e, "%" PRIu64, val));
+        txtenc_printf(e, "%" PRIu64, val);
         break;
       }
       case UPB_WIRE_TYPE_32BIT: {
@@ -322,7 +280,7 @@ static const char *txtenc_unknown(txtenc *e, const char *ptr, const char *end,
         CHK(end - ptr >= 4);
         memcpy(&val, ptr, 4);
         ptr += 4;
-        CHK(txtenc_printf(e, "0x%08" PRIu32, val));
+        txtenc_printf(e, "0x%08" PRIu32, val);
         break;
       }
       case UPB_WIRE_TYPE_64BIT: {
@@ -330,51 +288,52 @@ static const char *txtenc_unknown(txtenc *e, const char *ptr, const char *end,
         CHK(end - ptr >= 8);
         memcpy(&val, ptr, 8);
         ptr += 8;
-        CHK(txtenc_printf(e, "0x%016" PRIu64, val));
+        txtenc_printf(e, "0x%016" PRIu64, val);
         break;
       }
       case UPB_WIRE_TYPE_DELIMITED: {
         uint64_t len;
-        size_t ofs = e->ptr - e->buf;
+        char *start = e->ptr;
+        size_t start_overflow = e->overflow;
         CHK(ptr = txtenc_parsevarint(ptr, end, &len));
         CHK(end - ptr >= len);
 
         /* Speculatively try to parse as message. */
-        CHK(txtenc_putstr(e, "{"));
-        CHK(txtenc_endfield(e));
+        txtenc_putstr(e, "{");
+        txtenc_endfield(e);
         e->indent_depth++;
         if (txtenc_unknown(e, ptr, end, -1)) {
           e->indent_depth--;
-          CHK(txtenc_indent(e));
+          txtenc_indent(e);
           txtenc_putstr(e, "}");
         } else {
-          /* Didn't work out, print as string. */
-          UPB_ASSERT(e->end - e->buf >= ofs);
+          /* Didn't work out, print as raw bytes. */
           e->indent_depth--;
-          e->ptr = e->buf + ofs;
+          e->ptr = start;
+          e->overflow = start_overflow;
           upb_strview str = {ptr, len};
-          CHK(txtenc_string(e, str, true));
+          txtenc_string(e, str, true);
         }
         ptr += len;
         break;
       }
       case UPB_WIRE_TYPE_START_GROUP:
-        CHK(txtenc_putstr(e, "{"));
-        CHK(txtenc_endfield(e));
+        txtenc_putstr(e, "{");
+        txtenc_endfield(e);
         e->indent_depth++;
         CHK(ptr = txtenc_unknown(e, ptr, end, tag >> 3));
         e->indent_depth--;
-        CHK(txtenc_indent(e));
+        txtenc_indent(e);
         txtenc_putstr(e, "}");
         break;
     }
-    CHK(txtenc_endfield(e));
+    txtenc_endfield(e);
   }
 
-  return ptr;
+  return groupnum == -1 ? ptr : NULL;
 }
 
-static bool txtenc_msg(txtenc *e, const upb_msg *msg,
+static void txtenc_msg(txtenc *e, const upb_msg *msg,
                        const upb_msgdef *m) {
   size_t iter = UPB_MSG_BEGIN;
   const upb_fielddef *f;
@@ -382,50 +341,53 @@ static bool txtenc_msg(txtenc *e, const upb_msg *msg,
 
   while (upb_msg_next(msg, m, e->ext_pool, &f, &val, &iter)) {
     if (upb_fielddef_ismap(f)) {
-      CHK(txtenc_map(e, val.map_val, f));
+      txtenc_map(e, val.map_val, f);
     } else if (upb_fielddef_isseq(f)) {
-      CHK(txtenc_array(e, val.array_val, f));
+      txtenc_array(e, val.array_val, f);
     } else {
-      CHK(txtenc_field(e, val, f));
+      txtenc_field(e, val, f);
     }
   }
 
   if ((e->options & UPB_TXTENC_SKIPUNKNOWN) == 0) {
     size_t len;
     const char *ptr = upb_msg_getunknown(msg, &len);
-    const char *end = ptr + len;
-    CHK(txtenc_unknown(e, ptr, end, -1));
+    char *start = e->ptr;
+    if (ptr) {
+      if (!txtenc_unknown(e, ptr, ptr + len, -1)) {
+        /* Unknown failed to parse, back up and don't print it at all. */
+        e->ptr = start;
+      }
+    }
   }
-
-  return true;
 }
 
-char *upb_textencode(const upb_msg *msg, const upb_msgdef *m,
-                     const upb_symtab *ext_pool, upb_arena *arena, int options,
-                     size_t *size) {
+size_t txtenc_nullz(txtenc *e, size_t size) {
+  size_t ret = e->ptr - e->buf + e->overflow;
+
+  if (size > 0) {
+    if (e->ptr == e->end) e->ptr--;
+    *e->ptr = '\0';
+  }
+
+  return ret;
+}
+
+size_t upb_textencode(const upb_msg *msg, const upb_msgdef *m,
+                      const upb_symtab *ext_pool, int options, char *buf,
+                      size_t size) {
   txtenc e;
-  e.buf = NULL;
-  e.ptr = NULL;
-  e.end = NULL;
+
+  e.buf = buf;
+  e.ptr = buf;
+  e.end = buf + size;
+  e.overflow = 0;
   e.indent_depth = 0;
   e.options = options;
   e.ext_pool = ext_pool;
-  e.alloc = upb_arena_alloc(arena);
 
-  if (!txtenc_msg(&e, msg, m)) {
-    *size = 0;
-    return NULL;
-  }
-
-  *size = e.ptr - e.buf;
-
-  if (*size == 0) {
-    static char ch;
-    return &ch;
-  } else {
-    UPB_ASSERT(e.ptr);
-    return e.buf;
-  }
+  txtenc_msg(&e, msg, m);
+  return txtenc_nullz(&e, size);
 }
 
 #undef CHK

--- a/upb/textencode.c
+++ b/upb/textencode.c
@@ -1,0 +1,260 @@
+/*
+ * upb::pb::TextPrinter
+ *
+ * OPT: This is not optimized at all.  It uses printf() which parses the format
+ * string every time, and it allocates memory for every put.
+ */
+
+#include "upb/pb/textprinter.h"
+
+#include <ctype.h>
+#include <float.h>
+#include <inttypes.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "upb/sink.h"
+
+#include "upb/port_def.inc"
+
+typedef struct {
+  upb_alloc *alloc;
+  char *buf, *ptr, *end;
+  int indent_depth;
+  bool single_line;
+} txtenc;
+
+static bool txtenc_msg(txtenc *e, const upb_msg *msg, const upb_msgdef *m);
+
+#define CHK(x) do { if (!(x)) { return false; } } while(0)
+
+static size_t txtenc_roundup(size_t bytes) {
+  size_t ret = 128;
+  while (ret < bytes) {
+    ret *= 2;
+  }
+  return ret;
+}
+
+static bool txtenc_growbuf(txtenc *e, size_t bytes) {
+  size_t ofs = e->ptr - e->buf;
+  size_t old_size = e->end - e->buf;
+  size_t new_size = txtenc_roundup(ofs + bytes);
+
+  e->buf = upb_realloc(e->alloc, e->buf, old_size, new_size);
+  CHK(e->buf);
+
+  e->ptr = e->buf + ofs;
+  e->end = e->buf + new_size;
+  return true;
+}
+
+/* Call to ensure that at least "bytes" bytes are available for writing at
+ * e->ptr.  Returns false if the bytes could not be allocated. */
+static bool txtenc_reserve(txtenc *e, size_t bytes) {
+  if (UPB_LIKELY((size_t)(e->ptr - e->buf) >= bytes)) return true;
+  return txtenc_growbuf(e, bytes);
+}
+
+/* Writes the given bytes to the buffer, handling reserve/advance. */
+static bool txtenc_putbytes(txtenc *e, const void *data, size_t len) {
+  CHK(txtenc_reserve(e, len));
+  memcpy(e->ptr, data, len);
+  e->ptr += len;
+  return true;
+}
+
+static bool txtenc_putstr(txtenc *e, const char *str) {
+  return txtenc_putbytes(e, str, strlen(str));
+}
+
+static bool txtenc_indent(txtenc *e) {
+  if (!e->single_line) {
+    int i = e->indent_depth;
+    while (i-- > 0) {
+      CHK(txtenc_putstr(e, "  "));
+    }
+  }
+  return true;
+}
+
+static bool txtenc_endfield(txtenc *e) {
+  return txtenc_putstr(e, e->single_line ? " " : "\n");
+}
+
+static bool txtenc_enum(int32_t val, const upb_fielddef *f,
+                                txtenc *e) {
+  const upb_enumdef *e = upb_fielddef_enumsubdef(f);
+  const char *name = upb_enumdef_iton(e, val.int32_val);
+
+  if (name) {
+    return txtenc_printf(e, "%s", name);
+  } else {
+    return txtenc_printf(e, "%" PRId32, val.int32_val);
+  }
+}
+
+static bool txtenc_string(upb_strview str, txtenc *e) {
+  size_t i;
+  CHK(txtenc_putstr(e, "\""));
+
+  for (i = 0; i < str.size; i++) {
+  }
+
+  CHK(txtenc_putstr(e, "\""));
+  return true;
+}
+
+static bool txtenc_value(txtenc *e, upb_msgval val,
+                                 const upb_fielddef *f) {
+}
+
+static bool txtenc_field(upb_msgval val, const upb_fielddef *f,
+                                 txtenc *e) {
+  CHK(txtenc_indent(e));
+
+  switch (upb_fielddef_type(f)) {
+    case UPB_TYPE_BOOL:
+      CHK(txtenc_putstr(e, val.bool_val ? "true" : false));
+      break;
+    case UPB_TYPE_FLOAT:
+      CHK(txtenc_printf(e, "%f", val.float_val));
+      break;
+    case UPB_TYPE_DOUBLE:
+      CHK(txtenc_printf(e, "%f", val.double_val));
+      break;
+    case UPB_TYPE_INT32:
+      CHK(txtenc_printf(e, "%" PRId32, val.int32_val));
+      break;
+    case UPB_TYPE_UINT32:
+      CHK(txtenc_printf(e, "%" PRIu32, val.uint32_val));
+      break;
+    case UPB_TYPE_INT64:
+      CHK(txtenc_printf(e, "%" PRId64, val.int64_val));
+      break;
+    case UPB_TYPE_UINT64:
+      CHK(txtenc_printf(e, "%" PRIu64, val.uint64_val));
+      break;
+    case UPB_TYPE_STRING:
+    case UPB_TYPE_BYTES:
+      CHK(txtenc_string(val.str_val, e));
+      break;
+    case UPB_TYPE_ENUM:
+      CHK(txtenc_enum(val.int32_val, f, e));
+      break;
+    case UPB_TYPE_MESSAGE:
+      CHK(txtenc_putstr(e, "{"));
+      e->indent_depth++;
+      CHK(txtenc_msg(e, val.msg_val, upb_fielddef_msgsubdef(f)));
+      e->indent_depth--;
+      CHK(txtenc_indent(e));
+      CHK(txtenc_putstr(e, "}"));
+      break;
+  }
+
+  CHK(txtenc_endfield(e));
+}
+
+/*
+ * Arrays print as simple repeated elements, eg.
+ *
+ *    foo_field: 1
+ *    foo_field: 2
+ *    foo_field: 3
+ */
+static bool txtenc_array(txtenc *e, const upb_array *arr,
+                                 const upb_fielddef *f) {
+  size_t i;
+  size_t size = upb_array_size(arr);
+  for (i = 0; i < size; i++) {
+    CHK(txtenc_field(e, upb_array_get(arr, i), f));
+  }
+  return true;
+}
+
+/*
+ * Maps print as messages of key/value, etc.
+ *
+ *    foo_map: {
+ *      key: "abc"
+ *      value: 123
+ *    }
+ *    foo_map: {
+ *      key: "def"
+ *      value: 456
+ *    }
+ */
+static bool txtenc_map(txtenc *e, const upb_map *map,
+                               const upb_fielddef *f) {
+  const upb_fielddef *key_f = upb_fielddef_itof(f, 1);
+  const upb_fielddef *val_f = upb_fielddef_itof(f, 2);
+  size_t iter = UPB_MAP_BEGIN;
+
+  while (upb_mapiter_next(map, &iter)) {
+    upb_msgval key = upb_mapiter_key(map, iter);
+    upb_msgval val = upb_mapiter_value(map, iter);
+
+    CHK(txtenc_indent(e));
+    CHK(txtenc_printf(e, "%s: {", upb_fielddef_name(f)));
+    CHK(txtenc_endfield(e));
+    e->indent_depth++;
+
+    CHK(txtenc_field(e, val, val_f));
+    CHK(txtenc_field(e, val, val_f));
+
+    e->indent_depth++;
+    CHK(txtenc_indent(e));
+    CHK(txtenc_putstr(e, "}"));
+    CHK(txtenc_endfield(e));
+  }
+
+  return true;
+}
+
+static bool txtenc_msg(txtenc *e, const upb_msg *msg,
+                       const upb_msgdef *m) {
+  upb_msg_field_iter i;
+  for(upb_msg_field_begin(&i, m);
+      !upb_msg_field_done(&i);
+      upb_msg_field_next(&i)) {
+    const upb_fielddef *f = upb_msg_iter_field(&i);
+    if (upb_fielddef_ismap(f)) {
+      const upb_map *map = upb_msg_get(msg, f).map_val;
+      CHK(txtenc_map(e, map, f));
+    } else if (upb_fielddef_isseq(f)) {
+      const upb_array *arr = upb_msg_get(msg, f).arr_val;
+      CHK(txtenc_array(e, map, f));
+    } else if (upb_msg_has(msg, f)) {
+      upb_msgval value = upb_msg_get(msg, f);
+      CHK(txtenc_field(e, value, f));
+    }
+  }
+  return true;
+}
+
+char *upb_encode(const void *msg, const upb_msglayout *m, upb_arena *arena,
+                 size_t *size) {
+  txtenc e;
+  e.alloc = upb_arena_alloc(arena);
+  e.buf = NULL;
+  e.limit = NULL;
+  e.ptr = NULL;
+
+  if (!upb_encode_message(&e, msg, m, size)) {
+    *size = 0;
+    return NULL;
+  }
+
+  *size = e.limit - e.ptr;
+
+  if (*size == 0) {
+    static char ch;
+    return &ch;
+  } else {
+    UPB_ASSERT(e.ptr);
+    return e.ptr;
+  }
+}
+
+#undef CHK

--- a/upb/textencode.c
+++ b/upb/textencode.c
@@ -217,7 +217,7 @@ static void txtenc_map(txtenc *e, const upb_map *map, const upb_fielddef *f) {
     txtenc_field(e, key, key_f);
     txtenc_field(e, val, val_f);
 
-    e->indent_depth++;
+    e->indent_depth--;
     txtenc_indent(e);
     txtenc_putstr(e, "}");
     txtenc_endfield(e);

--- a/upb/textencode.h
+++ b/upb/textencode.h
@@ -1,0 +1,19 @@
+
+#ifndef UPB_TEXTENCODE_H_
+#define UPB_TEXTENCODE_H_
+
+#include "upb/def.h"
+
+enum {
+  /* When set, prints everything on a single line. */
+  UPB_TXTENC_SINGLELINE = 1,
+
+  /* When set, unknown fields are not printed. */
+  UPB_TXTENC_SKIPUNKNOWN = 2,
+};
+
+char *upb_textencode(const upb_msg *msg, const upb_msgdef *m,
+                     const upb_symtab *symtab, upb_arena *arena, int options,
+                     size_t *size);
+
+#endif  /* UPB_TEXTENCODE_H_ */

--- a/upb/textencode.h
+++ b/upb/textencode.h
@@ -9,7 +9,7 @@ enum {
   UPB_TXTENC_SINGLELINE = 1,
 
   /* When set, unknown fields are not printed. */
-  UPB_TXTENC_SKIPUNKNOWN = 2,
+  UPB_TXTENC_SKIPUNKNOWN = 2
 };
 
 /* Encodes the given |msg| to text format.  The message's reflection is given in

--- a/upb/textencode.h
+++ b/upb/textencode.h
@@ -12,8 +12,16 @@ enum {
   UPB_TXTENC_SKIPUNKNOWN = 2,
 };
 
-char *upb_textencode(const upb_msg *msg, const upb_msgdef *m,
-                     const upb_symtab *symtab, upb_arena *arena, int options,
-                     size_t *size);
+/* Encodes the given |msg| to text format.  The message's reflection is given in
+ * |m|.  The symtab in |symtab| is used to find extensions (if NULL, extensions
+ * will not be printed).
+ *
+ * Output is placed in the given buffer, and always NULL-terminated.  The output
+ * size (excluding NULL) is returned.  This means that a return value >= |size|
+ * implies that the output was truncated.  (These are the same semantics as
+ * snprintf()). */
+size_t upb_textencode(const upb_msg *msg, const upb_msgdef *m,
+                      const upb_symtab *ext_pool, int options, char *buf,
+                      size_t size);
 
 #endif  /* UPB_TEXTENCODE_H_ */


### PR DESCRIPTION
This implements a text format serializer `upb_textencode()` for `upb_msg` messages. It encodes into a fixed-size buffer, and if the output is too big it truncates. The output is always NULL-terminated, and the return value indicates the number of bytes that would have been written. These are the same semantics as `snprintf()`.