### PR TITLE
Separated C++ wrappers into separate files in a backward-compatible way.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -81,6 +81,7 @@ cc_library(
         "upb/decode.h",
         "upb/encode.h",
         "upb/upb.h",
+        "upb/upb.hpp",
     ],
     copts = select({
         ":windows": [],
@@ -129,6 +130,7 @@ cc_library(
     ],
     hdrs = [
         "upb/def.h",
+        "upb/def.hpp",
         "upb/reflection.h",
     ],
     copts = select({

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,8 @@ add_library(upb
   upb/upb.c
   upb/decode.h
   upb/encode.h
-  upb/upb.h)
+  upb/upb.h
+  upb/upb.hpp)
 target_link_libraries(upb
   port)
 add_library(generated_code_support__only_for_generated_code_do_not_use__i_give_permission_to_break_me INTERFACE)
@@ -84,6 +85,7 @@ add_library(reflection
   upb/msg.h
   upb/reflection.c
   upb/def.h
+  upb/def.hpp
   upb/reflection.h)
 target_link_libraries(reflection
   descriptor_upbproto

--- a/tests/file_descriptor_parsenew_fuzzer.cc
+++ b/tests/file_descriptor_parsenew_fuzzer.cc
@@ -1,7 +1,7 @@
 #include <cstdint>
 
 #include "google/protobuf/descriptor.upb.h"
-#include "upb/upb.h"
+#include "upb/upb.hpp"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   upb::Arena arena;

--- a/tests/json/test_json.cc
+++ b/tests/json/test_json.cc
@@ -3,18 +3,18 @@
  * A set of tests for JSON parsing and serialization.
  */
 
+#include <string>
+
+#include "tests/json/test.upb.h"  // Test that it compiles for C++.
 #include "tests/json/test.upbdefs.h"
-#include "tests/json/test.upb.h"   // Test that it compiles for C++.
 #include "tests/test_util.h"
 #include "tests/upb_test.h"
+#include "upb/def.hpp"
 #include "upb/handlers.h"
 #include "upb/json/parser.h"
 #include "upb/json/printer.h"
-#include "upb/upb.h"
-
-#include <string>
-
 #include "upb/port_def.inc"
+#include "upb/upb.h"
 
 // Macros for readability in test case list: allows us to give TEST("...") /
 // EXPECT("...") pairs.

--- a/tests/pb/test_encoder.cc
+++ b/tests/pb/test_encoder.cc
@@ -1,14 +1,15 @@
 
+#include <iostream>
+
+#include "google/protobuf/descriptor.upb.h"
+#include "google/protobuf/descriptor.upbdefs.h"
 #include "tests/test_util.h"
 #include "tests/upb_test.h"
 #include "upb/bindings/stdc++/string.h"
-#include "google/protobuf/descriptor.upb.h"
-#include "google/protobuf/descriptor.upbdefs.h"
 #include "upb/pb/decoder.h"
 #include "upb/pb/encoder.h"
-
 #include "upb/port_def.inc"
-#include <iostream>
+#include "upb/upb.hpp"
 
 void test_pb_roundtrip() {
   std::string input(

--- a/upb/def.c
+++ b/upb/def.c
@@ -239,6 +239,10 @@ static uint32_t upb_handlers_selectorcount(const upb_fielddef *f) {
   return ret;
 }
 
+static void upb_status_setoom(upb_status *status) {
+  upb_status_seterrmsg(status, "out of memory");
+}
+
 static bool assign_msg_indices(upb_msgdef *m, upb_status *s) {
   /* Sort fields.  upb internally relies on UPB_TYPE_MESSAGE fields having the
    * lowest indexes, but we do not publicly guarantee this. */

--- a/upb/def.h
+++ b/upb/def.h
@@ -320,7 +320,6 @@ bool _upb_symtab_loaddefinit(upb_symtab *s, const upb_def_init *init);
 
 #ifdef __cplusplus
 }  /* extern "C" */
-#include "upb/def.hpp"
 #endif  /* __cplusplus */
 
 #endif /* UPB_DEF_H_ */

--- a/upb/def.h
+++ b/upb/def.h
@@ -2,16 +2,13 @@
 ** Defs are upb's internal representation of the constructs that can appear
 ** in a .proto file:
 **
-** - upb::MessageDefPtr (upb_msgdef): describes a "message" construct.
-** - upb::FieldDefPtr (upb_fielddef): describes a message field.
-** - upb::FileDefPtr (upb_filedef): describes a .proto file and its defs.
-** - upb::EnumDefPtr (upb_enumdef): describes an enum.
-** - upb::OneofDefPtr (upb_oneofdef): describes a oneof.
+** - upb_msgdef: describes a "message" construct.
+** - upb_fielddef: describes a message field.
+** - upb_filedef: describes a .proto file and its defs.
+** - upb_enumdef: describes an enum.
+** - upb_oneofdef: describes a oneof.
 **
 ** TODO: definitions of services.
-**
-** This is a mixed C/C++ interface that offers a full API to both languages.
-** See the top-level README for more information.
 */
 
 #ifndef UPB_DEF_H_
@@ -21,23 +18,11 @@
 #include "upb/table.int.h"
 #include "google/protobuf/descriptor.upb.h"
 
-#ifdef __cplusplus
-#include <cstring>
-#include <memory>
-#include <string>
-#include <vector>
-
-namespace upb {
-class EnumDefPtr;
-class FieldDefPtr;
-class FileDefPtr;
-class MessageDefPtr;
-class OneofDefPtr;
-class SymbolTable;
-}
-#endif
-
 #include "upb/port_def.inc"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  /* __cplusplus */
 
 struct upb_enumdef;
 typedef struct upb_enumdef upb_enumdef;
@@ -89,10 +74,6 @@ typedef enum {
  * protobuf wire format. */
 #define UPB_MAX_FIELDNUMBER ((1 << 29) - 1)
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 const char *upb_fielddef_fullname(const upb_fielddef *f);
 upb_fieldtype_t upb_fielddef_type(const upb_fielddef *f);
 upb_descriptortype_t upb_fielddef_descriptortype(const upb_fielddef *f);
@@ -128,122 +109,7 @@ const upb_msglayout_field *upb_fielddef_layout(const upb_fielddef *f);
 /* Internal only. */
 uint32_t upb_fielddef_selectorbase(const upb_fielddef *f);
 
-#ifdef __cplusplus
-}  /* extern "C" */
-
-/* A upb_fielddef describes a single field in a message.  It is most often
- * found as a part of a upb_msgdef, but can also stand alone to represent
- * an extension. */
-class upb::FieldDefPtr {
- public:
-  FieldDefPtr() : ptr_(nullptr) {}
-  explicit FieldDefPtr(const upb_fielddef *ptr) : ptr_(ptr) {}
-
-  const upb_fielddef* ptr() const { return ptr_; }
-  explicit operator bool() const { return ptr_ != nullptr; }
-
-  typedef upb_fieldtype_t Type;
-  typedef upb_label_t Label;
-  typedef upb_descriptortype_t DescriptorType;
-
-  const char* full_name() const { return upb_fielddef_fullname(ptr_); }
-
-  Type type() const { return upb_fielddef_type(ptr_); }
-  Label label() const { return upb_fielddef_label(ptr_); }
-  const char* name() const { return upb_fielddef_name(ptr_); }
-  const char* json_name() const { return upb_fielddef_jsonname(ptr_); }
-  uint32_t number() const { return upb_fielddef_number(ptr_); }
-  bool is_extension() const { return upb_fielddef_isextension(ptr_); }
-
-  /* For UPB_TYPE_MESSAGE fields only where is_tag_delimited() == false,
-   * indicates whether this field should have lazy parsing handlers that yield
-   * the unparsed string for the submessage.
-   *
-   * TODO(haberman): I think we want to move this into a FieldOptions container
-   * when we add support for custom options (the FieldOptions struct will
-   * contain both regular FieldOptions like "lazy" *and* custom options). */
-  bool lazy() const { return upb_fielddef_lazy(ptr_); }
-
-  /* For non-string, non-submessage fields, this indicates whether binary
-   * protobufs are encoded in packed or non-packed format.
-   *
-   * TODO(haberman): see note above about putting options like this into a
-   * FieldOptions container. */
-  bool packed() const { return upb_fielddef_packed(ptr_); }
-
-  /* An integer that can be used as an index into an array of fields for
-   * whatever message this field belongs to.  Guaranteed to be less than
-   * f->containing_type()->field_count().  May only be accessed once the def has
-   * been finalized. */
-  uint32_t index() const { return upb_fielddef_index(ptr_); }
-
-  /* The MessageDef to which this field belongs.
-   *
-   * If this field has been added to a MessageDef, that message can be retrieved
-   * directly (this is always the case for frozen FieldDefs).
-   *
-   * If the field has not yet been added to a MessageDef, you can set the name
-   * of the containing type symbolically instead.  This is mostly useful for
-   * extensions, where the extension is declared separately from the message. */
-  MessageDefPtr containing_type() const;
-
-  /* The OneofDef to which this field belongs, or NULL if this field is not part
-   * of a oneof. */
-  OneofDefPtr containing_oneof() const;
-
-  /* The field's type according to the enum in descriptor.proto.  This is not
-   * the same as UPB_TYPE_*, because it distinguishes between (for example)
-   * INT32 and SINT32, whereas our "type" enum does not.  This return of
-   * descriptor_type() is a function of type(), integer_format(), and
-   * is_tag_delimited().  */
-  DescriptorType descriptor_type() const {
-    return upb_fielddef_descriptortype(ptr_);
-  }
-
-  /* Convenient field type tests. */
-  bool IsSubMessage() const { return upb_fielddef_issubmsg(ptr_); }
-  bool IsString() const { return upb_fielddef_isstring(ptr_); }
-  bool IsSequence() const { return upb_fielddef_isseq(ptr_); }
-  bool IsPrimitive() const { return upb_fielddef_isprimitive(ptr_); }
-  bool IsMap() const { return upb_fielddef_ismap(ptr_); }
-
-  /* Returns the non-string default value for this fielddef, which may either
-   * be something the client set explicitly or the "default default" (0 for
-   * numbers, empty for strings).  The field's type indicates the type of the
-   * returned value, except for enum fields that are still mutable.
-   *
-   * Requires that the given function matches the field's current type. */
-  int64_t default_int64() const { return upb_fielddef_defaultint64(ptr_); }
-  int32_t default_int32() const { return upb_fielddef_defaultint32(ptr_); }
-  uint64_t default_uint64() const { return upb_fielddef_defaultuint64(ptr_); }
-  uint32_t default_uint32() const { return upb_fielddef_defaultuint32(ptr_); }
-  bool default_bool() const { return upb_fielddef_defaultbool(ptr_); }
-  float default_float() const { return upb_fielddef_defaultfloat(ptr_); }
-  double default_double() const { return upb_fielddef_defaultdouble(ptr_); }
-
-  /* The resulting string is always NULL-terminated.  If non-NULL, the length
-   * will be stored in *len. */
-  const char *default_string(size_t * len) const {
-    return upb_fielddef_defaultstr(ptr_, len);
-  }
-
-  /* Returns the enum or submessage def for this field, if any.  The field's
-   * type must match (ie. you may only call enum_subdef() for fields where
-   * type() == UPB_TYPE_ENUM). */
-  EnumDefPtr enum_subdef() const;
-  MessageDefPtr message_subdef() const;
-
- private:
-  const upb_fielddef *ptr_;
-};
-
-#endif  /* __cplusplus */
-
 /* upb_oneofdef ***************************************************************/
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 typedef upb_inttable_iter upb_oneof_iter;
 
@@ -277,92 +143,6 @@ void upb_oneof_iter_setdone(upb_oneof_iter *iter);
 bool upb_oneof_iter_isequal(const upb_oneof_iter *iter1,
                             const upb_oneof_iter *iter2);
 
-#ifdef __cplusplus
-}  /* extern "C" */
-
-/* Class that represents a oneof. */
-class upb::OneofDefPtr {
- public:
-  OneofDefPtr() : ptr_(nullptr) {}
-  explicit OneofDefPtr(const upb_oneofdef *ptr) : ptr_(ptr) {}
-
-  const upb_oneofdef* ptr() const { return ptr_; }
-  explicit operator bool() { return ptr_ != nullptr; }
-
-  /* Returns the MessageDef that owns this OneofDef. */
-  MessageDefPtr containing_type() const;
-
-  /* Returns the name of this oneof. This is the name used to look up the oneof
-   * by name once added to a message def. */
-  const char* name() const { return upb_oneofdef_name(ptr_); }
-
-  /* Returns the number of fields currently defined in the oneof. */
-  int field_count() const { return upb_oneofdef_numfields(ptr_); }
-
-  /* Looks up by name. */
-  FieldDefPtr FindFieldByName(const char *name, size_t len) const {
-    return FieldDefPtr(upb_oneofdef_ntof(ptr_, name, len));
-  }
-  FieldDefPtr FindFieldByName(const char* name) const {
-    return FieldDefPtr(upb_oneofdef_ntofz(ptr_, name));
-  }
-
-  template <class T>
-  FieldDefPtr FindFieldByName(const T& str) const {
-    return FindFieldByName(str.c_str(), str.size());
-  }
-
-  /* Looks up by tag number. */
-  FieldDefPtr FindFieldByNumber(uint32_t num) const {
-    return FieldDefPtr(upb_oneofdef_itof(ptr_, num));
-  }
-
-  class const_iterator
-      : public std::iterator<std::forward_iterator_tag, FieldDefPtr> {
-   public:
-    void operator++() { upb_oneof_next(&iter_); }
-
-    FieldDefPtr operator*() const {
-      return FieldDefPtr(upb_oneof_iter_field(&iter_));
-    }
-
-    bool operator!=(const const_iterator& other) const {
-      return !upb_oneof_iter_isequal(&iter_, &other.iter_);
-    }
-
-    bool operator==(const const_iterator& other) const {
-      return upb_oneof_iter_isequal(&iter_, &other.iter_);
-    }
-
-   private:
-    friend class OneofDefPtr;
-
-    const_iterator() {}
-    explicit const_iterator(OneofDefPtr o) {
-      upb_oneof_begin(&iter_, o.ptr());
-    }
-    static const_iterator end() {
-      const_iterator iter;
-      upb_oneof_iter_setdone(&iter.iter_);
-      return iter;
-    }
-
-    upb_oneof_iter iter_;
-  };
-
-  const_iterator begin() const { return const_iterator(*this); }
-  const_iterator end() const { return const_iterator::end(); }
-
- private:
-  const upb_oneofdef *ptr_;
-};
-
-inline upb::OneofDefPtr upb::FieldDefPtr::containing_oneof() const {
-  return OneofDefPtr(upb_fielddef_containingoneof(ptr_));
-}
-
-#endif  /* __cplusplus */
-
 /* upb_msgdef *****************************************************************/
 
 typedef upb_inttable_iter upb_msg_field_iter;
@@ -383,10 +163,6 @@ typedef upb_strtable_iter upb_msg_oneof_iter;
 /* Well-known field tag numbers for duration messages. */
 #define UPB_TIMESTAMP_SECONDS 1
 #define UPB_TIMESTAMP_NANOS 2
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 const char *upb_msgdef_fullname(const upb_msgdef *m);
 const upb_filedef *upb_msgdef_file(const upb_msgdef *m);
@@ -468,194 +244,6 @@ void upb_msg_oneof_iter_setdone(upb_msg_oneof_iter * iter);
 bool upb_msg_oneof_iter_isequal(const upb_msg_oneof_iter *iter1,
                                 const upb_msg_oneof_iter *iter2);
 
-#ifdef __cplusplus
-}  /* extern "C" */
-
-/* Structure that describes a single .proto message type. */
-class upb::MessageDefPtr {
- public:
-  MessageDefPtr() : ptr_(nullptr) {}
-  explicit MessageDefPtr(const upb_msgdef *ptr) : ptr_(ptr) {}
-
-  const upb_msgdef *ptr() const { return ptr_; }
-  explicit operator bool() const { return ptr_ != nullptr; }
-
-  const char* full_name() const { return upb_msgdef_fullname(ptr_); }
-  const char* name() const { return upb_msgdef_name(ptr_); }
-
-  /* The number of fields that belong to the MessageDef. */
-  int field_count() const { return upb_msgdef_numfields(ptr_); }
-
-  /* The number of oneofs that belong to the MessageDef. */
-  int oneof_count() const { return upb_msgdef_numoneofs(ptr_); }
-
-  upb_syntax_t syntax() const { return upb_msgdef_syntax(ptr_); }
-
-  /* These return null pointers if the field is not found. */
-  FieldDefPtr FindFieldByNumber(uint32_t number) const {
-    return FieldDefPtr(upb_msgdef_itof(ptr_, number));
-  }
-  FieldDefPtr FindFieldByName(const char* name, size_t len) const {
-    return FieldDefPtr(upb_msgdef_ntof(ptr_, name, len));
-  }
-  FieldDefPtr FindFieldByName(const char *name) const {
-    return FieldDefPtr(upb_msgdef_ntofz(ptr_, name));
-  }
-
-  template <class T>
-  FieldDefPtr FindFieldByName(const T& str) const {
-    return FindFieldByName(str.c_str(), str.size());
-  }
-
-  OneofDefPtr FindOneofByName(const char* name, size_t len) const {
-    return OneofDefPtr(upb_msgdef_ntoo(ptr_, name, len));
-  }
-
-  OneofDefPtr FindOneofByName(const char *name) const {
-    return OneofDefPtr(upb_msgdef_ntooz(ptr_, name));
-  }
-
-  template <class T>
-  OneofDefPtr FindOneofByName(const T &str) const {
-    return FindOneofByName(str.c_str(), str.size());
-  }
-
-  /* Is this message a map entry? */
-  bool mapentry() const { return upb_msgdef_mapentry(ptr_); }
-
-  /* Return the type of well known type message. UPB_WELLKNOWN_UNSPECIFIED for
-   * non-well-known message. */
-  upb_wellknowntype_t wellknowntype() const {
-    return upb_msgdef_wellknowntype(ptr_);
-  }
-
-  /* Whether is a number wrapper. */
-  bool isnumberwrapper() const { return upb_msgdef_isnumberwrapper(ptr_); }
-
-  /* Iteration over fields.  The order is undefined. */
-  class const_field_iterator
-      : public std::iterator<std::forward_iterator_tag, FieldDefPtr> {
-   public:
-    void operator++() { upb_msg_field_next(&iter_); }
-
-    FieldDefPtr operator*() const {
-      return FieldDefPtr(upb_msg_iter_field(&iter_));
-    }
-
-    bool operator!=(const const_field_iterator &other) const {
-      return !upb_msg_field_iter_isequal(&iter_, &other.iter_);
-    }
-
-    bool operator==(const const_field_iterator &other) const {
-      return upb_msg_field_iter_isequal(&iter_, &other.iter_);
-    }
-
-   private:
-    friend class MessageDefPtr;
-
-    explicit const_field_iterator() {}
-
-    explicit const_field_iterator(MessageDefPtr msg) {
-      upb_msg_field_begin(&iter_, msg.ptr());
-    }
-
-    static const_field_iterator end() {
-      const_field_iterator iter;
-      upb_msg_field_iter_setdone(&iter.iter_);
-      return iter;
-    }
-
-    upb_msg_field_iter iter_;
-  };
-
-  /* Iteration over oneofs. The order is undefined. */
-  class const_oneof_iterator
-      : public std::iterator<std::forward_iterator_tag, OneofDefPtr> {
-   public:
-
-    void operator++() { upb_msg_oneof_next(&iter_); }
-
-    OneofDefPtr operator*() const {
-      return OneofDefPtr(upb_msg_iter_oneof(&iter_));
-    }
-
-    bool operator!=(const const_oneof_iterator& other) const {
-      return !upb_msg_oneof_iter_isequal(&iter_, &other.iter_);
-    }
-
-    bool operator==(const const_oneof_iterator &other) const {
-      return upb_msg_oneof_iter_isequal(&iter_, &other.iter_);
-    }
-
-   private:
-    friend class MessageDefPtr;
-
-    const_oneof_iterator() {}
-
-    explicit const_oneof_iterator(MessageDefPtr msg) {
-      upb_msg_oneof_begin(&iter_, msg.ptr());
-    }
-
-    static const_oneof_iterator end() {
-      const_oneof_iterator iter;
-      upb_msg_oneof_iter_setdone(&iter.iter_);
-      return iter;
-    }
-
-    upb_msg_oneof_iter iter_;
-  };
-
-  class ConstFieldAccessor {
-   public:
-    explicit ConstFieldAccessor(const upb_msgdef* md) : md_(md) {}
-    const_field_iterator begin() { return MessageDefPtr(md_).field_begin(); }
-    const_field_iterator end() { return MessageDefPtr(md_).field_end(); }
-   private:
-    const upb_msgdef* md_;
-  };
-
-  class ConstOneofAccessor {
-   public:
-    explicit ConstOneofAccessor(const upb_msgdef* md) : md_(md) {}
-    const_oneof_iterator begin() { return MessageDefPtr(md_).oneof_begin(); }
-    const_oneof_iterator end() { return MessageDefPtr(md_).oneof_end(); }
-   private:
-    const upb_msgdef* md_;
-  };
-
-  const_field_iterator field_begin() const {
-    return const_field_iterator(*this);
-  }
-
-  const_field_iterator field_end() const { return const_field_iterator::end(); }
-
-  const_oneof_iterator oneof_begin() const {
-    return const_oneof_iterator(*this);
-  }
-
-  const_oneof_iterator oneof_end() const { return const_oneof_iterator::end(); }
-
-  ConstFieldAccessor fields() const { return ConstFieldAccessor(ptr()); }
-  ConstOneofAccessor oneofs() const { return ConstOneofAccessor(ptr()); }
-
- private:
-  const upb_msgdef* ptr_;
-};
-
-inline upb::MessageDefPtr upb::FieldDefPtr::message_subdef() const {
-  return MessageDefPtr(upb_fielddef_msgsubdef(ptr_));
-}
-
-inline upb::MessageDefPtr upb::FieldDefPtr::containing_type() const {
-  return MessageDefPtr(upb_fielddef_containingtype(ptr_));
-}
-
-inline upb::MessageDefPtr upb::OneofDefPtr::containing_type() const {
-  return MessageDefPtr(upb_oneofdef_containingtype(ptr_));
-}
-
-#endif  /* __cplusplus */
-
 /* upb_enumdef ****************************************************************/
 
 typedef upb_strtable_iter upb_enum_iter;
@@ -690,74 +278,7 @@ bool upb_enum_done(upb_enum_iter *iter);
 const char *upb_enum_iter_name(upb_enum_iter *iter);
 int32_t upb_enum_iter_number(upb_enum_iter *iter);
 
-#ifdef __cplusplus
-
-class upb::EnumDefPtr {
- public:
-  EnumDefPtr() : ptr_(nullptr) {}
-  explicit EnumDefPtr(const upb_enumdef* ptr) : ptr_(ptr) {}
-
-  const upb_enumdef* ptr() const { return ptr_; }
-  explicit operator bool() const { return ptr_ != nullptr; }
-
-  const char* full_name() const { return upb_enumdef_fullname(ptr_); }
-  const char* name() const { return upb_enumdef_name(ptr_); }
-
-  /* The value that is used as the default when no field default is specified.
-   * If not set explicitly, the first value that was added will be used.
-   * The default value must be a member of the enum.
-   * Requires that value_count() > 0. */
-  int32_t default_value() const { return upb_enumdef_default(ptr_); }
-
-  /* Returns the number of values currently defined in the enum.  Note that
-   * multiple names can refer to the same number, so this may be greater than
-   * the total number of unique numbers. */
-  int value_count() const { return upb_enumdef_numvals(ptr_); }
-
-  /* Lookups from name to integer, returning true if found. */
-  bool FindValueByName(const char *name, int32_t *num) const {
-    return upb_enumdef_ntoiz(ptr_, name, num);
-  }
-
-  /* Finds the name corresponding to the given number, or NULL if none was
-   * found.  If more than one name corresponds to this number, returns the
-   * first one that was added. */
-  const char *FindValueByNumber(int32_t num) const {
-    return upb_enumdef_iton(ptr_, num);
-  }
-
-  /* Iteration over name/value pairs.  The order is undefined.
-   * Adding an enum val invalidates any iterators.
-   *
-   * TODO: make compatible with range-for, with elements as pairs? */
-  class Iterator {
-   public:
-    explicit Iterator(EnumDefPtr e) { upb_enum_begin(&iter_, e.ptr()); }
-
-    int32_t number() { return upb_enum_iter_number(&iter_); }
-    const char *name() { return upb_enum_iter_name(&iter_); }
-    bool Done() { return upb_enum_done(&iter_); }
-    void Next() { return upb_enum_next(&iter_); }
-
-   private:
-    upb_enum_iter iter_;
-  };
-
- private:
-  const upb_enumdef *ptr_;
-};
-
-inline upb::EnumDefPtr upb::FieldDefPtr::enum_subdef() const {
-  return EnumDefPtr(upb_fielddef_enumsubdef(ptr_));
-}
-
-#endif  /* __cplusplus */
-
 /* upb_filedef ****************************************************************/
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 const char *upb_filedef_name(const upb_filedef *f);
 const char *upb_filedef_package(const upb_filedef *f);
@@ -771,56 +292,7 @@ const upb_filedef *upb_filedef_dep(const upb_filedef *f, int i);
 const upb_msgdef *upb_filedef_msg(const upb_filedef *f, int i);
 const upb_enumdef *upb_filedef_enum(const upb_filedef *f, int i);
 
-#ifdef __cplusplus
-}  /* extern "C" */
-
-/* Class that represents a .proto file with some things defined in it.
- *
- * Many users won't care about FileDefs, but they are necessary if you want to
- * read the values of file-level options. */
-class upb::FileDefPtr {
- public:
-  explicit FileDefPtr(const upb_filedef *ptr) : ptr_(ptr) {}
-
-  const upb_filedef* ptr() const { return ptr_; }
-  explicit operator bool() const { return ptr_ != nullptr; }
-
-  /* Get/set name of the file (eg. "foo/bar.proto"). */
-  const char* name() const { return upb_filedef_name(ptr_); }
-
-  /* Package name for definitions inside the file (eg. "foo.bar"). */
-  const char* package() const { return upb_filedef_package(ptr_); }
-
-  /* Sets the php class prefix which is prepended to all php generated classes
-   * from this .proto. Default is empty. */
-  const char* phpprefix() const { return upb_filedef_phpprefix(ptr_); }
-
-  /* Use this option to change the namespace of php generated classes. Default
-   * is empty. When this option is empty, the package name will be used for
-   * determining the namespace. */
-  const char* phpnamespace() const { return upb_filedef_phpnamespace(ptr_); }
-
-  /* Syntax for the file.  Defaults to proto2. */
-  upb_syntax_t syntax() const { return upb_filedef_syntax(ptr_); }
-
-  /* Get the list of dependencies from the file.  These are returned in the
-   * order that they were added to the FileDefPtr. */
-  int dependency_count() const { return upb_filedef_depcount(ptr_); }
-  const FileDefPtr dependency(int index) const {
-    return FileDefPtr(upb_filedef_dep(ptr_, index));
-  }
-
- private:
-  const upb_filedef* ptr_;
-};
-
-#endif  /* __cplusplus */
-
 /* upb_symtab *****************************************************************/
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 upb_symtab *upb_symtab_new(void);
 void upb_symtab_free(upb_symtab* s);
@@ -844,52 +316,11 @@ typedef struct upb_def_init {
 
 bool _upb_symtab_loaddefinit(upb_symtab *s, const upb_def_init *init);
 
+#include "upb/port_undef.inc"
+
 #ifdef __cplusplus
 }  /* extern "C" */
-
-/* Non-const methods in upb::SymbolTable are NOT thread-safe. */
-class upb::SymbolTable {
- public:
-  SymbolTable() : ptr_(upb_symtab_new(), upb_symtab_free) {}
-  explicit SymbolTable(upb_symtab* s) : ptr_(s, upb_symtab_free) {}
-
-  const upb_symtab* ptr() const { return ptr_.get(); }
-  upb_symtab* ptr() { return ptr_.get(); }
-
-  /* Finds an entry in the symbol table with this exact name.  If not found,
-   * returns NULL. */
-  MessageDefPtr LookupMessage(const char *sym) const {
-    return MessageDefPtr(upb_symtab_lookupmsg(ptr_.get(), sym));
-  }
-
-  EnumDefPtr LookupEnum(const char *sym) const {
-    return EnumDefPtr(upb_symtab_lookupenum(ptr_.get(), sym));
-  }
-
-  FileDefPtr LookupFile(const char *name) const {
-    return FileDefPtr(upb_symtab_lookupfile(ptr_.get(), name));
-  }
-
-  /* TODO: iteration? */
-
-  /* Adds the given serialized FileDescriptorProto to the pool. */
-  FileDefPtr AddFile(const google_protobuf_FileDescriptorProto *file_proto,
-                     Status *status) {
-    return FileDefPtr(
-        upb_symtab_addfile(ptr_.get(), file_proto, status->ptr()));
-  }
-
- private:
-  std::unique_ptr<upb_symtab, decltype(&upb_symtab_free)> ptr_;
-};
-
-UPB_INLINE const char* upb_safecstr(const std::string& str) {
-  UPB_ASSERT(str.size() == std::strlen(str.c_str()));
-  return str.c_str();
-}
-
+#include "upb/def.hpp"
 #endif  /* __cplusplus */
-
-#include "upb/port_undef.inc"
 
 #endif /* UPB_DEF_H_ */

--- a/upb/def.hpp
+++ b/upb/def.hpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "upb/def.h"
+#include "upb/upb.hpp"
 
 namespace upb {
 

--- a/upb/def.hpp
+++ b/upb/def.hpp
@@ -1,0 +1,524 @@
+
+#ifndef UPB_DEF_HPP_
+#define UPB_DEF_HPP_
+
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "upb/def.h"
+
+namespace upb {
+
+class EnumDefPtr;
+class MessageDefPtr;
+class OneofDefPtr;
+
+// A upb::FieldDefPtr describes a single field in a message.  It is most often
+// found as a part of a upb_msgdef, but can also stand alone to represent
+// an extension.
+class FieldDefPtr {
+ public:
+  FieldDefPtr() : ptr_(nullptr) {}
+  explicit FieldDefPtr(const upb_fielddef* ptr) : ptr_(ptr) {}
+
+  const upb_fielddef* ptr() const { return ptr_; }
+  explicit operator bool() const { return ptr_ != nullptr; }
+
+  typedef upb_fieldtype_t Type;
+  typedef upb_label_t Label;
+  typedef upb_descriptortype_t DescriptorType;
+
+  const char* full_name() const { return upb_fielddef_fullname(ptr_); }
+
+  Type type() const { return upb_fielddef_type(ptr_); }
+  Label label() const { return upb_fielddef_label(ptr_); }
+  const char* name() const { return upb_fielddef_name(ptr_); }
+  const char* json_name() const { return upb_fielddef_jsonname(ptr_); }
+  uint32_t number() const { return upb_fielddef_number(ptr_); }
+  bool is_extension() const { return upb_fielddef_isextension(ptr_); }
+
+  // For UPB_TYPE_MESSAGE fields only where is_tag_delimited() == false,
+  // indicates whether this field should have lazy parsing handlers that yield
+  // the unparsed string for the submessage.
+  //
+  // TODO(haberman): I think we want to move this into a FieldOptions container
+  // when we add support for custom options (the FieldOptions struct will
+  // contain both regular FieldOptions like "lazy" *and* custom options).
+  bool lazy() const { return upb_fielddef_lazy(ptr_); }
+
+  // For non-string, non-submessage fields, this indicates whether binary
+  // protobufs are encoded in packed or non-packed format.
+  //
+  // TODO(haberman): see note above about putting options like this into a
+  // FieldOptions container.
+  bool packed() const { return upb_fielddef_packed(ptr_); }
+
+  // An integer that can be used as an index into an array of fields for
+  // whatever message this field belongs to.  Guaranteed to be less than
+  // f->containing_type()->field_count().  May only be accessed once the def has
+  // been finalized.
+  uint32_t index() const { return upb_fielddef_index(ptr_); }
+
+  // The MessageDef to which this field belongs.
+  //
+  // If this field has been added to a MessageDef, that message can be retrieved
+  // directly (this is always the case for frozen FieldDefs).
+  //
+  // If the field has not yet been added to a MessageDef, you can set the name
+  // of the containing type symbolically instead.  This is mostly useful for
+  // extensions, where the extension is declared separately from the message.
+  MessageDefPtr containing_type() const;
+
+  // The OneofDef to which this field belongs, or NULL if this field is not part
+  // of a oneof.
+  OneofDefPtr containing_oneof() const;
+
+  // The field's type according to the enum in descriptor.proto.  This is not
+  // the same as UPB_TYPE_*, because it distinguishes between (for example)
+  // INT32 and SINT32, whereas our "type" enum does not.  This return of
+  // descriptor_type() is a function of type(), integer_format(), and
+  // is_tag_delimited().
+  DescriptorType descriptor_type() const {
+    return upb_fielddef_descriptortype(ptr_);
+  }
+
+  // Convenient field type tests.
+  bool IsSubMessage() const { return upb_fielddef_issubmsg(ptr_); }
+  bool IsString() const { return upb_fielddef_isstring(ptr_); }
+  bool IsSequence() const { return upb_fielddef_isseq(ptr_); }
+  bool IsPrimitive() const { return upb_fielddef_isprimitive(ptr_); }
+  bool IsMap() const { return upb_fielddef_ismap(ptr_); }
+
+  // Returns the non-string default value for this fielddef, which may either
+  // be something the client set explicitly or the "default default" (0 for
+  // numbers, empty for strings).  The field's type indicates the type of the
+  // returned value, except for enum fields that are still mutable.
+  //
+  // Requires that the given function matches the field's current type.
+  int64_t default_int64() const { return upb_fielddef_defaultint64(ptr_); }
+  int32_t default_int32() const { return upb_fielddef_defaultint32(ptr_); }
+  uint64_t default_uint64() const { return upb_fielddef_defaultuint64(ptr_); }
+  uint32_t default_uint32() const { return upb_fielddef_defaultuint32(ptr_); }
+  bool default_bool() const { return upb_fielddef_defaultbool(ptr_); }
+  float default_float() const { return upb_fielddef_defaultfloat(ptr_); }
+  double default_double() const { return upb_fielddef_defaultdouble(ptr_); }
+
+  // The resulting string is always NULL-terminated.  If non-NULL, the length
+  // will be stored in *len.
+  const char* default_string(size_t* len) const {
+    return upb_fielddef_defaultstr(ptr_, len);
+  }
+
+  // Returns the enum or submessage def for this field, if any.  The field's
+  // type must match (ie. you may only call enum_subdef() for fields where
+  // type() == UPB_TYPE_ENUM).
+  EnumDefPtr enum_subdef() const;
+  MessageDefPtr message_subdef() const;
+
+ private:
+  const upb_fielddef* ptr_;
+};
+
+// Class that represents a oneof.
+class OneofDefPtr {
+ public:
+  OneofDefPtr() : ptr_(nullptr) {}
+  explicit OneofDefPtr(const upb_oneofdef* ptr) : ptr_(ptr) {}
+
+  const upb_oneofdef* ptr() const { return ptr_; }
+  explicit operator bool() { return ptr_ != nullptr; }
+
+  // Returns the MessageDef that owns this OneofDef.
+  MessageDefPtr containing_type() const;
+
+  // Returns the name of this oneof. This is the name used to look up the oneof
+  // by name once added to a message def.
+  const char* name() const { return upb_oneofdef_name(ptr_); }
+
+  // Returns the number of fields currently defined in the oneof.
+  int field_count() const { return upb_oneofdef_numfields(ptr_); }
+
+  // Looks up by name.
+  FieldDefPtr FindFieldByName(const char* name, size_t len) const {
+    return FieldDefPtr(upb_oneofdef_ntof(ptr_, name, len));
+  }
+  FieldDefPtr FindFieldByName(const char* name) const {
+    return FieldDefPtr(upb_oneofdef_ntofz(ptr_, name));
+  }
+
+  template <class T>
+  FieldDefPtr FindFieldByName(const T& str) const {
+    return FindFieldByName(str.c_str(), str.size());
+  }
+
+  // Looks up by tag number.
+  FieldDefPtr FindFieldByNumber(uint32_t num) const {
+    return FieldDefPtr(upb_oneofdef_itof(ptr_, num));
+  }
+
+  class const_iterator
+      : public std::iterator<std::forward_iterator_tag, FieldDefPtr> {
+   public:
+    void operator++() { upb_oneof_next(&iter_); }
+
+    FieldDefPtr operator*() const {
+      return FieldDefPtr(upb_oneof_iter_field(&iter_));
+    }
+
+    bool operator!=(const const_iterator& other) const {
+      return !upb_oneof_iter_isequal(&iter_, &other.iter_);
+    }
+
+    bool operator==(const const_iterator& other) const {
+      return upb_oneof_iter_isequal(&iter_, &other.iter_);
+    }
+
+   private:
+    friend class OneofDefPtr;
+
+    const_iterator() {}
+    explicit const_iterator(OneofDefPtr o) { upb_oneof_begin(&iter_, o.ptr()); }
+    static const_iterator end() {
+      const_iterator iter;
+      upb_oneof_iter_setdone(&iter.iter_);
+      return iter;
+    }
+
+    upb_oneof_iter iter_;
+  };
+
+  const_iterator begin() const { return const_iterator(*this); }
+  const_iterator end() const { return const_iterator::end(); }
+
+ private:
+  const upb_oneofdef* ptr_;
+};
+
+// Structure that describes a single .proto message type.
+class MessageDefPtr {
+ public:
+  MessageDefPtr() : ptr_(nullptr) {}
+  explicit MessageDefPtr(const upb_msgdef* ptr) : ptr_(ptr) {}
+
+  const upb_msgdef* ptr() const { return ptr_; }
+  explicit operator bool() const { return ptr_ != nullptr; }
+
+  const char* full_name() const { return upb_msgdef_fullname(ptr_); }
+  const char* name() const { return upb_msgdef_name(ptr_); }
+
+  // The number of fields that belong to the MessageDef.
+  int field_count() const { return upb_msgdef_numfields(ptr_); }
+
+  // The number of oneofs that belong to the MessageDef.
+  int oneof_count() const { return upb_msgdef_numoneofs(ptr_); }
+
+  upb_syntax_t syntax() const { return upb_msgdef_syntax(ptr_); }
+
+  // These return null pointers if the field is not found.
+  FieldDefPtr FindFieldByNumber(uint32_t number) const {
+    return FieldDefPtr(upb_msgdef_itof(ptr_, number));
+  }
+  FieldDefPtr FindFieldByName(const char* name, size_t len) const {
+    return FieldDefPtr(upb_msgdef_ntof(ptr_, name, len));
+  }
+  FieldDefPtr FindFieldByName(const char* name) const {
+    return FieldDefPtr(upb_msgdef_ntofz(ptr_, name));
+  }
+
+  template <class T>
+  FieldDefPtr FindFieldByName(const T& str) const {
+    return FindFieldByName(str.c_str(), str.size());
+  }
+
+  OneofDefPtr FindOneofByName(const char* name, size_t len) const {
+    return OneofDefPtr(upb_msgdef_ntoo(ptr_, name, len));
+  }
+
+  OneofDefPtr FindOneofByName(const char* name) const {
+    return OneofDefPtr(upb_msgdef_ntooz(ptr_, name));
+  }
+
+  template <class T>
+  OneofDefPtr FindOneofByName(const T& str) const {
+    return FindOneofByName(str.c_str(), str.size());
+  }
+
+  // Is this message a map entry?
+  bool mapentry() const { return upb_msgdef_mapentry(ptr_); }
+
+  // Return the type of well known type message. UPB_WELLKNOWN_UNSPECIFIED for
+  // non-well-known message.
+  upb_wellknowntype_t wellknowntype() const {
+    return upb_msgdef_wellknowntype(ptr_);
+  }
+
+  // Whether is a number wrapper.
+  bool isnumberwrapper() const { return upb_msgdef_isnumberwrapper(ptr_); }
+
+  // Iteration over fields.  The order is undefined.
+  class const_field_iterator
+      : public std::iterator<std::forward_iterator_tag, FieldDefPtr> {
+   public:
+    void operator++() { upb_msg_field_next(&iter_); }
+
+    FieldDefPtr operator*() const {
+      return FieldDefPtr(upb_msg_iter_field(&iter_));
+    }
+
+    bool operator!=(const const_field_iterator& other) const {
+      return !upb_msg_field_iter_isequal(&iter_, &other.iter_);
+    }
+
+    bool operator==(const const_field_iterator& other) const {
+      return upb_msg_field_iter_isequal(&iter_, &other.iter_);
+    }
+
+   private:
+    friend class MessageDefPtr;
+
+    explicit const_field_iterator() {}
+
+    explicit const_field_iterator(MessageDefPtr msg) {
+      upb_msg_field_begin(&iter_, msg.ptr());
+    }
+
+    static const_field_iterator end() {
+      const_field_iterator iter;
+      upb_msg_field_iter_setdone(&iter.iter_);
+      return iter;
+    }
+
+    upb_msg_field_iter iter_;
+  };
+
+  // Iteration over oneofs. The order is undefined.
+  class const_oneof_iterator
+      : public std::iterator<std::forward_iterator_tag, OneofDefPtr> {
+   public:
+    void operator++() { upb_msg_oneof_next(&iter_); }
+
+    OneofDefPtr operator*() const {
+      return OneofDefPtr(upb_msg_iter_oneof(&iter_));
+    }
+
+    bool operator!=(const const_oneof_iterator& other) const {
+      return !upb_msg_oneof_iter_isequal(&iter_, &other.iter_);
+    }
+
+    bool operator==(const const_oneof_iterator& other) const {
+      return upb_msg_oneof_iter_isequal(&iter_, &other.iter_);
+    }
+
+   private:
+    friend class MessageDefPtr;
+
+    const_oneof_iterator() {}
+
+    explicit const_oneof_iterator(MessageDefPtr msg) {
+      upb_msg_oneof_begin(&iter_, msg.ptr());
+    }
+
+    static const_oneof_iterator end() {
+      const_oneof_iterator iter;
+      upb_msg_oneof_iter_setdone(&iter.iter_);
+      return iter;
+    }
+
+    upb_msg_oneof_iter iter_;
+  };
+
+  class ConstFieldAccessor {
+   public:
+    explicit ConstFieldAccessor(const upb_msgdef* md) : md_(md) {}
+    const_field_iterator begin() { return MessageDefPtr(md_).field_begin(); }
+    const_field_iterator end() { return MessageDefPtr(md_).field_end(); }
+
+   private:
+    const upb_msgdef* md_;
+  };
+
+  class ConstOneofAccessor {
+   public:
+    explicit ConstOneofAccessor(const upb_msgdef* md) : md_(md) {}
+    const_oneof_iterator begin() { return MessageDefPtr(md_).oneof_begin(); }
+    const_oneof_iterator end() { return MessageDefPtr(md_).oneof_end(); }
+
+   private:
+    const upb_msgdef* md_;
+  };
+
+  const_field_iterator field_begin() const {
+    return const_field_iterator(*this);
+  }
+
+  const_field_iterator field_end() const { return const_field_iterator::end(); }
+
+  const_oneof_iterator oneof_begin() const {
+    return const_oneof_iterator(*this);
+  }
+
+  const_oneof_iterator oneof_end() const { return const_oneof_iterator::end(); }
+
+  ConstFieldAccessor fields() const { return ConstFieldAccessor(ptr()); }
+  ConstOneofAccessor oneofs() const { return ConstOneofAccessor(ptr()); }
+
+ private:
+  const upb_msgdef* ptr_;
+};
+
+class EnumDefPtr {
+ public:
+  EnumDefPtr() : ptr_(nullptr) {}
+  explicit EnumDefPtr(const upb_enumdef* ptr) : ptr_(ptr) {}
+
+  const upb_enumdef* ptr() const { return ptr_; }
+  explicit operator bool() const { return ptr_ != nullptr; }
+
+  const char* full_name() const { return upb_enumdef_fullname(ptr_); }
+  const char* name() const { return upb_enumdef_name(ptr_); }
+
+  // The value that is used as the default when no field default is specified.
+  // If not set explicitly, the first value that was added will be used.
+  // The default value must be a member of the enum.
+  // Requires that value_count() > 0.
+  int32_t default_value() const { return upb_enumdef_default(ptr_); }
+
+  // Returns the number of values currently defined in the enum.  Note that
+  // multiple names can refer to the same number, so this may be greater than
+  // the total number of unique numbers.
+  int value_count() const { return upb_enumdef_numvals(ptr_); }
+
+  // Lookups from name to integer, returning true if found.
+  bool FindValueByName(const char* name, int32_t* num) const {
+    return upb_enumdef_ntoiz(ptr_, name, num);
+  }
+
+  // Finds the name corresponding to the given number, or NULL if none was
+  // found.  If more than one name corresponds to this number, returns the
+  // first one that was added.
+  const char* FindValueByNumber(int32_t num) const {
+    return upb_enumdef_iton(ptr_, num);
+  }
+
+  // Iteration over name/value pairs.  The order is undefined.
+  // Adding an enum val invalidates any iterators.
+  //
+  // TODO: make compatible with range-for, with elements as pairs?
+  class Iterator {
+   public:
+    explicit Iterator(EnumDefPtr e) { upb_enum_begin(&iter_, e.ptr()); }
+
+    int32_t number() { return upb_enum_iter_number(&iter_); }
+    const char* name() { return upb_enum_iter_name(&iter_); }
+    bool Done() { return upb_enum_done(&iter_); }
+    void Next() { return upb_enum_next(&iter_); }
+
+   private:
+    upb_enum_iter iter_;
+  };
+
+ private:
+  const upb_enumdef* ptr_;
+};
+
+// Class that represents a .proto file with some things defined in it.
+//
+// Many users won't care about FileDefs, but they are necessary if you want to
+// read the values of file-level options.
+class FileDefPtr {
+ public:
+  explicit FileDefPtr(const upb_filedef* ptr) : ptr_(ptr) {}
+
+  const upb_filedef* ptr() const { return ptr_; }
+  explicit operator bool() const { return ptr_ != nullptr; }
+
+  // Get/set name of the file (eg. "foo/bar.proto").
+  const char* name() const { return upb_filedef_name(ptr_); }
+
+  // Package name for definitions inside the file (eg. "foo.bar").
+  const char* package() const { return upb_filedef_package(ptr_); }
+
+  // Sets the php class prefix which is prepended to all php generated classes
+  // from this .proto. Default is empty.
+  const char* phpprefix() const { return upb_filedef_phpprefix(ptr_); }
+
+  // Use this option to change the namespace of php generated classes. Default
+  // is empty. When this option is empty, the package name will be used for
+  // determining the namespace.
+  const char* phpnamespace() const { return upb_filedef_phpnamespace(ptr_); }
+
+  // Syntax for the file.  Defaults to proto2.
+  upb_syntax_t syntax() const { return upb_filedef_syntax(ptr_); }
+
+  // Get the list of dependencies from the file.  These are returned in the
+  // order that they were added to the FileDefPtr.
+  int dependency_count() const { return upb_filedef_depcount(ptr_); }
+  const FileDefPtr dependency(int index) const {
+    return FileDefPtr(upb_filedef_dep(ptr_, index));
+  }
+
+ private:
+  const upb_filedef* ptr_;
+};
+
+// Non-const methods in upb::SymbolTable are NOT thread-safe.
+class SymbolTable {
+ public:
+  SymbolTable() : ptr_(upb_symtab_new(), upb_symtab_free) {}
+  explicit SymbolTable(upb_symtab* s) : ptr_(s, upb_symtab_free) {}
+
+  const upb_symtab* ptr() const { return ptr_.get(); }
+  upb_symtab* ptr() { return ptr_.get(); }
+
+  // Finds an entry in the symbol table with this exact name.  If not found,
+  // returns NULL.
+  MessageDefPtr LookupMessage(const char* sym) const {
+    return MessageDefPtr(upb_symtab_lookupmsg(ptr_.get(), sym));
+  }
+
+  EnumDefPtr LookupEnum(const char* sym) const {
+    return EnumDefPtr(upb_symtab_lookupenum(ptr_.get(), sym));
+  }
+
+  FileDefPtr LookupFile(const char* name) const {
+    return FileDefPtr(upb_symtab_lookupfile(ptr_.get(), name));
+  }
+
+  // TODO: iteration?
+
+  // Adds the given serialized FileDescriptorProto to the pool.
+  FileDefPtr AddFile(const google_protobuf_FileDescriptorProto* file_proto,
+                     Status* status) {
+    return FileDefPtr(
+        upb_symtab_addfile(ptr_.get(), file_proto, status->ptr()));
+  }
+
+ private:
+  std::unique_ptr<upb_symtab, decltype(&upb_symtab_free)> ptr_;
+};
+
+inline MessageDefPtr FieldDefPtr::message_subdef() const {
+  return MessageDefPtr(upb_fielddef_msgsubdef(ptr_));
+}
+
+inline MessageDefPtr FieldDefPtr::containing_type() const {
+  return MessageDefPtr(upb_fielddef_containingtype(ptr_));
+}
+
+inline MessageDefPtr OneofDefPtr::containing_type() const {
+  return MessageDefPtr(upb_oneofdef_containingtype(ptr_));
+}
+
+inline OneofDefPtr FieldDefPtr::containing_oneof() const {
+  return OneofDefPtr(upb_fielddef_containingoneof(ptr_));
+}
+
+inline EnumDefPtr FieldDefPtr::enum_subdef() const {
+  return EnumDefPtr(upb_fielddef_enumsubdef(ptr_));
+}
+
+}  // namespace upb
+
+#endif  // UPB_DEF_HPP_

--- a/upb/handlers.h
+++ b/upb/handlers.h
@@ -25,6 +25,7 @@
 #include "upb/port_def.inc"
 
 #ifdef __cplusplus
+#include "upb/def.hpp"
 namespace upb {
 class HandlersPtr;
 class HandlerCache;

--- a/upb/upb.h
+++ b/upb/upb.h
@@ -1,8 +1,5 @@
 /*
 ** This file contains shared definitions that are widely used across upb.
-**
-** This is a mixed C/C++ interface that offers a full API to both languages.
-** See the top-level README for more information.
 */
 
 #ifndef UPB_H_
@@ -15,24 +12,14 @@
 #include <stdint.h>
 #include <string.h>
 
-#ifdef __cplusplus
-#include <memory>
-namespace upb {
-class Arena;
-class Status;
-template <int N> class InlinedArena;
-}
-#endif
-
 #include "upb/port_def.inc"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* upb_status *****************************************************************/
 
-/* upb_status represents a success or failure status and error message.
- * It owns no resources and allocates no memory, so it should work
- * even in OOM situations. */
-
-/* The maximum length of an error message before it will get truncated. */
 #define UPB_STATUS_MAX_MESSAGE 127
 
 typedef struct {
@@ -40,58 +27,14 @@ typedef struct {
   char msg[UPB_STATUS_MAX_MESSAGE];  /* Error message; NULL-terminated. */
 } upb_status;
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 const char *upb_status_errmsg(const upb_status *status);
 bool upb_ok(const upb_status *status);
 
-/* Any of the functions that write to a status object allow status to be NULL,
- * to support use cases where the function's caller does not care about the
- * status message. */
+/* These are no-op if |status| is NULL. */
 void upb_status_clear(upb_status *status);
 void upb_status_seterrmsg(upb_status *status, const char *msg);
 void upb_status_seterrf(upb_status *status, const char *fmt, ...);
 void upb_status_vseterrf(upb_status *status, const char *fmt, va_list args);
-
-UPB_INLINE void upb_status_setoom(upb_status *status) {
-  upb_status_seterrmsg(status, "out of memory");
-}
-
-#ifdef __cplusplus
-}  /* extern "C" */
-
-class upb::Status {
- public:
-  Status() { upb_status_clear(&status_); }
-
-  upb_status* ptr() { return &status_; }
-
-  /* Returns true if there is no error. */
-  bool ok() const { return upb_ok(&status_); }
-
-  /* Guaranteed to be NULL-terminated. */
-  const char *error_message() const { return upb_status_errmsg(&status_); }
-
-  /* The error message will be truncated if it is longer than
-   * UPB_STATUS_MAX_MESSAGE-4. */
-  void SetErrorMessage(const char *msg) { upb_status_seterrmsg(&status_, msg); }
-  void SetFormattedErrorMessage(const char *fmt, ...) {
-    va_list args;
-    va_start(args, fmt);
-    upb_status_vseterrf(&status_, fmt, args);
-    va_end(args);
-  }
-
-  /* Resets the status to a successful state with no message. */
-  void Clear() { upb_status_clear(&status_); }
-
- private:
-  upb_status status_;
-};
-
-#endif  /* __cplusplus */
 
 /** upb_strview ************************************************************/
 
@@ -159,15 +102,7 @@ UPB_INLINE void upb_free(upb_alloc *alloc, void *ptr) {
 
 /* The global allocator used by upb.  Uses the standard malloc()/free(). */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 extern upb_alloc upb_alloc_global;
-
-#ifdef __cplusplus
-}  /* extern "C" */
-#endif
 
 /* Functions that hard-code the global malloc.
  *
@@ -204,10 +139,6 @@ typedef void upb_cleanup_func(void *ud);
 
 struct upb_arena;
 typedef struct upb_arena upb_arena;
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 typedef struct {
   /* We implement the allocator interface.
@@ -258,64 +189,6 @@ UPB_INLINE upb_arena *upb_arena_new(void) {
   return upb_arena_init(NULL, 0, &upb_alloc_global);
 }
 
-#ifdef __cplusplus
-}  /* extern "C" */
-
-class upb::Arena {
- public:
-  /* A simple arena with no initial memory block and the default allocator. */
-  Arena() : ptr_(upb_arena_new(), upb_arena_free) {}
-
-  upb_arena* ptr() { return ptr_.get(); }
-
-  /* Allows this arena to be used as a generic allocator.
-   *
-   * The arena does not need free() calls so when using Arena as an allocator
-   * it is safe to skip them.  However they are no-ops so there is no harm in
-   * calling free() either. */
-  upb_alloc *allocator() { return upb_arena_alloc(ptr_.get()); }
-
-  /* Add a cleanup function to run when the arena is destroyed.
-   * Returns false on out-of-memory. */
-  bool AddCleanup(void *ud, upb_cleanup_func* func) {
-    return upb_arena_addcleanup(ptr_.get(), ud, func);
-  }
-
-  /* Total number of bytes that have been allocated.  It is undefined what
-   * Realloc() does to &arena_ counter. */
-  size_t BytesAllocated() const { return upb_arena_bytesallocated(ptr_.get()); }
-
- private:
-  std::unique_ptr<upb_arena, decltype(&upb_arena_free)> ptr_;
-};
-
-#endif
-
-/* upb::InlinedArena **********************************************************/
-
-/* upb::InlinedArena seeds the arenas with a predefined amount of memory.  No
- * heap memory will be allocated until the initial block is exceeded.
- *
- * These types only exist in C++ */
-
-#ifdef __cplusplus
-
-template <int N> class upb::InlinedArena : public upb::Arena {
- public:
-  InlinedArena() : ptr_(upb_arena_new(&initial_block_, N, &upb_alloc_global)) {}
-
-  upb_arena* ptr() { return ptr_.get(); }
-
- private:
-  InlinedArena(const InlinedArena*) = delete;
-  InlinedArena& operator=(const InlinedArena*) = delete;
-
-  std::unique_ptr<upb_arena, decltype(&upb_arena_free)> ptr_;
-  char initial_block_[N];
-};
-
-#endif  /* __cplusplus */
-
 /* Constants ******************************************************************/
 
 /* Generic function type. */
@@ -335,20 +208,15 @@ typedef enum {
  * types defined in descriptor.proto, which gives INT32 and SINT32 separate
  * types (we distinguish the two with the "integer encoding" enum below). */
 typedef enum {
-  /* Types stored in 1 byte. */
   UPB_TYPE_BOOL     = 1,
-  /* Types stored in 4 bytes. */
   UPB_TYPE_FLOAT    = 2,
   UPB_TYPE_INT32    = 3,
   UPB_TYPE_UINT32   = 4,
   UPB_TYPE_ENUM     = 5,  /* Enum values are int32. */
-  /* Types stored as void* (probably 4 or 8 bytes). */
   UPB_TYPE_MESSAGE  = 6,
-  /* Types stored as 8 bytes. */
   UPB_TYPE_DOUBLE   = 7,
   UPB_TYPE_INT64    = 8,
   UPB_TYPE_UINT64   = 9,
-  /* Types stored as upb_strview (2 * void*) (probably 8 or 16 bytes). */
   UPB_TYPE_STRING   = 10,
   UPB_TYPE_BYTES    = 11
 } upb_fieldtype_t;
@@ -405,5 +273,10 @@ typedef enum {
 #define UPB_MAP_BEGIN -1
 
 #include "upb/port_undef.inc"
+
+#ifdef __cplusplus
+}  /* extern "C" */
+#include "upb/upb.hpp"  /* C++ Wrappers. */
+#endif
 
 #endif  /* UPB_H_ */

--- a/upb/upb.h
+++ b/upb/upb.h
@@ -276,7 +276,6 @@ typedef enum {
 
 #ifdef __cplusplus
 }  /* extern "C" */
-#include "upb/upb.hpp"  /* C++ Wrappers. */
 #endif
 
 #endif  /* UPB_H_ */

--- a/upb/upb.hpp
+++ b/upb/upb.hpp
@@ -65,10 +65,10 @@ class Arena {
   std::unique_ptr<upb_arena, decltype(&upb_arena_free)> ptr_;
 };
 
-// upb::InlinedArena seeds the arenas with a predefined amount of memory.  No
+// InlinedArena seeds the arenas with a predefined amount of memory.  No
 // heap memory will be allocated until the initial block is exceeded.
 template <int N>
-class InlinedArena : public upb::Arena {
+class InlinedArena : public Arena {
  public:
   InlinedArena() : ptr_(upb_arena_new(&initial_block_, N, &upb_alloc_global)) {}
 

--- a/upb/upb.hpp
+++ b/upb/upb.hpp
@@ -1,0 +1,87 @@
+
+#ifndef UPB_HPP_
+#define UPB_HPP_
+
+#include <memory>
+
+#include "upb/upb.h"
+
+namespace upb {
+
+class Status {
+ public:
+  Status() { upb_status_clear(&status_); }
+
+  upb_status* ptr() { return &status_; }
+
+  // Returns true if there is no error.
+  bool ok() const { return upb_ok(&status_); }
+
+  // Guaranteed to be NULL-terminated.
+  const char *error_message() const { return upb_status_errmsg(&status_); }
+
+  // The error message will be truncated if it is longer than
+  // UPB_STATUS_MAX_MESSAGE-4.
+  void SetErrorMessage(const char *msg) { upb_status_seterrmsg(&status_, msg); }
+  void SetFormattedErrorMessage(const char *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    upb_status_vseterrf(&status_, fmt, args);
+    va_end(args);
+  }
+
+  // Resets the status to a successful state with no message.
+  void Clear() { upb_status_clear(&status_); }
+
+ private:
+  upb_status status_;
+};
+
+class Arena {
+ public:
+  // A simple arena with no initial memory block and the default allocator.
+  Arena() : ptr_(upb_arena_new(), upb_arena_free) {}
+
+  upb_arena* ptr() { return ptr_.get(); }
+
+  // Allows this arena to be used as a generic allocator.
+  //
+  // The arena does not need free() calls so when using Arena as an allocator
+  // it is safe to skip them.  However they are no-ops so there is no harm in
+  // calling free() either.
+  upb_alloc *allocator() { return upb_arena_alloc(ptr_.get()); }
+
+  // Add a cleanup function to run when the arena is destroyed.
+  // Returns false on out-of-memory.
+  bool AddCleanup(void *ud, upb_cleanup_func* func) {
+    return upb_arena_addcleanup(ptr_.get(), ud, func);
+  }
+
+  // Total number of bytes that have been allocated.  It is undefined what
+  // Realloc() does to &arena_ counter.
+  size_t BytesAllocated() const { return upb_arena_bytesallocated(ptr_.get()); }
+
+ private:
+  std::unique_ptr<upb_arena, decltype(&upb_arena_free)> ptr_;
+};
+
+// upb::InlinedArena seeds the arenas with a predefined amount of memory.  No
+// heap memory will be allocated until the initial block is exceeded.
+template <int N>
+class InlinedArena : public upb::Arena {
+ public:
+  InlinedArena() : ptr_(upb_arena_new(&initial_block_, N, &upb_alloc_global)) {}
+
+  upb_arena* ptr() { return ptr_.get(); }
+
+ private:
+  InlinedArena(const InlinedArena*) = delete;
+  InlinedArena& operator=(const InlinedArena*) = delete;
+
+  std::unique_ptr<upb_arena, decltype(&upb_arena_free)> ptr_;
+  char initial_block_[N];
+};
+
+}  // namespace upb
+
+#endif // UPB_HPP_


### PR DESCRIPTION
This makes both the C (.h) and C++ (.hpp) files read nicer.
Existing users of the C++ wrappers will have to add manual
#includes of the `.hpp` files.