### PR TITLE
Benchmarks vs. proto2

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -357,6 +357,7 @@ cc_binary(
         ":descriptor_upb_proto",
         ":descriptor_upbreflection",
         "@com_github_google_benchmark//:benchmark_main",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 

--- a/tests/benchmark.cc
+++ b/tests/benchmark.cc
@@ -3,8 +3,10 @@
 #include <benchmark/benchmark.h>
 #include "google/protobuf/descriptor.upb.h"
 #include "google/protobuf/descriptor.upbdefs.h"
+#include "google/protobuf/descriptor.pb.h"
 
 upb_strview descriptor = google_protobuf_descriptor_proto_upbdefinit.descriptor;
+namespace protobuf = ::google::protobuf;
 
 /* A buffer big enough to parse descriptor.proto without going to heap. */
 char buf[65535];
@@ -27,7 +29,7 @@ static void BM_ArenaInitialBlockOneAlloc(benchmark::State& state) {
 }
 BENCHMARK(BM_ArenaInitialBlockOneAlloc);
 
-static void BM_ParseDescriptorNoHeap(benchmark::State& state) {
+static void BM_ParseDescriptor_Upb_LargeInitialBlock(benchmark::State& state) {
   size_t bytes = 0;
   for (auto _ : state) {
     upb_arena* arena = upb_arena_init(buf, sizeof(buf), NULL);
@@ -43,9 +45,9 @@ static void BM_ParseDescriptorNoHeap(benchmark::State& state) {
   }
   state.SetBytesProcessed(state.iterations() * descriptor.size);
 }
-BENCHMARK(BM_ParseDescriptorNoHeap);
+BENCHMARK(BM_ParseDescriptor_Upb_LargeInitialBlock);
 
-static void BM_ParseDescriptor(benchmark::State& state) {
+static void BM_ParseDescriptor_Upb(benchmark::State& state) {
   size_t bytes = 0;
   for (auto _ : state) {
     upb_arena* arena = upb_arena_new();
@@ -61,9 +63,55 @@ static void BM_ParseDescriptor(benchmark::State& state) {
   }
   state.SetBytesProcessed(state.iterations() * descriptor.size);
 }
-BENCHMARK(BM_ParseDescriptor);
+BENCHMARK(BM_ParseDescriptor_Upb);
 
-static void BM_SerializeDescriptor(benchmark::State& state) {
+static void BM_ParseDescriptor_Proto2_NoArena(benchmark::State& state) {
+  size_t bytes = 0;
+  for (auto _ : state) {
+    protobuf::FileDescriptorProto proto;
+    bool ok = proto.ParseFromArray(descriptor.data, descriptor.size);
+
+    if (!ok) {
+      printf("Failed to parse.\n");
+      exit(1);
+    }
+    bytes += descriptor.size;
+  }
+  state.SetBytesProcessed(state.iterations() * descriptor.size);
+}
+BENCHMARK(BM_ParseDescriptor_Proto2_NoArena);
+
+static void BM_ParseDescriptor_Proto2_WithArena(benchmark::State& state) {
+  size_t bytes = 0;
+  for (auto _ : state) {
+    protobuf::Arena arena;
+    auto proto = protobuf::Arena::CreateMessage<protobuf::FileDescriptorProto>(
+        &arena);
+    bool ok = proto->ParseFromArray(descriptor.data, descriptor.size);
+
+    if (!ok) {
+      printf("Failed to parse.\n");
+      exit(1);
+    }
+    bytes += descriptor.size;
+  }
+  state.SetBytesProcessed(state.iterations() * descriptor.size);
+}
+BENCHMARK(BM_ParseDescriptor_Proto2_WithArena);
+
+static void BM_SerializeDescriptor_Proto2(benchmark::State& state) {
+  size_t bytes = 0;
+  protobuf::FileDescriptorProto proto;
+  proto.ParseFromArray(descriptor.data, descriptor.size);
+  for (auto _ : state) {
+    proto.SerializeToArray(buf, sizeof(buf));
+    bytes += descriptor.size;
+  }
+  state.SetBytesProcessed(state.iterations() * descriptor.size);
+}
+BENCHMARK(BM_SerializeDescriptor_Proto2);
+
+static void BM_SerializeDescriptor_Upb(benchmark::State& state) {
   int64_t total = 0;
   upb_arena* arena = upb_arena_new();
   google_protobuf_FileDescriptorProto* set =
@@ -83,6 +131,6 @@ static void BM_SerializeDescriptor(benchmark::State& state) {
     }
     total += size;
   }
-  state.SetBytesProcessed(state.iterations() * descriptor.size);
+  state.SetBytesProcessed(total);
 }
-BENCHMARK(BM_SerializeDescriptor);
+BENCHMARK(BM_SerializeDescriptor_Upb);


### PR DESCRIPTION
Results on a Linux desktop:

```
-----------------------------------------------------------------------------------------
Benchmark                                                  Time           CPU Iterations
-----------------------------------------------------------------------------------------
BM_ArenaOneAlloc                                          21 ns         21 ns   32929756
BM_ArenaInitialBlockOneAlloc                               6 ns          6 ns  116214617
BM_ParseDescriptor_Upb_LargeInitialBlock               11521 ns      11521 ns      60726    630.67MB/s
BM_ParseDescriptor_Upb                                 12016 ns      12015 ns      58255   604.737MB/s
BM_ParseDescriptor_Proto2_NoArena                      32583 ns      32578 ns      21571   223.036MB/s
BM_ParseDescriptor_Proto2_Arena                        23086 ns      23085 ns      30533   314.746MB/s
BM_ParseDescriptor_Proto2_Arena_LargeInitialBlock      18618 ns      18618 ns      37634   390.273MB/s
BM_SerializeDescriptor_Proto2                           5171 ns       5171 ns     125985   1.37227GB/s
BM_SerializeDescriptor_Upb                             17776 ns      17776 ns      39409   408.754MB/s
```

On a macOS laptop:

```
-----------------------------------------------------------------------------------------
Benchmark                                                  Time           CPU Iterations
-----------------------------------------------------------------------------------------
BM_ArenaOneAlloc                                         106 ns        106 ns    6403513
BM_ArenaInitialBlockOneAlloc                               5 ns          5 ns  124875125
BM_ParseDescriptor_Upb_LargeInitialBlock               11873 ns      11867 ns      60045   612.268MB/s
BM_ParseDescriptor_Upb                                 12733 ns      12731 ns      56340   570.721MB/s
BM_ParseDescriptor_Proto2_NoArena                      93898 ns      93876 ns       7370   77.4007MB/s
BM_ParseDescriptor_Proto2_Arena                        21595 ns      21592 ns      31813   336.509MB/s
BM_ParseDescriptor_Proto2_Arena_LargeInitialBlock      20480 ns      20478 ns      34287   354.826MB/s
BM_SerializeDescriptor_Proto2                           4666 ns       4665 ns     133741   1.52094GB/s
BM_SerializeDescriptor_Upb                             18881 ns      18879 ns      36326    384.88MB/s
```