### PR TITLE
Fixed parsing for string->double maps.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -354,11 +354,24 @@ cc_test(
     ],
 )
 
+proto_library(
+    name = "test_proto",
+    testonly = 1,
+    srcs = ["tests/test.proto"],
+)
+
+upb_proto_library(
+    name = "test_upbproto",
+    testonly = 1,
+    deps = [":test_proto"],
+)
+
 cc_test(
     name = "test_generated_code",
     srcs = ["tests/test_generated_code.c"],
     deps = [
         ":test_messages_proto3_proto_upb",
+        ":test_upbproto",
         ":upb_test",
     ],
 )
@@ -657,6 +670,7 @@ cc_test(
         "@com_google_protobuf//:descriptor_proto",
         ":descriptor_proto_lua",
         ":test_messages_proto3_proto_lua",
+        ":test_proto_lua",
         "tests/bindings/lua/test_upb.lua",
         "third_party/lunit/console.lua",
         "third_party/lunit/lunit.lua",
@@ -683,8 +697,13 @@ cc_binary(
 )
 
 lua_proto_library(
+    name = "test_proto_lua",
+    testonly = 1,
+    deps = [":test_proto"],
+)
+
+lua_proto_library(
     name = "descriptor_proto_lua",
-    visibility = ["//visibility:public"],
     deps = ["@com_google_protobuf//:descriptor_proto"],
 )
 

--- a/tests/bindings/lua/main.c
+++ b/tests/bindings/lua/main.c
@@ -27,7 +27,9 @@ const char *init =
     "./third_party/lunit/?.lua;"
     "external/com_google_protobuf/?.lua;"
     "external/com_google_protobuf/src/?.lua;"
+    "bazel-bin/?.lua;"
     "bazel-bin/external/com_google_protobuf/src/?.lua;"
+    "bazel-bin/external/com_google_protobuf/?.lua;"
     "bazel-bin/external/com_google_protobuf/?.lua;"
     "upb/bindings/lua/?.lua"
   "'";

--- a/tests/bindings/lua/test.proto
+++ b/tests/bindings/lua/test.proto
@@ -1,8 +1,7 @@
-
 syntax = "proto2";
 
-package upb_test;
+package lua_test;
 
-message MapTest {
+message TestLua {
   map<string, double> map_string_double = 1;
 }

--- a/tests/bindings/lua/test_upb.lua
+++ b/tests/bindings/lua/test_upb.lua
@@ -1,6 +1,7 @@
 
 local upb = require "lupb"
 local lunit = require "lunit"
+local upb_test = require "tests.test_pb"
 local test_messages_proto3 = require "google.protobuf.test_messages_proto3_pb"
 local descriptor = require "google.protobuf.descriptor_pb"
 
@@ -66,6 +67,32 @@ function test_msg_map()
   local msg2 = upb.decode(test_messages_proto3.TestAllTypesProto3, serialized)
   assert_equal(10, msg2.map_int32_int32[5])
   assert_equal(12, msg2.map_int32_int32[6])
+end
+
+function test_string_double_map()
+  msg = upb_test.MapTest()
+  msg.map_string_double["one"] = 1.0
+  msg.map_string_double["two point five"] = 2.5
+  assert_equal(1, msg.map_string_double["one"])
+  assert_equal(2.5, msg.map_string_double["two point five"])
+
+  -- Test overwrite.
+  msg.map_string_double["one"] = 2
+  assert_equal(2, msg.map_string_double["one"])
+  assert_equal(2.5, msg.map_string_double["two point five"])
+  msg.map_string_double["one"] = 1.0
+
+  -- Test delete.
+  msg.map_string_double["one"] = nil
+  assert_nil(msg.map_string_double["one"])
+  assert_equal(2.5, msg.map_string_double["two point five"])
+  msg.map_string_double["one"] = 1
+
+  local serialized = upb.encode(msg)
+  assert_true(#serialized > 0)
+  local msg2 = upb.decode(upb_test.MapTest, serialized)
+  assert_equal(1, msg2.map_string_double["one"])
+  assert_equal(2.5, msg2.map_string_double["two point five"])
 end
 
 function test_msg_string_map()

--- a/tests/test_generated_code.c
+++ b/tests/test_generated_code.c
@@ -5,6 +5,7 @@
 
 #include "src/google/protobuf/test_messages_proto3.upb.h"
 #include "tests/upb_test.h"
+#include "tests/test.upb.h"
 
 const char test_str[] = "abcdefg";
 const char test_str2[] = "12345678910";
@@ -112,6 +113,25 @@ static void check_string_map_one_entry(
   const_ent = protobuf_test_messages_proto3_TestAllTypesProto3_map_string_string_next(
       msg, &iter);
   ASSERT(!const_ent);
+}
+
+static void test_string_double_map() {
+  upb_arena *arena = upb_arena_new();
+  upb_strview serialized;
+  upb_test_MapTest *msg = upb_test_MapTest_new(arena);
+  upb_test_MapTest *msg2;
+  double val;
+
+  upb_test_MapTest_map_string_double_set(msg, test_str_view, 1.5, arena);
+  serialized.data = upb_test_MapTest_serialize(msg, arena, &serialized.size);
+  ASSERT(serialized.data);
+
+  msg2 = upb_test_MapTest_parse(serialized.data, serialized.size, arena);
+  ASSERT(msg2);
+  ASSERT(upb_test_MapTest_map_string_double_get(msg2, test_str_view, &val));
+  ASSERT(val == 1.5);
+
+  upb_arena_free(arena);
 }
 
 static void test_string_map() {
@@ -323,6 +343,7 @@ void test_repeated() {
 int run_tests(int argc, char *argv[]) {
   test_scalars();
   test_string_map();
+  test_string_double_map();
   test_int32_map();
   test_repeated();
   return 0;


### PR DESCRIPTION
Map parsing/serializing relies on map entries always
having a predictable layout.  The code that generates
layout was not respecting this in the case of string
keys and primitive values.

Also added tests to validate this.