### PR TITLE
Optimized the binary encoder for a 2x speedup

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -7,7 +7,7 @@ import re
 def Run(cmd):
   subprocess.check_call(cmd, shell=True)
 
-def RunAgainstBranch(branch, outfile, runs=12):
+def RunAgainstBranch(branch, outbase, runs=12):
   tmpfile = "/tmp/bench-output.json"
   Run("rm -rf {}".format(tmpfile))
   Run("git checkout {}".format(branch))
@@ -15,10 +15,13 @@ def RunAgainstBranch(branch, outfile, runs=12):
 
   Run("./bazel-bin/benchmark --benchmark_out_format=json --benchmark_out={} --benchmark_repetitions={}".format(tmpfile, runs))
 
+  Run("bazel build -c opt --copt=-g :conformance_upb")
+  Run("cp -f bazel-bin/conformance_upb {}.bin".format(outbase))
+
   with open(tmpfile) as f:
     bench_json = json.load(f)
 
-  with open(outfile, "w") as f:
+  with open(outbase + ".txt", "w") as f:
     for run in bench_json["benchmarks"]:
       name = re.sub(r'^BM_', 'Benchmark', run["name"])
       if name.endswith("_mean") or name.endswith("_median") or name.endswith("_stddev"):
@@ -26,7 +29,17 @@ def RunAgainstBranch(branch, outfile, runs=12):
       values = (name, run["iterations"], run["cpu_time"])
       print("{} {} {} ns/op".format(*values), file=f)
 
-RunAgainstBranch("master", "/tmp/old.txt")
-RunAgainstBranch("decoder", "/tmp/new.txt")
+RunAgainstBranch("6e140c267cc9bf6a4ef89d3f9a842209d7537599", "/tmp/old")
+RunAgainstBranch("encoder", "/tmp/new")
+
+print()
+print()
 
 Run("~/go/bin/benchstat /tmp/old.txt /tmp/new.txt")
+
+print()
+print()
+
+Run("objcopy --strip-debug /tmp/old.bin /tmp/old.bin.stripped")
+Run("objcopy --strip-debug /tmp/new.bin /tmp/new.bin.stripped")
+Run("~/code/bloaty/bloaty /tmp/new.bin.stripped -- /tmp/old.bin.stripped --debug-file=/tmp/old.bin --debug-file=/tmp/new.bin -d compileunits,symbols")

--- a/tests/benchmark.cc
+++ b/tests/benchmark.cc
@@ -83,6 +83,6 @@ static void BM_SerializeDescriptor(benchmark::State& state) {
     }
     total += size;
   }
-  state.SetBytesProcessed(state.iterations() * descriptor.size);
+  state.SetBytesProcessed(total);
 }
 BENCHMARK(BM_SerializeDescriptor);

--- a/tests/benchmark.cc
+++ b/tests/benchmark.cc
@@ -62,3 +62,27 @@ static void BM_ParseDescriptor(benchmark::State& state) {
   state.SetBytesProcessed(state.iterations() * descriptor.size);
 }
 BENCHMARK(BM_ParseDescriptor);
+
+static void BM_SerializeDescriptor(benchmark::State& state) {
+  int64_t total = 0;
+  upb_arena* arena = upb_arena_new();
+  google_protobuf_FileDescriptorProto* set =
+      google_protobuf_FileDescriptorProto_parse(descriptor.data,
+                                                descriptor.size, arena);
+  if (!set) {
+    printf("Failed to parse.\n");
+    exit(1);
+  }
+  for (auto _ : state) {
+    upb_arena* enc_arena = upb_arena_init(buf, sizeof(buf), NULL);
+    size_t size;
+    char *data = google_protobuf_FileDescriptorProto_serialize(set, enc_arena, &size);
+    if (!data) {
+      printf("Failed to serialize.\n");
+      exit(1);
+    }
+    total += size;
+  }
+  state.SetBytesProcessed(state.iterations() * descriptor.size);
+}
+BENCHMARK(BM_SerializeDescriptor);

--- a/upb/encode.c
+++ b/upb/encode.c
@@ -227,6 +227,8 @@ static void encode_scalar(upb_encstate *e, const void *_field_mem,
       wire_type = UPB_WIRE_TYPE_DELIMITED;
       break;
     }
+    default:
+      UPB_UNREACHABLE();
   }
 #undef CASE
 

--- a/upb/encode.c
+++ b/upb/encode.c
@@ -15,12 +15,12 @@
 UPB_NOINLINE
 static size_t encode_varint64(uint64_t val, char *buf) {
   size_t i = 0;
-  while (val) {
+  do {
     uint8_t byte = val & 0x7fU;
     val >>= 7;
     if (val) byte |= 0x80U;
     buf[i++] = byte;
-  }
+  } while (val);
   return i;
 }
 
@@ -59,6 +59,8 @@ static void encode_growbuffer(upb_encstate *e, size_t bytes) {
   e->ptr = new_buf + new_size - (e->limit - e->ptr);
   e->limit = new_buf + new_size;
   e->buf = new_buf;
+
+  e->ptr -= bytes;
 }
 
 /* Call to ensure that at least "bytes" bytes are available for writing at
@@ -67,6 +69,7 @@ UPB_FORCEINLINE
 static void encode_reserve(upb_encstate *e, size_t bytes) {
   if ((size_t)(e->ptr - e->buf) < bytes) {
     encode_growbuffer(e, bytes);
+    return;
   }
 
   e->ptr -= bytes;

--- a/upb/encode.c
+++ b/upb/encode.c
@@ -2,6 +2,7 @@
 
 #include "upb/encode.h"
 
+#include <setjmp.h>
 #include <string.h>
 
 #include "upb/msg.h"
@@ -10,7 +11,6 @@
 #include "upb/port_def.inc"
 
 #define UPB_PB_VARINT_MAX_LEN 10
-#define CHK(x) do { if (!(x)) { return false; } } while(0)
 
 static size_t upb_encode_varint(uint64_t val, char *buf) {
   size_t i;
@@ -29,6 +29,7 @@ static uint32_t upb_zzencode_32(int32_t n) { return ((uint32_t)n << 1) ^ (n >> 3
 static uint64_t upb_zzencode_64(int64_t n) { return ((uint64_t)n << 1) ^ (n >> 63); }
 
 typedef struct {
+  jmp_buf err;
   upb_alloc *alloc;
   char *buf, *ptr, *limit;
 } upb_encstate;
@@ -41,11 +42,14 @@ static size_t upb_roundup_pow2(size_t bytes) {
   return ret;
 }
 
-static bool upb_encode_growbuffer(upb_encstate *e, size_t bytes) {
+UPB_NORETURN static void encode_err(upb_encstate *e) { longjmp(e->err, 1); }
+
+static void upb_encode_growbuffer(upb_encstate *e, size_t bytes) {
   size_t old_size = e->limit - e->buf;
   size_t new_size = upb_roundup_pow2(bytes + (e->limit - e->ptr));
   char *new_buf = upb_realloc(e->alloc, e->buf, old_size, new_size);
-  CHK(new_buf);
+
+  if (!new_buf) encode_err(e);
 
   /* We want previous data at the end, realloc() put it at the beginning. */
   if (old_size > 0) {
@@ -55,87 +59,85 @@ static bool upb_encode_growbuffer(upb_encstate *e, size_t bytes) {
   e->ptr = new_buf + new_size - (e->limit - e->ptr);
   e->limit = new_buf + new_size;
   e->buf = new_buf;
-  return true;
 }
 
 /* Call to ensure that at least "bytes" bytes are available for writing at
  * e->ptr.  Returns false if the bytes could not be allocated. */
-static bool upb_encode_reserve(upb_encstate *e, size_t bytes) {
-  CHK(UPB_LIKELY((size_t)(e->ptr - e->buf) >= bytes) ||
-      upb_encode_growbuffer(e, bytes));
+static void upb_encode_reserve(upb_encstate *e, size_t bytes) {
+  if ((size_t)(e->ptr - e->buf) < bytes) {
+    upb_encode_growbuffer(e, bytes);
+  }
 
   e->ptr -= bytes;
-  return true;
 }
 
 /* Writes the given bytes to the buffer, handling reserve/advance. */
-static bool upb_put_bytes(upb_encstate *e, const void *data, size_t len) {
-  if (len == 0) return true;
-  CHK(upb_encode_reserve(e, len));
+static void upb_put_bytes(upb_encstate *e, const void *data, size_t len) {
+  if (len == 0) return;  /* memcpy() with zero size is UB */
+  upb_encode_reserve(e, len);
   memcpy(e->ptr, data, len);
-  return true;
 }
 
-static bool upb_put_fixed64(upb_encstate *e, uint64_t val) {
+static void upb_put_fixed64(upb_encstate *e, uint64_t val) {
   val = _upb_be_swap64(val);
-  return upb_put_bytes(e, &val, sizeof(uint64_t));
+  upb_put_bytes(e, &val, sizeof(uint64_t));
 }
 
-static bool upb_put_fixed32(upb_encstate *e, uint32_t val) {
+static void upb_put_fixed32(upb_encstate *e, uint32_t val) {
   val = _upb_be_swap32(val);
-  return upb_put_bytes(e, &val, sizeof(uint32_t));
+  upb_put_bytes(e, &val, sizeof(uint32_t));
 }
 
-static bool upb_put_varint(upb_encstate *e, uint64_t val) {
+static void upb_put_varint(upb_encstate *e, uint64_t val) {
   size_t len;
   char *start;
-  CHK(upb_encode_reserve(e, UPB_PB_VARINT_MAX_LEN));
+  upb_encode_reserve(e, UPB_PB_VARINT_MAX_LEN);
   len = upb_encode_varint(val, e->ptr);
   start = e->ptr + UPB_PB_VARINT_MAX_LEN - len;
   memmove(start, e->ptr, len);
   e->ptr = start;
-  return true;
 }
 
-static bool upb_put_double(upb_encstate *e, double d) {
+static void upb_put_double(upb_encstate *e, double d) {
   uint64_t u64;
   UPB_ASSERT(sizeof(double) == sizeof(uint64_t));
   memcpy(&u64, &d, sizeof(uint64_t));
-  return upb_put_fixed64(e, u64);
+  upb_put_fixed64(e, u64);
 }
 
-static bool upb_put_float(upb_encstate *e, float d) {
+static void upb_put_float(upb_encstate *e, float d) {
   uint32_t u32;
   UPB_ASSERT(sizeof(float) == sizeof(uint32_t));
   memcpy(&u32, &d, sizeof(uint32_t));
-  return upb_put_fixed32(e, u32);
+  upb_put_fixed32(e, u32);
 }
 
-static bool upb_put_tag(upb_encstate *e, int field_number, int wire_type) {
-  return upb_put_varint(e, (field_number << 3) | wire_type);
+static void upb_put_tag(upb_encstate *e, int field_number, int wire_type) {
+  upb_put_varint(e, (field_number << 3) | wire_type);
 }
 
-static bool upb_put_fixedarray(upb_encstate *e, const upb_array *arr,
+static void upb_put_fixedarray(upb_encstate *e, const upb_array *arr,
                                size_t elem_size, uint32_t tag) {
   size_t bytes = arr->len * elem_size;
   const char* data = _upb_array_constptr(arr);
   const char* ptr = data + bytes - elem_size;
   if (tag) {
     while (true) {
-      CHK(upb_put_bytes(e, ptr, elem_size) && upb_put_varint(e, tag));
+      upb_put_bytes(e, ptr, elem_size);
+      upb_put_varint(e, tag);
       if (ptr == data) break;
       ptr -= elem_size;
     }
-    return true;
   } else {
-    return upb_put_bytes(e, data, bytes) && upb_put_varint(e, bytes);
+    upb_put_bytes(e, data, bytes);
+    upb_put_varint(e, bytes);
   }
 }
 
-bool upb_encode_message(upb_encstate *e, const char *msg,
-                        const upb_msglayout *m, size_t *size);
+static void upb_encode_message(upb_encstate *e, const char *msg,
+                               const upb_msglayout *m, size_t *size);
 
-static bool upb_encode_scalarfield(upb_encstate *e, const void *_field_mem,
+static void upb_encode_scalarfield(upb_encstate *e, const void *_field_mem,
                                    const upb_msglayout *m,
                                    const upb_msglayout_field *f,
                                    bool skip_zero_value) {
@@ -143,10 +145,11 @@ static bool upb_encode_scalarfield(upb_encstate *e, const void *_field_mem,
 #define CASE(ctype, type, wire_type, encodeval) do { \
   ctype val = *(ctype*)field_mem; \
   if (skip_zero_value && val == 0) { \
-    return true; \
+    return; \
   } \
-  return upb_put_ ## type(e, encodeval) && \
-      upb_put_tag(e, f->number, wire_type); \
+  upb_put_ ## type(e, encodeval); \
+  upb_put_tag(e, f->number, wire_type); \
+  return; \
 } while(0)
 
   switch (f->descriptortype) {
@@ -178,47 +181,50 @@ static bool upb_encode_scalarfield(upb_encstate *e, const void *_field_mem,
     case UPB_DESCRIPTOR_TYPE_BYTES: {
       upb_strview view = *(upb_strview*)field_mem;
       if (skip_zero_value && view.size == 0) {
-        return true;
+        return;
       }
-      return upb_put_bytes(e, view.data, view.size) &&
-          upb_put_varint(e, view.size) &&
-          upb_put_tag(e, f->number, UPB_WIRE_TYPE_DELIMITED);
+      upb_put_bytes(e, view.data, view.size);
+      upb_put_varint(e, view.size);
+      upb_put_tag(e, f->number, UPB_WIRE_TYPE_DELIMITED);
+      return;
     }
     case UPB_DESCRIPTOR_TYPE_GROUP: {
       size_t size;
       void *submsg = *(void **)field_mem;
       const upb_msglayout *subm = m->submsgs[f->submsg_index];
       if (submsg == NULL) {
-        return true;
+        return;
       }
-      return upb_put_tag(e, f->number, UPB_WIRE_TYPE_END_GROUP) &&
-          upb_encode_message(e, submsg, subm, &size) &&
-          upb_put_tag(e, f->number, UPB_WIRE_TYPE_START_GROUP);
+      upb_put_tag(e, f->number, UPB_WIRE_TYPE_END_GROUP);
+      upb_encode_message(e, submsg, subm, &size);
+      upb_put_tag(e, f->number, UPB_WIRE_TYPE_START_GROUP);
+      return;
     }
     case UPB_DESCRIPTOR_TYPE_MESSAGE: {
       size_t size;
       void *submsg = *(void **)field_mem;
       const upb_msglayout *subm = m->submsgs[f->submsg_index];
       if (submsg == NULL) {
-        return true;
+        return;
       }
-      return upb_encode_message(e, submsg, subm, &size) &&
-          upb_put_varint(e, size) &&
-          upb_put_tag(e, f->number, UPB_WIRE_TYPE_DELIMITED);
+      upb_encode_message(e, submsg, subm, &size);
+      upb_put_varint(e, size);
+      upb_put_tag(e, f->number, UPB_WIRE_TYPE_DELIMITED);
+      return;
     }
   }
 #undef CASE
   UPB_UNREACHABLE();
 }
 
-static bool upb_encode_array(upb_encstate *e, const char *field_mem,
+static void upb_encode_array(upb_encstate *e, const char *field_mem,
                              const upb_msglayout *m,
                              const upb_msglayout_field *f) {
   const upb_array *arr = *(const upb_array**)field_mem;
   bool packed = f->label == _UPB_LABEL_PACKED;
 
   if (arr == NULL || arr->len == 0) {
-    return true;
+    return;
   }
 
 #define VARINT_CASE(ctype, encode)                                       \
@@ -229,10 +235,10 @@ static bool upb_encode_array(upb_encstate *e, const char *field_mem,
     uint32_t tag = packed ? 0 : (f->number << 3) | UPB_WIRE_TYPE_VARINT; \
     do {                                                                 \
       ptr--;                                                             \
-      CHK(upb_put_varint(e, encode));                                    \
-      if (tag) CHK(upb_put_varint(e, tag));                              \
+      upb_put_varint(e, encode);                                         \
+      if (tag) upb_put_varint(e, tag);                                   \
     } while (ptr != start);                                              \
-    if (!tag) CHK(upb_put_varint(e, e->limit - e->ptr - pre_len));       \
+    if (!tag) upb_put_varint(e, e->limit - e->ptr - pre_len);            \
   }                                                                      \
   break;                                                                 \
   do {                                                                   \
@@ -243,18 +249,18 @@ static bool upb_encode_array(upb_encstate *e, const char *field_mem,
 
   switch (f->descriptortype) {
     case UPB_DESCRIPTOR_TYPE_DOUBLE:
-      CHK(upb_put_fixedarray(e, arr, sizeof(double), TAG(UPB_WIRE_TYPE_64BIT)));
+      upb_put_fixedarray(e, arr, sizeof(double), TAG(UPB_WIRE_TYPE_64BIT));
       break;
     case UPB_DESCRIPTOR_TYPE_FLOAT:
-      CHK(upb_put_fixedarray(e, arr, sizeof(float), TAG(UPB_WIRE_TYPE_32BIT)));
+      upb_put_fixedarray(e, arr, sizeof(float), TAG(UPB_WIRE_TYPE_32BIT));
       break;
     case UPB_DESCRIPTOR_TYPE_SFIXED64:
     case UPB_DESCRIPTOR_TYPE_FIXED64:
-      CHK(upb_put_fixedarray(e, arr, sizeof(uint64_t), TAG(UPB_WIRE_TYPE_64BIT)));
+      upb_put_fixedarray(e, arr, sizeof(uint64_t), TAG(UPB_WIRE_TYPE_64BIT));
       break;
     case UPB_DESCRIPTOR_TYPE_FIXED32:
     case UPB_DESCRIPTOR_TYPE_SFIXED32:
-      CHK(upb_put_fixedarray(e, arr, sizeof(uint32_t), TAG(UPB_WIRE_TYPE_32BIT)));
+      upb_put_fixedarray(e, arr, sizeof(uint32_t), TAG(UPB_WIRE_TYPE_32BIT));
       break;
     case UPB_DESCRIPTOR_TYPE_INT64:
     case UPB_DESCRIPTOR_TYPE_UINT64:
@@ -276,11 +282,11 @@ static bool upb_encode_array(upb_encstate *e, const char *field_mem,
       const upb_strview *ptr = start + arr->len;
       do {
         ptr--;
-        CHK(upb_put_bytes(e, ptr->data, ptr->size) &&
-            upb_put_varint(e, ptr->size) &&
-            upb_put_tag(e, f->number, UPB_WIRE_TYPE_DELIMITED));
+        upb_put_bytes(e, ptr->data, ptr->size);
+        upb_put_varint(e, ptr->size);
+        upb_put_tag(e, f->number, UPB_WIRE_TYPE_DELIMITED);
       } while (ptr != start);
-      return true;
+      return;
     }
     case UPB_DESCRIPTOR_TYPE_GROUP: {
       const void *const*start = _upb_array_constptr(arr);
@@ -289,11 +295,11 @@ static bool upb_encode_array(upb_encstate *e, const char *field_mem,
       do {
         size_t size;
         ptr--;
-        CHK(upb_put_tag(e, f->number, UPB_WIRE_TYPE_END_GROUP) &&
-            upb_encode_message(e, *ptr, subm, &size) &&
-            upb_put_tag(e, f->number, UPB_WIRE_TYPE_START_GROUP));
+        upb_put_tag(e, f->number, UPB_WIRE_TYPE_END_GROUP);
+        upb_encode_message(e, *ptr, subm, &size);
+        upb_put_tag(e, f->number, UPB_WIRE_TYPE_START_GROUP);
       } while (ptr != start);
-      return true;
+      return;
     }
     case UPB_DESCRIPTOR_TYPE_MESSAGE: {
       const void *const*start = _upb_array_constptr(arr);
@@ -302,22 +308,21 @@ static bool upb_encode_array(upb_encstate *e, const char *field_mem,
       do {
         size_t size;
         ptr--;
-        CHK(upb_encode_message(e, *ptr, subm, &size) &&
-            upb_put_varint(e, size) &&
-            upb_put_tag(e, f->number, UPB_WIRE_TYPE_DELIMITED));
+        upb_encode_message(e, *ptr, subm, &size);
+        upb_put_varint(e, size);
+        upb_put_tag(e, f->number, UPB_WIRE_TYPE_DELIMITED);
       } while (ptr != start);
-      return true;
+      return;
     }
   }
 #undef VARINT_CASE
 
   if (packed) {
-    CHK(upb_put_tag(e, f->number, UPB_WIRE_TYPE_DELIMITED));
+    upb_put_tag(e, f->number, UPB_WIRE_TYPE_DELIMITED);
   }
-  return true;
 }
 
-static bool upb_encode_map(upb_encstate *e, const char *field_mem,
+static void upb_encode_map(upb_encstate *e, const char *field_mem,
                            const upb_msglayout *m,
                            const upb_msglayout_field *f) {
   const upb_map *map = *(const upb_map**)field_mem;
@@ -326,7 +331,7 @@ static bool upb_encode_map(upb_encstate *e, const char *field_mem,
   const upb_msglayout_field *val_field = &entry->fields[1];
   upb_strtable_iter i;
   if (map == NULL) {
-    return true;
+    return;
   }
 
   upb_strtable_begin(&i, &map->table);
@@ -338,18 +343,15 @@ static bool upb_encode_map(upb_encstate *e, const char *field_mem,
     upb_map_entry ent;
     _upb_map_fromkey(key, &ent.k, map->key_size);
     _upb_map_fromvalue(val, &ent.v, map->val_size);
-    CHK(upb_encode_scalarfield(e, &ent.v, entry, val_field, false));
-    CHK(upb_encode_scalarfield(e, &ent.k, entry, key_field, false));
+    upb_encode_scalarfield(e, &ent.v, entry, val_field, false);
+    upb_encode_scalarfield(e, &ent.k, entry, key_field, false);
     size = (e->limit - e->ptr) - pre_len;
-    CHK(upb_put_varint(e, size));
-    CHK(upb_put_tag(e, f->number, UPB_WIRE_TYPE_DELIMITED));
+    upb_put_varint(e, size);
+    upb_put_tag(e, f->number, UPB_WIRE_TYPE_DELIMITED);
   }
-
-  return true;
 }
 
-
-bool upb_encode_message(upb_encstate *e, const char *msg,
+static void upb_encode_message(upb_encstate *e, const char *msg,
                         const upb_msglayout *m, size_t *size) {
   int i;
   size_t pre_len = e->limit - e->ptr;
@@ -366,9 +368,9 @@ bool upb_encode_message(upb_encstate *e, const char *msg,
     const upb_msglayout_field *f = &m->fields[i];
 
     if (_upb_isrepeated(f)) {
-      CHK(upb_encode_array(e, msg + f->offset, m, f));
+      upb_encode_array(e, msg + f->offset, m, f);
     } else if (f->label == _UPB_LABEL_MAP) {
-      CHK(upb_encode_map(e, msg + f->offset, m, f));
+      upb_encode_map(e, msg + f->offset, m, f);
     } else {
       bool skip_empty = false;
       if (f->presence == 0) {
@@ -385,12 +387,11 @@ bool upb_encode_message(upb_encstate *e, const char *msg,
           continue;
         }
       }
-      CHK(upb_encode_scalarfield(e, msg + f->offset, m, f, skip_empty));
+      upb_encode_scalarfield(e, msg + f->offset, m, f, skip_empty);
     }
   }
 
   *size = (e->limit - e->ptr) - pre_len;
-  return true;
 }
 
 char *upb_encode(const void *msg, const upb_msglayout *m, upb_arena *arena,
@@ -401,10 +402,12 @@ char *upb_encode(const void *msg, const upb_msglayout *m, upb_arena *arena,
   e.limit = NULL;
   e.ptr = NULL;
 
-  if (!upb_encode_message(&e, msg, m, size)) {
+  if (setjmp(e.err)) {
     *size = 0;
     return NULL;
   }
+
+  upb_encode_message(&e, msg, m, size);
 
   *size = e.limit - e.ptr;
 
@@ -416,5 +419,3 @@ char *upb_encode(const void *msg, const upb_msglayout *m, upb_arena *arena,
     return e.ptr;
   }
 }
-
-#undef CHK

--- a/upb/encode.c
+++ b/upb/encode.c
@@ -12,10 +12,9 @@
 
 #define UPB_PB_VARINT_MAX_LEN 10
 
-static size_t upb_encode_varint(uint64_t val, char *buf) {
-  size_t i;
-  if (val < 128) { buf[0] = val; return 1; }
-  i = 0;
+UPB_NOINLINE
+static size_t encode_varint64(uint64_t val, char *buf) {
+  size_t i = 0;
   while (val) {
     uint8_t byte = val & 0x7fU;
     val >>= 7;
@@ -25,8 +24,8 @@ static size_t upb_encode_varint(uint64_t val, char *buf) {
   return i;
 }
 
-static uint32_t upb_zzencode_32(int32_t n) { return ((uint32_t)n << 1) ^ (n >> 31); }
-static uint64_t upb_zzencode_64(int64_t n) { return ((uint64_t)n << 1) ^ (n >> 63); }
+static uint32_t encode_zz32(int32_t n) { return ((uint32_t)n << 1) ^ (n >> 31); }
+static uint64_t encode_zz64(int64_t n) { return ((uint64_t)n << 1) ^ (n >> 63); }
 
 typedef struct {
   jmp_buf err;
@@ -44,7 +43,8 @@ static size_t upb_roundup_pow2(size_t bytes) {
 
 UPB_NORETURN static void encode_err(upb_encstate *e) { longjmp(e->err, 1); }
 
-static void upb_encode_growbuffer(upb_encstate *e, size_t bytes) {
+UPB_NOINLINE
+static void encode_growbuffer(upb_encstate *e, size_t bytes) {
   size_t old_size = e->limit - e->buf;
   size_t new_size = upb_roundup_pow2(bytes + (e->limit - e->ptr));
   char *new_buf = upb_realloc(e->alloc, e->buf, old_size, new_size);
@@ -63,92 +63,104 @@ static void upb_encode_growbuffer(upb_encstate *e, size_t bytes) {
 
 /* Call to ensure that at least "bytes" bytes are available for writing at
  * e->ptr.  Returns false if the bytes could not be allocated. */
-static void upb_encode_reserve(upb_encstate *e, size_t bytes) {
+UPB_FORCEINLINE
+static void encode_reserve(upb_encstate *e, size_t bytes) {
   if ((size_t)(e->ptr - e->buf) < bytes) {
-    upb_encode_growbuffer(e, bytes);
+    encode_growbuffer(e, bytes);
   }
 
   e->ptr -= bytes;
 }
 
 /* Writes the given bytes to the buffer, handling reserve/advance. */
-static void upb_put_bytes(upb_encstate *e, const void *data, size_t len) {
+static void encode_bytes(upb_encstate *e, const void *data, size_t len) {
   if (len == 0) return;  /* memcpy() with zero size is UB */
-  upb_encode_reserve(e, len);
+  encode_reserve(e, len);
   memcpy(e->ptr, data, len);
 }
 
-static void upb_put_fixed64(upb_encstate *e, uint64_t val) {
+static void encode_fixed64(upb_encstate *e, uint64_t val) {
   val = _upb_be_swap64(val);
-  upb_put_bytes(e, &val, sizeof(uint64_t));
+  encode_bytes(e, &val, sizeof(uint64_t));
 }
 
-static void upb_put_fixed32(upb_encstate *e, uint32_t val) {
+static void encode_fixed32(upb_encstate *e, uint32_t val) {
   val = _upb_be_swap32(val);
-  upb_put_bytes(e, &val, sizeof(uint32_t));
+  encode_bytes(e, &val, sizeof(uint32_t));
 }
 
-static void upb_put_varint(upb_encstate *e, uint64_t val) {
+UPB_NOINLINE
+static void encode_longvarint(upb_encstate *e, uint64_t val) {
   size_t len;
   char *start;
-  upb_encode_reserve(e, UPB_PB_VARINT_MAX_LEN);
-  len = upb_encode_varint(val, e->ptr);
+
+  encode_reserve(e, UPB_PB_VARINT_MAX_LEN);
+  len = encode_varint64(val, e->ptr);
   start = e->ptr + UPB_PB_VARINT_MAX_LEN - len;
   memmove(start, e->ptr, len);
   e->ptr = start;
 }
 
-static void upb_put_double(upb_encstate *e, double d) {
+UPB_FORCEINLINE
+static void encode_varint(upb_encstate *e, uint64_t val) {
+  if (val < 128 && e->ptr != e->buf) {
+    --e->ptr;
+    *e->ptr = val;
+  } else {
+    encode_longvarint(e, val);
+  }
+}
+
+static void encode_double(upb_encstate *e, double d) {
   uint64_t u64;
   UPB_ASSERT(sizeof(double) == sizeof(uint64_t));
   memcpy(&u64, &d, sizeof(uint64_t));
-  upb_put_fixed64(e, u64);
+  encode_fixed64(e, u64);
 }
 
-static void upb_put_float(upb_encstate *e, float d) {
+static void encode_float(upb_encstate *e, float d) {
   uint32_t u32;
   UPB_ASSERT(sizeof(float) == sizeof(uint32_t));
   memcpy(&u32, &d, sizeof(uint32_t));
-  upb_put_fixed32(e, u32);
+  encode_fixed32(e, u32);
 }
 
-static void upb_put_tag(upb_encstate *e, int field_number, int wire_type) {
-  upb_put_varint(e, (field_number << 3) | wire_type);
+static void encode_tag(upb_encstate *e, int field_number, int wire_type) {
+  encode_varint(e, (field_number << 3) | wire_type);
 }
 
-static void upb_put_fixedarray(upb_encstate *e, const upb_array *arr,
+static void encode_fixedarray(upb_encstate *e, const upb_array *arr,
                                size_t elem_size, uint32_t tag) {
   size_t bytes = arr->len * elem_size;
   const char* data = _upb_array_constptr(arr);
   const char* ptr = data + bytes - elem_size;
   if (tag) {
     while (true) {
-      upb_put_bytes(e, ptr, elem_size);
-      upb_put_varint(e, tag);
+      encode_bytes(e, ptr, elem_size);
+      encode_varint(e, tag);
       if (ptr == data) break;
       ptr -= elem_size;
     }
   } else {
-    upb_put_bytes(e, data, bytes);
-    upb_put_varint(e, bytes);
+    encode_bytes(e, data, bytes);
+    encode_varint(e, bytes);
   }
 }
 
-static void upb_encode_message(upb_encstate *e, const char *msg,
-                               const upb_msglayout *m, size_t *size);
+static void encode_message(upb_encstate *e, const char *msg,
+                           const upb_msglayout *m, size_t *size);
 
-static void upb_encode_scalarfield(upb_encstate *e, const void *_field_mem,
-                                   const upb_msglayout *m,
-                                   const upb_msglayout_field *f,
-                                   bool skip_zero_value) {
+static void encode_scalar(upb_encstate *e, const void *_field_mem,
+                          const upb_msglayout *m, const upb_msglayout_field *f,
+                          bool skip_zero_value) {
   const char *field_mem = _field_mem;
 #define CASE(ctype, type, wire_type, encodeval) do { \
   ctype val = *(ctype*)field_mem; \
   if (skip_zero_value && val == 0) { \
     return; \
   } \
-  upb_put_ ## type(e, encodeval); \
-  upb_put_tag(e, f->number, wire_type); \
+  encode_ ## type(e, encodeval); \
+  encode_tag(e, f->number, wire_type); \
   return; \
 } while(0)
 
@@ -174,18 +186,18 @@ static void upb_encode_scalarfield(upb_encstate *e, const void *_field_mem,
     case UPB_DESCRIPTOR_TYPE_BOOL:
       CASE(bool, varint, UPB_WIRE_TYPE_VARINT, val);
     case UPB_DESCRIPTOR_TYPE_SINT32:
-      CASE(int32_t, varint, UPB_WIRE_TYPE_VARINT, upb_zzencode_32(val));
+      CASE(int32_t, varint, UPB_WIRE_TYPE_VARINT, encode_zz32(val));
     case UPB_DESCRIPTOR_TYPE_SINT64:
-      CASE(int64_t, varint, UPB_WIRE_TYPE_VARINT, upb_zzencode_64(val));
+      CASE(int64_t, varint, UPB_WIRE_TYPE_VARINT, encode_zz64(val));
     case UPB_DESCRIPTOR_TYPE_STRING:
     case UPB_DESCRIPTOR_TYPE_BYTES: {
       upb_strview view = *(upb_strview*)field_mem;
       if (skip_zero_value && view.size == 0) {
         return;
       }
-      upb_put_bytes(e, view.data, view.size);
-      upb_put_varint(e, view.size);
-      upb_put_tag(e, f->number, UPB_WIRE_TYPE_DELIMITED);
+      encode_bytes(e, view.data, view.size);
+      encode_varint(e, view.size);
+      encode_tag(e, f->number, UPB_WIRE_TYPE_DELIMITED);
       return;
     }
     case UPB_DESCRIPTOR_TYPE_GROUP: {
@@ -195,9 +207,9 @@ static void upb_encode_scalarfield(upb_encstate *e, const void *_field_mem,
       if (submsg == NULL) {
         return;
       }
-      upb_put_tag(e, f->number, UPB_WIRE_TYPE_END_GROUP);
-      upb_encode_message(e, submsg, subm, &size);
-      upb_put_tag(e, f->number, UPB_WIRE_TYPE_START_GROUP);
+      encode_tag(e, f->number, UPB_WIRE_TYPE_END_GROUP);
+      encode_message(e, submsg, subm, &size);
+      encode_tag(e, f->number, UPB_WIRE_TYPE_START_GROUP);
       return;
     }
     case UPB_DESCRIPTOR_TYPE_MESSAGE: {
@@ -207,9 +219,9 @@ static void upb_encode_scalarfield(upb_encstate *e, const void *_field_mem,
       if (submsg == NULL) {
         return;
       }
-      upb_encode_message(e, submsg, subm, &size);
-      upb_put_varint(e, size);
-      upb_put_tag(e, f->number, UPB_WIRE_TYPE_DELIMITED);
+      encode_message(e, submsg, subm, &size);
+      encode_varint(e, size);
+      encode_tag(e, f->number, UPB_WIRE_TYPE_DELIMITED);
       return;
     }
   }
@@ -217,9 +229,8 @@ static void upb_encode_scalarfield(upb_encstate *e, const void *_field_mem,
   UPB_UNREACHABLE();
 }
 
-static void upb_encode_array(upb_encstate *e, const char *field_mem,
-                             const upb_msglayout *m,
-                             const upb_msglayout_field *f) {
+static void encode_array(upb_encstate *e, const char *field_mem,
+                         const upb_msglayout *m, const upb_msglayout_field *f) {
   const upb_array *arr = *(const upb_array**)field_mem;
   bool packed = f->label == _UPB_LABEL_PACKED;
 
@@ -235,10 +246,10 @@ static void upb_encode_array(upb_encstate *e, const char *field_mem,
     uint32_t tag = packed ? 0 : (f->number << 3) | UPB_WIRE_TYPE_VARINT; \
     do {                                                                 \
       ptr--;                                                             \
-      upb_put_varint(e, encode);                                         \
-      if (tag) upb_put_varint(e, tag);                                   \
+      encode_varint(e, encode);                                         \
+      if (tag) encode_varint(e, tag);                                   \
     } while (ptr != start);                                              \
-    if (!tag) upb_put_varint(e, e->limit - e->ptr - pre_len);            \
+    if (!tag) encode_varint(e, e->limit - e->ptr - pre_len);            \
   }                                                                      \
   break;                                                                 \
   do {                                                                   \
@@ -249,18 +260,18 @@ static void upb_encode_array(upb_encstate *e, const char *field_mem,
 
   switch (f->descriptortype) {
     case UPB_DESCRIPTOR_TYPE_DOUBLE:
-      upb_put_fixedarray(e, arr, sizeof(double), TAG(UPB_WIRE_TYPE_64BIT));
+      encode_fixedarray(e, arr, sizeof(double), TAG(UPB_WIRE_TYPE_64BIT));
       break;
     case UPB_DESCRIPTOR_TYPE_FLOAT:
-      upb_put_fixedarray(e, arr, sizeof(float), TAG(UPB_WIRE_TYPE_32BIT));
+      encode_fixedarray(e, arr, sizeof(float), TAG(UPB_WIRE_TYPE_32BIT));
       break;
     case UPB_DESCRIPTOR_TYPE_SFIXED64:
     case UPB_DESCRIPTOR_TYPE_FIXED64:
-      upb_put_fixedarray(e, arr, sizeof(uint64_t), TAG(UPB_WIRE_TYPE_64BIT));
+      encode_fixedarray(e, arr, sizeof(uint64_t), TAG(UPB_WIRE_TYPE_64BIT));
       break;
     case UPB_DESCRIPTOR_TYPE_FIXED32:
     case UPB_DESCRIPTOR_TYPE_SFIXED32:
-      upb_put_fixedarray(e, arr, sizeof(uint32_t), TAG(UPB_WIRE_TYPE_32BIT));
+      encode_fixedarray(e, arr, sizeof(uint32_t), TAG(UPB_WIRE_TYPE_32BIT));
       break;
     case UPB_DESCRIPTOR_TYPE_INT64:
     case UPB_DESCRIPTOR_TYPE_UINT64:
@@ -273,18 +284,18 @@ static void upb_encode_array(upb_encstate *e, const char *field_mem,
     case UPB_DESCRIPTOR_TYPE_BOOL:
       VARINT_CASE(bool, *ptr);
     case UPB_DESCRIPTOR_TYPE_SINT32:
-      VARINT_CASE(int32_t, upb_zzencode_32(*ptr));
+      VARINT_CASE(int32_t, encode_zz32(*ptr));
     case UPB_DESCRIPTOR_TYPE_SINT64:
-      VARINT_CASE(int64_t, upb_zzencode_64(*ptr));
+      VARINT_CASE(int64_t, encode_zz64(*ptr));
     case UPB_DESCRIPTOR_TYPE_STRING:
     case UPB_DESCRIPTOR_TYPE_BYTES: {
       const upb_strview *start = _upb_array_constptr(arr);
       const upb_strview *ptr = start + arr->len;
       do {
         ptr--;
-        upb_put_bytes(e, ptr->data, ptr->size);
-        upb_put_varint(e, ptr->size);
-        upb_put_tag(e, f->number, UPB_WIRE_TYPE_DELIMITED);
+        encode_bytes(e, ptr->data, ptr->size);
+        encode_varint(e, ptr->size);
+        encode_tag(e, f->number, UPB_WIRE_TYPE_DELIMITED);
       } while (ptr != start);
       return;
     }
@@ -295,9 +306,9 @@ static void upb_encode_array(upb_encstate *e, const char *field_mem,
       do {
         size_t size;
         ptr--;
-        upb_put_tag(e, f->number, UPB_WIRE_TYPE_END_GROUP);
-        upb_encode_message(e, *ptr, subm, &size);
-        upb_put_tag(e, f->number, UPB_WIRE_TYPE_START_GROUP);
+        encode_tag(e, f->number, UPB_WIRE_TYPE_END_GROUP);
+        encode_message(e, *ptr, subm, &size);
+        encode_tag(e, f->number, UPB_WIRE_TYPE_START_GROUP);
       } while (ptr != start);
       return;
     }
@@ -308,9 +319,9 @@ static void upb_encode_array(upb_encstate *e, const char *field_mem,
       do {
         size_t size;
         ptr--;
-        upb_encode_message(e, *ptr, subm, &size);
-        upb_put_varint(e, size);
-        upb_put_tag(e, f->number, UPB_WIRE_TYPE_DELIMITED);
+        encode_message(e, *ptr, subm, &size);
+        encode_varint(e, size);
+        encode_tag(e, f->number, UPB_WIRE_TYPE_DELIMITED);
       } while (ptr != start);
       return;
     }
@@ -318,13 +329,12 @@ static void upb_encode_array(upb_encstate *e, const char *field_mem,
 #undef VARINT_CASE
 
   if (packed) {
-    upb_put_tag(e, f->number, UPB_WIRE_TYPE_DELIMITED);
+    encode_tag(e, f->number, UPB_WIRE_TYPE_DELIMITED);
   }
 }
 
-static void upb_encode_map(upb_encstate *e, const char *field_mem,
-                           const upb_msglayout *m,
-                           const upb_msglayout_field *f) {
+static void encode_map(upb_encstate *e, const char *field_mem,
+                       const upb_msglayout *m, const upb_msglayout_field *f) {
   const upb_map *map = *(const upb_map**)field_mem;
   const upb_msglayout *entry = m->submsgs[f->submsg_index];
   const upb_msglayout_field *key_field = &entry->fields[0];
@@ -343,51 +353,53 @@ static void upb_encode_map(upb_encstate *e, const char *field_mem,
     upb_map_entry ent;
     _upb_map_fromkey(key, &ent.k, map->key_size);
     _upb_map_fromvalue(val, &ent.v, map->val_size);
-    upb_encode_scalarfield(e, &ent.v, entry, val_field, false);
-    upb_encode_scalarfield(e, &ent.k, entry, key_field, false);
+    encode_scalar(e, &ent.v, entry, val_field, false);
+    encode_scalar(e, &ent.k, entry, key_field, false);
     size = (e->limit - e->ptr) - pre_len;
-    upb_put_varint(e, size);
-    upb_put_tag(e, f->number, UPB_WIRE_TYPE_DELIMITED);
+    encode_varint(e, size);
+    encode_tag(e, f->number, UPB_WIRE_TYPE_DELIMITED);
   }
 }
 
-static void upb_encode_message(upb_encstate *e, const char *msg,
-                        const upb_msglayout *m, size_t *size) {
-  int i;
+static void encode_scalarfield(upb_encstate *e, const char *msg,
+                               const upb_msglayout *m,
+                               const upb_msglayout_field *f) {
+  bool skip_empty = false;
+  if (f->presence == 0) {
+    /* Proto3 presence. */
+    skip_empty = true;
+  } else if (f->presence > 0) {
+    /* Proto2 presence: hasbit. */
+    if (!_upb_hasbit_field(msg, f)) return;
+  } else {
+    /* Field is in a oneof. */
+    if (_upb_getoneofcase_field(msg, f) != f->number) return;
+  }
+  encode_scalar(e, msg + f->offset, m, f, skip_empty);
+}
+
+static void encode_message(upb_encstate *e, const char *msg,
+                           const upb_msglayout *m, size_t *size) {
   size_t pre_len = e->limit - e->ptr;
   const char *unknown;
   size_t unknown_size;
+  const upb_msglayout_field *f = &m->fields[m->field_count];
+  const upb_msglayout_field *first = &m->fields[0];
 
   unknown = upb_msg_getunknown(msg, &unknown_size);
 
   if (unknown) {
-    upb_put_bytes(e, unknown, unknown_size);
+    encode_bytes(e, unknown, unknown_size);
   }
 
-  for (i = m->field_count - 1; i >= 0; i--) {
-    const upb_msglayout_field *f = &m->fields[i];
-
+  while (f != first) {
+    f--;
     if (_upb_isrepeated(f)) {
-      upb_encode_array(e, msg + f->offset, m, f);
+      encode_array(e, msg + f->offset, m, f);
     } else if (f->label == _UPB_LABEL_MAP) {
-      upb_encode_map(e, msg + f->offset, m, f);
+      encode_map(e, msg + f->offset, m, f);
     } else {
-      bool skip_empty = false;
-      if (f->presence == 0) {
-        /* Proto3 presence. */
-        skip_empty = true;
-      } else if (f->presence > 0) {
-        /* Proto2 presence: hasbit. */
-        if (!_upb_hasbit_field(msg, f)) {
-          continue;
-        }
-      } else {
-        /* Field is in a oneof. */
-        if (_upb_getoneofcase_field(msg, f) != f->number) {
-          continue;
-        }
-      }
-      upb_encode_scalarfield(e, msg + f->offset, m, f, skip_empty);
+      encode_scalarfield(e, msg, m, f);
     }
   }
 
@@ -407,7 +419,7 @@ char *upb_encode(const void *msg, const upb_msglayout *m, upb_arena *arena,
     return NULL;
   }
 
-  upb_encode_message(&e, msg, m, size);
+  encode_message(&e, msg, m, size);
 
   *size = e.limit - e.ptr;
 

--- a/upb/encode.c
+++ b/upb/encode.c
@@ -246,10 +246,10 @@ static void encode_array(upb_encstate *e, const char *field_mem,
     uint32_t tag = packed ? 0 : (f->number << 3) | UPB_WIRE_TYPE_VARINT; \
     do {                                                                 \
       ptr--;                                                             \
-      encode_varint(e, encode);                                         \
-      if (tag) encode_varint(e, tag);                                   \
+      encode_varint(e, encode);                                          \
+      if (tag) encode_varint(e, tag);                                    \
     } while (ptr != start);                                              \
-    if (!tag) encode_varint(e, e->limit - e->ptr - pre_len);            \
+    if (!tag) encode_varint(e, e->limit - e->ptr - pre_len);             \
   }                                                                      \
   break;                                                                 \
   do {                                                                   \


### PR DESCRIPTION
This PR optimizes the varint-encoding path, in particular the fast path for one-byte varints.

There is some modest code size growth, but a roughly 2x speed improvement:

```
name                       old time/op  new time/op  delta        
ArenaOneAlloc              21.1ns ± 0%  20.5ns ± 1%   -3.06%  (p=0.000 n=12+12)
ArenaInitialBlockOneAlloc  5.25ns ± 0%  5.25ns ± 0%     ~     (p=0.833 n=11+12)
ParseDescriptorNoHeap      16.4µs ± 0%  16.9µs ± 0%   +2.48%  (p=0.000 n=12+12)
ParseDescriptor            17.0µs ± 1%  17.3µs ± 1%   +1.69%  (p=0.000 n=12+12)
SerializeDescriptor        21.6µs ± 0%  10.7µs ± 0%  -50.66%  (p=0.000 n=12+12)


    FILE SIZE        VM SIZE   
 --------------  --------------
   +16%    +815    +16%    +749    upb/encode.c
      [NEW] +3.00Ki   [NEW] +2.96Ki    encode_message
      [NEW] +1.12Ki   [NEW] +1.08Ki    encode_scalar
      [NEW]    +322   [NEW]    +280    encode_growbuffer
      [NEW]    +293   [NEW]    +251    encode_fixedarray
      [NEW]    +214   [NEW]    +170    encode_bytes.part.0
      [NEW]    +205   [NEW]    +163    encode_longvarint
      [NEW]    +131   [NEW]     +91    encode_varint64
      [NEW]    +120   [NEW]     +85    encode_tag
       +38%     +74    +46%     +74    upb_encode
      [NEW]     +32   [NEW]      +1    ch.5007
      [DEL]     -32   [DEL]      -1    ch.4956
      [DEL]    -195   [DEL]    -157    upb_put_bytes
      [DEL]    -274   [DEL]    -235    upb_put_varint
      [DEL]    -275   [DEL]    -232    upb_put_fixedarray
      [DEL]    -289   [DEL]    -243    upb_encode_growbuffer
      [DEL]    -985   [DEL]    -938    upb_encode_scalarfield
      [DEL] -2.68Ki   [DEL] -2.64Ki    upb_encode_message
  +1.7%     +35   +1.7%     +35    [section .text]
 -19.8%    -786   [ = ]       0    [Unmapped]
  +0.0%     +64   +0.6%    +784    TOTAL
```

This PR also includes a benchmark for encoding, as well as updates to the benchmarking script that produces the above output.

I also renamed the functions in the encoder to follow a more regular `encode_*()` scheme, and renamed some symbols in the old encoder to avoid collisions. The old encoder is on its last legs, and will be deleted once Ruby is migrated to `upb_msg`.