### PR TITLE
Add UPB_NORETURN for MSC

### DIFF
--- a/upb/port_def.inc
+++ b/upb/port_def.inc
@@ -79,6 +79,10 @@
 #define UPB_FORCEINLINE __inline__ __attribute__((always_inline))
 #define UPB_NOINLINE __attribute__((noinline))
 #define UPB_NORETURN __attribute__((__noreturn__))
+#elif defined(_MSC_VER)
+#define UPB_NOINLINE
+#define UPB_FORCEINLINE
+#define UPB_NORETURN __declspec(noreturn)
 #else  /* !defined(__GNUC__) */
 #define UPB_FORCEINLINE
 #define UPB_NOINLINE


### PR DESCRIPTION
This is backport from internal cl/324840856. Without this, it will have a following error on Windows;

```
third_party/upb/upb/decode.c(563,7): error: variable 'op' is used uninitialized whenever switch default is taken [-Werror,-Wsometimes-uninitialized]
      default:
      ^~~~~~~
third_party/upb/upb/decode.c(567,9): note: uninitialized use occurs here
    if (op >= 0) {
        ^~
third_party/upb/upb/decode.c(511,11): note: initialize the variable 'op' to silence this warning
    int op;
          ^
           = 0
1 error generated.
```