### PR TITLE
Add load statements for @rules_proto

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,8 @@
 load(
+    "@rules_proto//proto:defs.bzl",
+    "proto_library",
+)
+load(
     "//bazel:build_defs.bzl",
     "generated_file_staleness_test",
     "licenses",  # copybara:strip_for_google3

--- a/bazel/upb_proto_library.bzl
+++ b/bazel/upb_proto_library.bzl
@@ -5,6 +5,7 @@
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@rules_proto//proto:defs.bzl", "ProtoInfo")
 
 # Generic support code #########################################################
 

--- a/examples/bazel/BUILD
+++ b/examples/bazel/BUILD
@@ -1,4 +1,4 @@
-
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@upb//bazel:upb_proto_library.bzl", "upb_proto_library")
 
 proto_library(


### PR DESCRIPTION
This makes upb compatible with --incompatible_load_proto_rules_from_bzl.
See https://github.com/bazelbuild/bazel/issues/8922