### PR TITLE
Removed .gitmodules, we don't use submodules any more.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "third_party/protobuf"]
-	path = third_party/protobuf
-	url = https://github.com/google/protobuf.git


### PR DESCRIPTION
All dependencies are through Bazel now.

Fixes https://github.com/protocolbuffers/upb/issues/192