### PR TITLE
Added simple offset-based accessors for defs, and deprecated old iterators

### DIFF
--- a/generated_for_cmake/upb/json/parser.c
+++ b/generated_for_cmake/upb/json/parser.c
@@ -3295,7 +3295,7 @@ static void json_parser_reset(upb_json_parser *p) {
 
 static upb_json_parsermethod *parsermethod_new(upb_json_codecache *c,
                                                const upb_msgdef *md) {
-  upb_msg_field_iter i;
+  int i, n;
   upb_alloc *alloc = upb_arena_alloc(c->arena);
 
   upb_json_parsermethod *m = upb_malloc(alloc, sizeof(*m));
@@ -3310,10 +3310,9 @@ static upb_json_parsermethod *parsermethod_new(upb_json_codecache *c,
 
   /* Build name_table */
 
-  for(upb_msg_field_begin(&i, md);
-      !upb_msg_field_done(&i);
-      upb_msg_field_next(&i)) {
-    const upb_fielddef *f = upb_msg_iter_field(&i);
+  n = upb_msgdef_fieldcount(md);
+  for(i = 0; i < n; i++) {
+    const upb_fielddef *f = upb_msgdef_field(md, i);
     upb_value v = upb_value_constptr(f);
     const char *name;
 
@@ -3402,7 +3401,7 @@ const upb_json_parsermethod *upb_json_codecache_get(upb_json_codecache *c,
                                                     const upb_msgdef *md) {
   upb_json_parsermethod *m;
   upb_value v;
-  upb_msg_field_iter i;
+  int i, n;
   upb_alloc *alloc = upb_arena_alloc(c->arena);
 
   if (upb_inttable_lookupptr(&c->methods, md, &v)) {
@@ -3417,10 +3416,9 @@ const upb_json_parsermethod *upb_json_codecache_get(upb_json_codecache *c,
 
   /* Populate parser methods for all submessages, so the name tables will
    * be available during parsing. */
-  for(upb_msg_field_begin(&i, md);
-      !upb_msg_field_done(&i);
-      upb_msg_field_next(&i)) {
-    upb_fielddef *f = upb_msg_iter_field(&i);
+  n = upb_msgdef_fieldcount(md);
+  for(i = 0; i < n; i++) {
+    const upb_fielddef *f = upb_msgdef_field(md, i);
 
     if (upb_fielddef_issubmsg(f)) {
       const upb_msgdef *subdef = upb_fielddef_msgsubdef(f);

--- a/tests/bindings/lua/test_upb.lua
+++ b/tests/bindings/lua/test_upb.lua
@@ -37,6 +37,27 @@ function test_def_readers()
   assert_nil(f:containing_oneof())
   assert_equal(m, f:containing_type())
   assert_equal(0, f:default())
+  local message_field_count = 0
+  for field in m:fields() do
+    message_field_count = message_field_count + 1
+  end
+  assert_equal(message_field_count, #m)
+
+  local message_oneof_count = 0
+  for oneof in m:oneofs() do
+    message_oneof_count = message_oneof_count + 1
+  end
+  assert_equal(message_oneof_count, m:oneof_count())
+
+  -- oneof
+  local o = m:lookup_name("oneof_field")
+  assert_equal("oneof_field", o:name())
+  assert_equal(m, o:containing_type())
+  local oneof_field_count = 0
+  for field in o:fields() do
+    oneof_field_count = oneof_field_count + 1
+  end
+  assert_equal(oneof_field_count, #o)
 
   -- enum
   local e = test_messages_proto3['TestAllTypesProto3.NestedEnum']

--- a/upb/bindings/lua/def.c
+++ b/upb/bindings/lua/def.c
@@ -159,10 +159,11 @@ static int lupb_fielddef_name(lua_State *L) {
 static int lupb_fielddef_number(lua_State *L) {
   const upb_fielddef *f = lupb_fielddef_check(L, 1);
   int32_t num = upb_fielddef_number(f);
-  if (num)
+  if (num) {
     lua_pushinteger(L, num);
-  else
+  } else {
     lua_pushnil(L);
+  }
   return 1;
 }
 
@@ -224,13 +225,54 @@ static int lupb_oneofdef_containingtype(lua_State *L) {
   return 1;
 }
 
-/* lupb_oneofdef_field()
+static int lupb_oneofdef_field(lua_State *L) {
+  const upb_oneofdef *o = lupb_oneofdef_check(L, 1);
+  int32_t idx = lupb_checkint32(L, 2);
+  int count = upb_oneofdef_fieldcount(o);
+
+  if (idx < 0 || idx >= count) {
+    const char *msg = lua_pushfstring(L, "index %d exceeds field count %d",
+                                      idx, count);
+    return luaL_argerror(L, 2, msg);
+  }
+
+  lupb_wrapper_pushwrapper(L, 1, upb_oneofdef_field(o, idx), LUPB_FIELDDEF);
+  return 1;
+}
+
+static int lupb_oneofiter_next(lua_State *L) {
+  const upb_oneofdef *o = lupb_oneofdef_check(L, lua_upvalueindex(1));
+  int *index = lua_touserdata(L, lua_upvalueindex(2));
+  const upb_fielddef *f;
+  if (*index == upb_oneofdef_fieldcount(o)) return 0;
+  f = upb_oneofdef_field(o, (*index)++);
+  lupb_wrapper_pushwrapper(L, lua_upvalueindex(1), f, LUPB_FIELDDEF);
+  return 1;
+}
+
+static int lupb_oneofdef_fields(lua_State *L) {
+  lupb_oneofdef_check(L, 1);
+  int *index = lua_newuserdata(L, sizeof(int));
+  *index = 0;
+
+  /* Closure upvalues are: oneofdef, index. */
+  lua_pushcclosure(L, &lupb_oneofiter_next, 2);
+  return 1;
+}
+
+static int lupb_oneofdef_len(lua_State *L) {
+  const upb_oneofdef *o = lupb_oneofdef_check(L, 1);
+  lua_pushinteger(L, upb_oneofdef_fieldcount(o));
+  return 1;
+}
+
+/* lupb_oneofdef_lookupfield()
  *
  * Handles:
- *   oneof.field(field_number)
- *   oneof.field(field_name)
+ *   oneof.lookup_field(field_number)
+ *   oneof.lookup_field(field_name)
  */
-static int lupb_oneofdef_field(lua_State *L) {
+static int lupb_oneofdef_lookupfield(lua_State *L) {
   const upb_oneofdef *o = lupb_oneofdef_check(L, 1);
   const upb_fielddef *f;
 
@@ -252,33 +294,6 @@ static int lupb_oneofdef_field(lua_State *L) {
   return 1;
 }
 
-static int lupb_oneofiter_next(lua_State *L) {
-  upb_oneof_iter *i = lua_touserdata(L, lua_upvalueindex(1));
-  const upb_fielddef *f;
-  if (upb_oneof_done(i)) return 0;
-  f = upb_oneof_iter_field(i);
-  upb_oneof_next(i);
-  lupb_symtab_pushwrapper(L, lua_upvalueindex(2), f, LUPB_FIELDDEF);
-  return 1;
-}
-
-static int lupb_oneofdef_fields(lua_State *L) {
-  const upb_oneofdef *o = lupb_oneofdef_check(L, 1);
-  upb_oneof_iter *i = lua_newuserdata(L, sizeof(upb_oneof_iter));
-  lupb_wrapper_pushsymtab(L, 1);
-  upb_oneof_begin(i, o);
-
-  /* Closure upvalues are: iter, symtab. */
-  lua_pushcclosure(L, &lupb_oneofiter_next, 2);
-  return 1;
-}
-
-static int lupb_oneofdef_len(lua_State *L) {
-  const upb_oneofdef *o = lupb_oneofdef_check(L, 1);
-  lua_pushinteger(L, upb_oneofdef_numfields(o));
-  return 1;
-}
-
 static int lupb_oneofdef_name(lua_State *L) {
   const upb_oneofdef *o = lupb_oneofdef_check(L, 1);
   lua_pushstring(L, upb_oneofdef_name(o));
@@ -289,6 +304,7 @@ static const struct luaL_Reg lupb_oneofdef_m[] = {
   {"containing_type", lupb_oneofdef_containingtype},
   {"field", lupb_oneofdef_field},
   {"fields", lupb_oneofdef_fields},
+  {"lookup_field", lupb_oneofdef_lookupfield},
   {"name", lupb_oneofdef_name},
   {NULL, NULL}
 };
@@ -309,9 +325,15 @@ const upb_msgdef *lupb_msgdef_check(lua_State *L, int narg) {
   return lupb_wrapper_check(L, narg, LUPB_MSGDEF);
 }
 
-static int lupb_msgdef_len(lua_State *L) {
+static int lupb_msgdef_fieldcount(lua_State *L) {
   const upb_msgdef *m = lupb_msgdef_check(L, 1);
-  lua_pushinteger(L, upb_msgdef_numfields(m));
+  lua_pushinteger(L, upb_msgdef_fieldcount(m));
+  return 1;
+}
+
+static int lupb_msgdef_oneofcount(lua_State *L) {
+  const upb_msgdef *m = lupb_msgdef_check(L, 1);
+  lua_pushinteger(L, upb_msgdef_oneofcount(m));
   return 1;
 }
 
@@ -376,23 +398,21 @@ static int lupb_msgdef_name(lua_State *L) {
 }
 
 static int lupb_msgfielditer_next(lua_State *L) {
-  upb_msg_field_iter *i = lua_touserdata(L, lua_upvalueindex(1));
+  const upb_msgdef *m = lupb_msgdef_check(L, lua_upvalueindex(1));
+  int *index = lua_touserdata(L, lua_upvalueindex(2));
   const upb_fielddef *f;
-
-  if (upb_msg_field_done(i)) return 0;
-  f = upb_msg_iter_field(i);
-  lupb_symtab_pushwrapper(L, lua_upvalueindex(2), f, LUPB_FIELDDEF);
-  upb_msg_field_next(i);
+  if (*index == upb_msgdef_fieldcount(m)) return 0;
+  f = upb_msgdef_field(m, (*index)++);
+  lupb_wrapper_pushwrapper(L, lua_upvalueindex(1), f, LUPB_FIELDDEF);
   return 1;
 }
 
 static int lupb_msgdef_fields(lua_State *L) {
-  const upb_msgdef *m = lupb_msgdef_check(L, 1);
-  upb_msg_field_iter *i = lua_newuserdata(L, sizeof(upb_msg_field_iter));
-  lupb_wrapper_pushsymtab(L, 1);
-  upb_msg_field_begin(i, m);
+  lupb_msgdef_check(L, 1);
+  int *index = lua_newuserdata(L, sizeof(int));
+  *index = 0;
 
-  /* Closure upvalues are: iter, symtab. */
+  /* Closure upvalues are: msgdef, index. */
   lua_pushcclosure(L, &lupb_msgfielditer_next, 2);
   return 1;
 }
@@ -411,22 +431,21 @@ static int lupb_msgdef_fullname(lua_State *L) {
 }
 
 static int lupb_msgoneofiter_next(lua_State *L) {
-  upb_msg_oneof_iter *i = lua_touserdata(L, lua_upvalueindex(1));
+  const upb_msgdef *m = lupb_msgdef_check(L, lua_upvalueindex(1));
+  int *index = lua_touserdata(L, lua_upvalueindex(2));
   const upb_oneofdef *o;
-  if (upb_msg_oneof_done(i)) return 0;
-  o = upb_msg_iter_oneof(i);
-  upb_msg_oneof_next(i);
-  lupb_symtab_pushwrapper(L, lua_upvalueindex(2), o, LUPB_ONEOFDEF);
+  if (*index == upb_msgdef_oneofcount(m)) return 0;
+  o = upb_msgdef_oneof(m, (*index)++);
+  lupb_wrapper_pushwrapper(L, lua_upvalueindex(1), o, LUPB_ONEOFDEF);
   return 1;
 }
 
 static int lupb_msgdef_oneofs(lua_State *L) {
-  const upb_msgdef *m = lupb_msgdef_check(L, 1);
-  upb_msg_oneof_iter *i = lua_newuserdata(L, sizeof(upb_msg_oneof_iter));
-  lupb_wrapper_pushsymtab(L, 1);
-  upb_msg_oneof_begin(i, m);
+  lupb_msgdef_check(L, 1);
+  int *index = lua_newuserdata(L, sizeof(int));
+  *index = 0;
 
-  /* Closure upvalues are: iter, symtab. */
+  /* Closure upvalues are: msgdef, index. */
   lua_pushcclosure(L, &lupb_msgoneofiter_next, 2);
   return 1;
 }
@@ -452,7 +471,7 @@ static int lupb_msgdef_tostring(lua_State *L) {
 
 static const struct luaL_Reg lupb_msgdef_mm[] = {
   {"__call", lupb_msg_pushnew},
-  {"__len", lupb_msgdef_len},
+  {"__len", lupb_msgdef_fieldcount},
   {"__tostring", lupb_msgdef_tostring},
   {NULL, NULL}
 };
@@ -460,10 +479,12 @@ static const struct luaL_Reg lupb_msgdef_mm[] = {
 static const struct luaL_Reg lupb_msgdef_m[] = {
   {"field", lupb_msgdef_field},
   {"fields", lupb_msgdef_fields},
+  {"field_count", lupb_msgdef_fieldcount},
   {"file", lupb_msgdef_file},
   {"full_name", lupb_msgdef_fullname},
   {"lookup_name", lupb_msgdef_lookupname},
   {"name", lupb_msgdef_name},
+  {"oneof_count", lupb_msgdef_oneofcount},
   {"oneofs", lupb_msgdef_oneofs},
   {"syntax", lupb_msgdef_syntax},
   {"_map_entry", lupb_msgdef_mapentry},

--- a/upb/def.c
+++ b/upb/def.c
@@ -89,7 +89,9 @@ struct upb_enumdef {
 struct upb_oneofdef {
   const upb_msgdef *parent;
   const char *full_name;
-  uint32_t index;
+  int field_count;
+  bool synthetic;
+  const upb_fielddef **fields;
   upb_strtable ntof;
   upb_inttable itof;
 };
@@ -290,37 +292,6 @@ static bool assign_msg_indices(upb_msgdef *m, upb_status *s) {
   m->selector_count = selector;
 
   upb_gfree(fields);
-  return true;
-}
-
-static bool check_oneofs(upb_msgdef *m, upb_status *s) {
-  int i;
-  int first_synthetic = -1;
-  upb_oneofdef *mutable_oneofs = (upb_oneofdef*)m->oneofs;
-
-  for (i = 0; i < m->oneof_count; i++) {
-    mutable_oneofs[i].index = i;
-
-    if (upb_oneofdef_issynthetic(&mutable_oneofs[i])) {
-      if (first_synthetic == -1) {
-        first_synthetic = i;
-      }
-    } else {
-      if (first_synthetic != -1) {
-        upb_status_seterrf(
-            s, "Synthetic oneofs must be after all other oneofs: %s",
-            upb_oneofdef_name(&mutable_oneofs[i]));
-        return false;
-      }
-    }
-  }
-
-  if (first_synthetic == -1) {
-    m->real_oneof_count = m->oneof_count;
-  } else {
-    m->real_oneof_count = first_synthetic;
-  }
-
   return true;
 }
 
@@ -726,13 +697,30 @@ int upb_msgdef_numrealoneofs(const upb_msgdef *m) {
   return m->real_oneof_count;
 }
 
+int upb_msgdef_fieldcount(const upb_msgdef *m) {
+  return m->field_count;
+}
+
+int upb_msgdef_oneofcount(const upb_msgdef *m) {
+  return m->oneof_count;
+}
+
+int upb_msgdef_realoneofcount(const upb_msgdef *m) {
+  return m->real_oneof_count;
+}
+
 const upb_msglayout *upb_msgdef_layout(const upb_msgdef *m) {
   return m->layout;
 }
 
-const upb_fielddef *_upb_msgdef_field(const upb_msgdef *m, int i) {
-  if (i >= m->field_count) return NULL;
+const upb_fielddef *upb_msgdef_field(const upb_msgdef *m, int i) {
+  UPB_ASSERT(i >= 0 && i < m->field_count);
   return &m->fields[i];
+}
+
+const upb_oneofdef *upb_msgdef_oneof(const upb_msgdef *m, int i) {
+  UPB_ASSERT(i >= 0 && i < m->oneof_count);
+  return &m->oneofs[i];
 }
 
 bool upb_msgdef_mapentry(const upb_msgdef *m) {
@@ -822,22 +810,25 @@ const upb_msgdef *upb_oneofdef_containingtype(const upb_oneofdef *o) {
   return o->parent;
 }
 
+int upb_oneofdef_fieldcount(const upb_oneofdef *o) {
+  return o->field_count;
+}
+
+const upb_fielddef *upb_oneofdef_field(const upb_oneofdef *o, int i) {
+  UPB_ASSERT(i < o->field_count);
+  return o->fields[i];
+}
+
 int upb_oneofdef_numfields(const upb_oneofdef *o) {
-  return (int)upb_strtable_count(&o->ntof);
+  return o->field_count;
 }
 
 uint32_t upb_oneofdef_index(const upb_oneofdef *o) {
-  return o->index;
+  return o - o->parent->oneofs;
 }
 
 bool upb_oneofdef_issynthetic(const upb_oneofdef *o) {
-  upb_inttable_iter iter;
-  const upb_fielddef *f;
-  upb_inttable_begin(&iter, &o->itof);
-  if (upb_oneofdef_numfields(o) != 1) return false;
-  f = upb_value_getptr(upb_inttable_iter_value(&iter));
-  UPB_ASSERT(f);
-  return f->proto3_optional_;
+  return o->synthetic;
 }
 
 const upb_fielddef *upb_oneofdef_ntof(const upb_oneofdef *o,
@@ -1154,6 +1145,46 @@ static const char *makefullname(const symtab_addctx *ctx, const char *prefix,
   }
 }
 
+static bool finalize_oneofs(symtab_addctx *ctx, upb_msgdef *m) {
+  int i;
+  int synthetic_count = 0;
+  upb_oneofdef *mutable_oneofs = (upb_oneofdef*)m->oneofs;
+
+  for (i = 0; i < m->oneof_count; i++) {
+    upb_oneofdef *o = &mutable_oneofs[i];
+
+    if (o->synthetic && o->field_count != 1) {
+      upb_status_seterrf(
+          ctx->status, "Synthetic oneofs must have one field, not %d: %s",
+          o->field_count, upb_oneofdef_name(o));
+      return false;
+    }
+
+    if (o->synthetic) {
+      synthetic_count++;
+    } else if (synthetic_count != 0) {
+      upb_status_seterrf(
+          ctx->status, "Synthetic oneofs must be after all other oneofs: %s",
+          upb_oneofdef_name(o));
+      return false;
+    }
+
+    o->fields = upb_malloc(ctx->alloc, sizeof(upb_fielddef*) * o->field_count);
+    o->field_count = 0;
+  }
+
+  for (i = 0; i < m->field_count; i++) {
+    const upb_fielddef *f = &m->fields[i];
+    upb_oneofdef *o = (upb_oneofdef*)f->oneof;
+    if (o) {
+      o->fields[o->field_count++] = f;
+    }
+  }
+
+  m->real_oneof_count = m->oneof_count - synthetic_count;
+  return true;
+}
+
 size_t getjsonname(const char *name, char *buf, size_t len) {
   size_t src, dst = 0;
   bool ucase_next = false;
@@ -1270,6 +1301,8 @@ static bool create_oneofdef(
   o = (upb_oneofdef*)&m->oneofs[m->oneof_count++];
   o->parent = m;
   o->full_name = makefullname(ctx, m->full_name, name);
+  o->field_count = 0;
+  o->synthetic = false;
 
   v = pack_def(o, UPB_DEFTYPE_ONEOF);
   CHK_OOM(symtab_add(ctx, o->full_name, v));
@@ -1549,10 +1582,20 @@ static bool create_fielddef(
     oneof = (upb_oneofdef*)&m->oneofs[oneof_index];
     f->oneof = oneof;
 
+    oneof->field_count++;
+    if (f->proto3_optional_) {
+      oneof->synthetic = true;
+    }
     CHK(upb_inttable_insert2(&oneof->itof, f->number_, v, alloc));
     CHK(upb_strtable_insert3(&oneof->ntof, name.data, name.size, v, alloc));
   } else {
     f->oneof = NULL;
+    if (f->proto3_optional_) {
+      upb_status_seterrf(ctx->status,
+                         "field with proto3_optional was not in a oneof (%s)",
+                         f->full_name);
+      return false;
+    }
   }
 
   options = google_protobuf_FieldDescriptorProto_has_options(field_proto) ?
@@ -1692,7 +1735,7 @@ static bool create_msgdef(symtab_addctx *ctx, const char *prefix,
   }
 
   CHK(assign_msg_indices(m, ctx->status));
-  CHK(check_oneofs(m, ctx->status));
+  CHK(finalize_oneofs(ctx, m));
   assign_msg_wellknowntype(m);
   upb_inttable_compact2(&m->itof, ctx->alloc);
 

--- a/upb/def.h
+++ b/upb/def.h
@@ -134,7 +134,7 @@ UPB_INLINE const upb_fielddef *upb_oneofdef_ntofz(const upb_oneofdef *o,
 }
 const upb_fielddef *upb_oneofdef_itof(const upb_oneofdef *o, uint32_t num);
 
-// DEPRECATED, slated for removal.
+/* DEPRECATED, slated for removal. */
 int upb_oneofdef_numfields(const upb_oneofdef *o);
 void upb_oneof_begin(upb_oneof_iter *iter, const upb_oneofdef *o);
 void upb_oneof_next(upb_oneof_iter *iter);
@@ -143,7 +143,7 @@ upb_fielddef *upb_oneof_iter_field(const upb_oneof_iter *iter);
 void upb_oneof_iter_setdone(upb_oneof_iter *iter);
 bool upb_oneof_iter_isequal(const upb_oneof_iter *iter1,
                             const upb_oneof_iter *iter2);
-// END DEPRECATED
+/* END DEPRECATED */
 
 /* upb_msgdef *****************************************************************/
 
@@ -215,7 +215,7 @@ UPB_INLINE bool upb_msgdef_lookupnamez(const upb_msgdef *m, const char *name,
 const upb_fielddef *upb_msgdef_lookupjsonname(const upb_msgdef *m,
                                               const char *name, size_t len);
 
-// DEPRECATED, slated for removal
+/* DEPRECATED, slated for removal */
 int upb_msgdef_numfields(const upb_msgdef *m);
 int upb_msgdef_numoneofs(const upb_msgdef *m);
 int upb_msgdef_numrealoneofs(const upb_msgdef *m);
@@ -233,7 +233,7 @@ const upb_oneofdef *upb_msg_iter_oneof(const upb_msg_oneof_iter *iter);
 void upb_msg_oneof_iter_setdone(upb_msg_oneof_iter * iter);
 bool upb_msg_oneof_iter_isequal(const upb_msg_oneof_iter *iter1,
                                 const upb_msg_oneof_iter *iter2);
-// END DEPRECATED
+/* END DEPRECATED */
 
 /* upb_enumdef ****************************************************************/
 

--- a/upb/def.h
+++ b/upb/def.h
@@ -117,9 +117,10 @@ typedef upb_inttable_iter upb_oneof_iter;
 
 const char *upb_oneofdef_name(const upb_oneofdef *o);
 const upb_msgdef *upb_oneofdef_containingtype(const upb_oneofdef *o);
-int upb_oneofdef_numfields(const upb_oneofdef *o);
 uint32_t upb_oneofdef_index(const upb_oneofdef *o);
 bool upb_oneofdef_issynthetic(const upb_oneofdef *o);
+int upb_oneofdef_fieldcount(const upb_oneofdef *o);
+const upb_fielddef *upb_oneofdef_field(const upb_oneofdef *o, int i);
 
 /* Oneof lookups:
  * - ntof:  look up a field by name.
@@ -133,11 +134,8 @@ UPB_INLINE const upb_fielddef *upb_oneofdef_ntofz(const upb_oneofdef *o,
 }
 const upb_fielddef *upb_oneofdef_itof(const upb_oneofdef *o, uint32_t num);
 
-/*  upb_oneof_iter i;
- *  for(upb_oneof_begin(&i, e); !upb_oneof_done(&i); upb_oneof_next(&i)) {
- *    // ...
- *  }
- */
+// DEPRECATED, slated for removal.
+int upb_oneofdef_numfields(const upb_oneofdef *o);
 void upb_oneof_begin(upb_oneof_iter *iter, const upb_oneofdef *o);
 void upb_oneof_next(upb_oneof_iter *iter);
 bool upb_oneof_done(upb_oneof_iter *iter);
@@ -145,6 +143,7 @@ upb_fielddef *upb_oneof_iter_field(const upb_oneof_iter *iter);
 void upb_oneof_iter_setdone(upb_oneof_iter *iter);
 bool upb_oneof_iter_isequal(const upb_oneof_iter *iter1,
                             const upb_oneof_iter *iter2);
+// END DEPRECATED
 
 /* upb_msgdef *****************************************************************/
 
@@ -170,21 +169,21 @@ typedef upb_strtable_iter upb_msg_oneof_iter;
 const char *upb_msgdef_fullname(const upb_msgdef *m);
 const upb_filedef *upb_msgdef_file(const upb_msgdef *m);
 const char *upb_msgdef_name(const upb_msgdef *m);
-int upb_msgdef_numfields(const upb_msgdef *m);
-int upb_msgdef_numoneofs(const upb_msgdef *m);
-int upb_msgdef_numrealoneofs(const upb_msgdef *m);
 upb_syntax_t upb_msgdef_syntax(const upb_msgdef *m);
 bool upb_msgdef_mapentry(const upb_msgdef *m);
 upb_wellknowntype_t upb_msgdef_wellknowntype(const upb_msgdef *m);
 bool upb_msgdef_iswrapper(const upb_msgdef *m);
 bool upb_msgdef_isnumberwrapper(const upb_msgdef *m);
+int upb_msgdef_fieldcount(const upb_msgdef *m);
+int upb_msgdef_oneofcount(const upb_msgdef *m);
+const upb_fielddef *upb_msgdef_field(const upb_msgdef *m, int i);
+const upb_oneofdef *upb_msgdef_oneof(const upb_msgdef *m, int i);
 const upb_fielddef *upb_msgdef_itof(const upb_msgdef *m, uint32_t i);
 const upb_fielddef *upb_msgdef_ntof(const upb_msgdef *m, const char *name,
                                     size_t len);
 const upb_oneofdef *upb_msgdef_ntoo(const upb_msgdef *m, const char *name,
                                     size_t len);
 const upb_msglayout *upb_msgdef_layout(const upb_msgdef *m);
-const upb_fielddef *_upb_msgdef_field(const upb_msgdef *m, int i);
 
 UPB_INLINE const upb_oneofdef *upb_msgdef_ntooz(const upb_msgdef *m,
                                                const char *name) {
@@ -216,19 +215,10 @@ UPB_INLINE bool upb_msgdef_lookupnamez(const upb_msgdef *m, const char *name,
 const upb_fielddef *upb_msgdef_lookupjsonname(const upb_msgdef *m,
                                               const char *name, size_t len);
 
-/* Iteration over fields and oneofs.  For example:
- *
- * upb_msg_field_iter i;
- * for(upb_msg_field_begin(&i, m);
- *     !upb_msg_field_done(&i);
- *     upb_msg_field_next(&i)) {
- *   upb_fielddef *f = upb_msg_iter_field(&i);
- *   // ...
- * }
- *
- * For C we don't have separate iterators for const and non-const.
- * It is the caller's responsibility to cast the upb_fielddef* to
- * const if the upb_msgdef* is const. */
+// DEPRECATED, slated for removal
+int upb_msgdef_numfields(const upb_msgdef *m);
+int upb_msgdef_numoneofs(const upb_msgdef *m);
+int upb_msgdef_numrealoneofs(const upb_msgdef *m);
 void upb_msg_field_begin(upb_msg_field_iter *iter, const upb_msgdef *m);
 void upb_msg_field_next(upb_msg_field_iter *iter);
 bool upb_msg_field_done(const upb_msg_field_iter *iter);
@@ -236,9 +226,6 @@ upb_fielddef *upb_msg_iter_field(const upb_msg_field_iter *iter);
 void upb_msg_field_iter_setdone(upb_msg_field_iter *iter);
 bool upb_msg_field_iter_isequal(const upb_msg_field_iter * iter1,
                                 const upb_msg_field_iter * iter2);
-
-/* Similar to above, we also support iterating through the oneofs in a
- * msgdef. */
 void upb_msg_oneof_begin(upb_msg_oneof_iter * iter, const upb_msgdef *m);
 void upb_msg_oneof_next(upb_msg_oneof_iter * iter);
 bool upb_msg_oneof_done(const upb_msg_oneof_iter *iter);
@@ -246,6 +233,7 @@ const upb_oneofdef *upb_msg_iter_oneof(const upb_msg_oneof_iter *iter);
 void upb_msg_oneof_iter_setdone(upb_msg_oneof_iter * iter);
 bool upb_msg_oneof_iter_isequal(const upb_msg_oneof_iter *iter1,
                                 const upb_msg_oneof_iter *iter2);
+// END DEPRECATED
 
 /* upb_enumdef ****************************************************************/
 
@@ -270,11 +258,6 @@ UPB_INLINE bool upb_enumdef_ntoiz(const upb_enumdef *e,
 }
 const char *upb_enumdef_iton(const upb_enumdef *e, int32_t num);
 
-/*  upb_enum_iter i;
- *  for(upb_enum_begin(&i, e); !upb_enum_done(&i); upb_enum_next(&i)) {
- *    // ...
- *  }
- */
 void upb_enum_begin(upb_enum_iter *iter, const upb_enumdef *e);
 void upb_enum_next(upb_enum_iter *iter);
 bool upb_enum_done(upb_enum_iter *iter);

--- a/upb/def.hpp
+++ b/upb/def.hpp
@@ -24,21 +24,21 @@ class FieldDefPtr {
   FieldDefPtr() : ptr_(nullptr) {}
   explicit FieldDefPtr(const upb_fielddef* ptr) : ptr_(ptr) {}
 
-  const upb_fielddef* ptr() { return ptr_; }
-  explicit operator bool() { return ptr_ != nullptr; }
+  const upb_fielddef* ptr() const { return ptr_; }
+  explicit operator bool() const { return ptr_ != nullptr; }
 
   typedef upb_fieldtype_t Type;
   typedef upb_label_t Label;
   typedef upb_descriptortype_t DescriptorType;
 
-  const char* full_name() { return upb_fielddef_fullname(ptr_); }
+  const char* full_name() const { return upb_fielddef_fullname(ptr_); }
 
-  Type type() { return upb_fielddef_type(ptr_); }
-  Label label() { return upb_fielddef_label(ptr_); }
-  const char* name() { return upb_fielddef_name(ptr_); }
-  const char* json_name() { return upb_fielddef_jsonname(ptr_); }
-  uint32_t number() { return upb_fielddef_number(ptr_); }
-  bool is_extension() { return upb_fielddef_isextension(ptr_); }
+  Type type() const { return upb_fielddef_type(ptr_); }
+  Label label() const { return upb_fielddef_label(ptr_); }
+  const char* name() const { return upb_fielddef_name(ptr_); }
+  const char* json_name() const { return upb_fielddef_jsonname(ptr_); }
+  uint32_t number() const { return upb_fielddef_number(ptr_); }
+  bool is_extension() const { return upb_fielddef_isextension(ptr_); }
 
   // For UPB_TYPE_MESSAGE fields only where is_tag_delimited() == false,
   // indicates whether this field should have lazy parsing handlers that yield
@@ -47,20 +47,20 @@ class FieldDefPtr {
   // TODO(haberman): I think we want to move this into a FieldOptions container
   // when we add support for custom options (the FieldOptions struct will
   // contain both regular FieldOptions like "lazy" *and* custom options).
-  bool lazy() { return upb_fielddef_lazy(ptr_); }
+  bool lazy() const { return upb_fielddef_lazy(ptr_); }
 
   // For non-string, non-submessage fields, this indicates whether binary
   // protobufs are encoded in packed or non-packed format.
   //
   // TODO(haberman): see note above about putting options like this into a
   // FieldOptions container.
-  bool packed() { return upb_fielddef_packed(ptr_); }
+  bool packed() const { return upb_fielddef_packed(ptr_); }
 
   // An integer that can be used as an index into an array of fields for
   // whatever message this field belongs to.  Guaranteed to be less than
   // f->containing_type()->field_count().  May only be accessed once the def has
   // been finalized.
-  uint32_t index() { return upb_fielddef_index(ptr_); }
+  uint32_t index() const { return upb_fielddef_index(ptr_); }
 
   // The MessageDef to which this field belongs.
   //
@@ -70,27 +70,27 @@ class FieldDefPtr {
   // If the field has not yet been added to a MessageDef, you can set the name
   // of the containing type symbolically instead.  This is mostly useful for
   // extensions, where the extension is declared separately from the message.
-  MessageDefPtr containing_type();
+  MessageDefPtr containing_type() const;
 
   // The OneofDef to which this field belongs, or NULL if this field is not part
   // of a oneof.
-  OneofDefPtr containing_oneof();
+  OneofDefPtr containing_oneof() const;
 
   // The field's type according to the enum in descriptor.proto.  This is not
   // the same as UPB_TYPE_*, because it distinguishes between (for example)
   // INT32 and SINT32, whereas our "type" enum does not.  This return of
   // descriptor_type() is a function of type(), integer_format(), and
   // is_tag_delimited().
-  DescriptorType descriptor_type() {
+  DescriptorType descriptor_type() const {
     return upb_fielddef_descriptortype(ptr_);
   }
 
   // Convenient field type tests.
-  bool IsSubMessage() { return upb_fielddef_issubmsg(ptr_); }
-  bool IsString() { return upb_fielddef_isstring(ptr_); }
-  bool IsSequence() { return upb_fielddef_isseq(ptr_); }
-  bool IsPrimitive() { return upb_fielddef_isprimitive(ptr_); }
-  bool IsMap() { return upb_fielddef_ismap(ptr_); }
+  bool IsSubMessage() const { return upb_fielddef_issubmsg(ptr_); }
+  bool IsString() const { return upb_fielddef_isstring(ptr_); }
+  bool IsSequence() const { return upb_fielddef_isseq(ptr_); }
+  bool IsPrimitive() const { return upb_fielddef_isprimitive(ptr_); }
+  bool IsMap() const { return upb_fielddef_ismap(ptr_); }
 
   // Returns the non-string default value for this fielddef, which may either
   // be something the client set explicitly or the "default default" (0 for
@@ -98,25 +98,25 @@ class FieldDefPtr {
   // returned value, except for enum fields that are still mutable.
   //
   // Requires that the given function matches the field's current type.
-  int64_t default_int64() { return upb_fielddef_defaultint64(ptr_); }
-  int32_t default_int32() { return upb_fielddef_defaultint32(ptr_); }
-  uint64_t default_uint64() { return upb_fielddef_defaultuint64(ptr_); }
-  uint32_t default_uint32() { return upb_fielddef_defaultuint32(ptr_); }
-  bool default_bool() { return upb_fielddef_defaultbool(ptr_); }
-  float default_float() { return upb_fielddef_defaultfloat(ptr_); }
-  double default_double() { return upb_fielddef_defaultdouble(ptr_); }
+  int64_t default_int64() const { return upb_fielddef_defaultint64(ptr_); }
+  int32_t default_int32() const { return upb_fielddef_defaultint32(ptr_); }
+  uint64_t default_uint64() const { return upb_fielddef_defaultuint64(ptr_); }
+  uint32_t default_uint32() const { return upb_fielddef_defaultuint32(ptr_); }
+  bool default_bool() const { return upb_fielddef_defaultbool(ptr_); }
+  float default_float() const { return upb_fielddef_defaultfloat(ptr_); }
+  double default_double() const { return upb_fielddef_defaultdouble(ptr_); }
 
   // The resulting string is always NULL-terminated.  If non-NULL, the length
   // will be stored in *len.
-  const char* default_string(size_t* len) {
+  const char* default_string(size_t* len) const {
     return upb_fielddef_defaultstr(ptr_, len);
   }
 
   // Returns the enum or submessage def for this field, if any.  The field's
   // type must match (ie. you may only call enum_subdef() for fields where
   // type() == UPB_TYPE_ENUM).
-  EnumDefPtr enum_subdef();
-  MessageDefPtr message_subdef();
+  EnumDefPtr enum_subdef() const;
+  MessageDefPtr message_subdef() const;
 
  private:
   const upb_fielddef* ptr_;
@@ -128,34 +128,34 @@ class OneofDefPtr {
   OneofDefPtr() : ptr_(nullptr) {}
   explicit OneofDefPtr(const upb_oneofdef* ptr) : ptr_(ptr) {}
 
-  const upb_oneofdef* ptr() { return ptr_; }
-  explicit operator bool() { return ptr_ != nullptr; }
+  const upb_oneofdef* ptr() const { return ptr_; }
+  explicit operator bool() const { return ptr_ != nullptr; }
 
   // Returns the MessageDef that contains this OneofDef.
-  MessageDefPtr containing_type();
+  MessageDefPtr containing_type() const;
 
   // Returns the name of this oneof.
-  const char* name() { return upb_oneofdef_name(ptr_); }
+  const char* name() const { return upb_oneofdef_name(ptr_); }
 
   // Returns the number of fields in the oneof.
-  int field_count() { return upb_oneofdef_numfields(ptr_); }
-  FieldDefPtr field(int i) { return FieldDefPtr(upb_oneofdef_field(ptr_, i)); }
+  int field_count() const { return upb_oneofdef_numfields(ptr_); }
+  FieldDefPtr field(int i) const { return FieldDefPtr(upb_oneofdef_field(ptr_, i)); }
 
   // Looks up by name.
-  FieldDefPtr FindFieldByName(const char* name, size_t len) {
+  FieldDefPtr FindFieldByName(const char* name, size_t len) const {
     return FieldDefPtr(upb_oneofdef_ntof(ptr_, name, len));
   }
-  FieldDefPtr FindFieldByName(const char* name) {
+  FieldDefPtr FindFieldByName(const char* name) const {
     return FieldDefPtr(upb_oneofdef_ntofz(ptr_, name));
   }
 
   template <class T>
-  FieldDefPtr FindFieldByName(const T& str) {
+  FieldDefPtr FindFieldByName(const T& str) const {
     return FindFieldByName(str.c_str(), str.size());
   }
 
   // Looks up by tag number.
-  FieldDefPtr FindFieldByNumber(uint32_t num) {
+  FieldDefPtr FindFieldByNumber(uint32_t num) const {
     return FieldDefPtr(upb_oneofdef_itof(ptr_, num));
   }
 
@@ -169,62 +169,62 @@ class MessageDefPtr {
   MessageDefPtr() : ptr_(nullptr) {}
   explicit MessageDefPtr(const upb_msgdef* ptr) : ptr_(ptr) {}
 
-  const upb_msgdef* ptr() { return ptr_; }
-  explicit operator bool() { return ptr_ != nullptr; }
+  const upb_msgdef* ptr() const { return ptr_; }
+  explicit operator bool() const { return ptr_ != nullptr; }
 
-  const char* full_name() { return upb_msgdef_fullname(ptr_); }
-  const char* name() { return upb_msgdef_name(ptr_); }
+  const char* full_name() const { return upb_msgdef_fullname(ptr_); }
+  const char* name() const { return upb_msgdef_name(ptr_); }
 
   // The number of fields that belong to the MessageDef.
-  int field_count() { return upb_msgdef_numfields(ptr_); }
-  FieldDefPtr field(int i) { return FieldDefPtr(upb_msgdef_field(ptr_, i)); }
+  int field_count() const { return upb_msgdef_numfields(ptr_); }
+  FieldDefPtr field(int i) const { return FieldDefPtr(upb_msgdef_field(ptr_, i)); }
 
   // The number of oneofs that belong to the MessageDef.
-  int oneof_count() { return upb_msgdef_numoneofs(ptr_); }
-  OneofDefPtr oneof(int i) { return OneofDefPtr(upb_msgdef_oneof(ptr_, i)); }
+  int oneof_count() const { return upb_msgdef_numoneofs(ptr_); }
+  OneofDefPtr oneof(int i) const { return OneofDefPtr(upb_msgdef_oneof(ptr_, i)); }
 
-  upb_syntax_t syntax() { return upb_msgdef_syntax(ptr_); }
+  upb_syntax_t syntax() const { return upb_msgdef_syntax(ptr_); }
 
   // These return null pointers if the field is not found.
-  FieldDefPtr FindFieldByNumber(uint32_t number) {
+  FieldDefPtr FindFieldByNumber(uint32_t number) const {
     return FieldDefPtr(upb_msgdef_itof(ptr_, number));
   }
-  FieldDefPtr FindFieldByName(const char* name, size_t len) {
+  FieldDefPtr FindFieldByName(const char* name, size_t len) const {
     return FieldDefPtr(upb_msgdef_ntof(ptr_, name, len));
   }
-  FieldDefPtr FindFieldByName(const char* name) {
+  FieldDefPtr FindFieldByName(const char* name) const {
     return FieldDefPtr(upb_msgdef_ntofz(ptr_, name));
   }
 
   template <class T>
-  FieldDefPtr FindFieldByName(const T& str) {
+  FieldDefPtr FindFieldByName(const T& str) const {
     return FindFieldByName(str.c_str(), str.size());
   }
 
-  OneofDefPtr FindOneofByName(const char* name, size_t len) {
+  OneofDefPtr FindOneofByName(const char* name, size_t len) const {
     return OneofDefPtr(upb_msgdef_ntoo(ptr_, name, len));
   }
 
-  OneofDefPtr FindOneofByName(const char* name) {
+  OneofDefPtr FindOneofByName(const char* name) const {
     return OneofDefPtr(upb_msgdef_ntooz(ptr_, name));
   }
 
   template <class T>
-  OneofDefPtr FindOneofByName(const T& str) {
+  OneofDefPtr FindOneofByName(const T& str) const {
     return FindOneofByName(str.c_str(), str.size());
   }
 
   // Is this message a map entry?
-  bool mapentry() { return upb_msgdef_mapentry(ptr_); }
+  bool mapentry() const { return upb_msgdef_mapentry(ptr_); }
 
   // Return the type of well known type message. UPB_WELLKNOWN_UNSPECIFIED for
   // non-well-known message.
-  upb_wellknowntype_t wellknowntype() {
+  upb_wellknowntype_t wellknowntype() const {
     return upb_msgdef_wellknowntype(ptr_);
   }
 
   // Whether is a number wrapper.
-  bool isnumberwrapper() { return upb_msgdef_isnumberwrapper(ptr_); }
+  bool isnumberwrapper() const { return upb_msgdef_isnumberwrapper(ptr_); }
 
  private:
   class FieldIter {
@@ -276,8 +276,8 @@ class MessageDefPtr {
   };
 
  public:
-  FieldAccessor fields() { return FieldAccessor(ptr()); }
-  OneofAccessor oneofs() { return OneofAccessor(ptr()); }
+  FieldAccessor fields() const { return FieldAccessor(ptr()); }
+  OneofAccessor oneofs() const { return OneofAccessor(ptr()); }
 
  private:
   const upb_msgdef* ptr_;
@@ -288,32 +288,32 @@ class EnumDefPtr {
   EnumDefPtr() : ptr_(nullptr) {}
   explicit EnumDefPtr(const upb_enumdef* ptr) : ptr_(ptr) {}
 
-  const upb_enumdef* ptr() { return ptr_; }
-  explicit operator bool() { return ptr_ != nullptr; }
+  const upb_enumdef* ptr() const { return ptr_; }
+  explicit operator bool() const { return ptr_ != nullptr; }
 
-  const char* full_name() { return upb_enumdef_fullname(ptr_); }
-  const char* name() { return upb_enumdef_name(ptr_); }
+  const char* full_name() const { return upb_enumdef_fullname(ptr_); }
+  const char* name() const { return upb_enumdef_name(ptr_); }
 
   // The value that is used as the default when no field default is specified.
   // If not set explicitly, the first value that was added will be used.
   // The default value must be a member of the enum.
   // Requires that value_count() > 0.
-  int32_t default_value() { return upb_enumdef_default(ptr_); }
+  int32_t default_value() const { return upb_enumdef_default(ptr_); }
 
   // Returns the number of values currently defined in the enum.  Note that
   // multiple names can refer to the same number, so this may be greater than
   // the total number of unique numbers.
-  int value_count() { return upb_enumdef_numvals(ptr_); }
+  int value_count() const { return upb_enumdef_numvals(ptr_); }
 
   // Lookups from name to integer, returning true if found.
-  bool FindValueByName(const char* name, int32_t* num) {
+  bool FindValueByName(const char* name, int32_t* num) const {
     return upb_enumdef_ntoiz(ptr_, name, num);
   }
 
   // Finds the name corresponding to the given number, or NULL if none was
   // found.  If more than one name corresponds to this number, returns the
   // first one that was added.
-  const char* FindValueByNumber(int32_t num) {
+  const char* FindValueByNumber(int32_t num) const {
     return upb_enumdef_iton(ptr_, num);
   }
 
@@ -346,31 +346,31 @@ class FileDefPtr {
  public:
   explicit FileDefPtr(const upb_filedef* ptr) : ptr_(ptr) {}
 
-  const upb_filedef* ptr() { return ptr_; }
-  explicit operator bool() { return ptr_ != nullptr; }
+  const upb_filedef* ptr() const { return ptr_; }
+  explicit operator bool() const { return ptr_ != nullptr; }
 
   // Get/set name of the file (eg. "foo/bar.proto").
-  const char* name() { return upb_filedef_name(ptr_); }
+  const char* name() const { return upb_filedef_name(ptr_); }
 
   // Package name for definitions inside the file (eg. "foo.bar").
-  const char* package() { return upb_filedef_package(ptr_); }
+  const char* package() const { return upb_filedef_package(ptr_); }
 
   // Sets the php class prefix which is prepended to all php generated classes
   // from this .proto. Default is empty.
-  const char* phpprefix() { return upb_filedef_phpprefix(ptr_); }
+  const char* phpprefix() const { return upb_filedef_phpprefix(ptr_); }
 
   // Use this option to change the namespace of php generated classes. Default
   // is empty. When this option is empty, the package name will be used for
   // determining the namespace.
-  const char* phpnamespace() { return upb_filedef_phpnamespace(ptr_); }
+  const char* phpnamespace() const { return upb_filedef_phpnamespace(ptr_); }
 
   // Syntax for the file.  Defaults to proto2.
-  upb_syntax_t syntax() { return upb_filedef_syntax(ptr_); }
+  upb_syntax_t syntax() const { return upb_filedef_syntax(ptr_); }
 
   // Get the list of dependencies from the file.  These are returned in the
   // order that they were added to the FileDefPtr.
-  int dependency_count() { return upb_filedef_depcount(ptr_); }
-  const FileDefPtr dependency(int index) {
+  int dependency_count() const { return upb_filedef_depcount(ptr_); }
+  const FileDefPtr dependency(int index) const {
     return FileDefPtr(upb_filedef_dep(ptr_, index));
   }
 
@@ -414,23 +414,23 @@ class SymbolTable {
   std::unique_ptr<upb_symtab, decltype(&upb_symtab_free)> ptr_;
 };
 
-inline MessageDefPtr FieldDefPtr::message_subdef() {
+inline MessageDefPtr FieldDefPtr::message_subdef() const {
   return MessageDefPtr(upb_fielddef_msgsubdef(ptr_));
 }
 
-inline MessageDefPtr FieldDefPtr::containing_type() {
+inline MessageDefPtr FieldDefPtr::containing_type() const {
   return MessageDefPtr(upb_fielddef_containingtype(ptr_));
 }
 
-inline MessageDefPtr OneofDefPtr::containing_type() {
+inline MessageDefPtr OneofDefPtr::containing_type() const {
   return MessageDefPtr(upb_oneofdef_containingtype(ptr_));
 }
 
-inline OneofDefPtr FieldDefPtr::containing_oneof() {
+inline OneofDefPtr FieldDefPtr::containing_oneof() const {
   return OneofDefPtr(upb_fielddef_containingoneof(ptr_));
 }
 
-inline EnumDefPtr FieldDefPtr::enum_subdef() {
+inline EnumDefPtr FieldDefPtr::enum_subdef() const {
   return EnumDefPtr(upb_fielddef_enumsubdef(ptr_));
 }
 

--- a/upb/def.hpp
+++ b/upb/def.hpp
@@ -24,21 +24,21 @@ class FieldDefPtr {
   FieldDefPtr() : ptr_(nullptr) {}
   explicit FieldDefPtr(const upb_fielddef* ptr) : ptr_(ptr) {}
 
-  const upb_fielddef* ptr() const { return ptr_; }
-  explicit operator bool() const { return ptr_ != nullptr; }
+  const upb_fielddef* ptr() { return ptr_; }
+  explicit operator bool() { return ptr_ != nullptr; }
 
   typedef upb_fieldtype_t Type;
   typedef upb_label_t Label;
   typedef upb_descriptortype_t DescriptorType;
 
-  const char* full_name() const { return upb_fielddef_fullname(ptr_); }
+  const char* full_name() { return upb_fielddef_fullname(ptr_); }
 
-  Type type() const { return upb_fielddef_type(ptr_); }
-  Label label() const { return upb_fielddef_label(ptr_); }
-  const char* name() const { return upb_fielddef_name(ptr_); }
-  const char* json_name() const { return upb_fielddef_jsonname(ptr_); }
-  uint32_t number() const { return upb_fielddef_number(ptr_); }
-  bool is_extension() const { return upb_fielddef_isextension(ptr_); }
+  Type type() { return upb_fielddef_type(ptr_); }
+  Label label() { return upb_fielddef_label(ptr_); }
+  const char* name() { return upb_fielddef_name(ptr_); }
+  const char* json_name() { return upb_fielddef_jsonname(ptr_); }
+  uint32_t number() { return upb_fielddef_number(ptr_); }
+  bool is_extension() { return upb_fielddef_isextension(ptr_); }
 
   // For UPB_TYPE_MESSAGE fields only where is_tag_delimited() == false,
   // indicates whether this field should have lazy parsing handlers that yield
@@ -47,20 +47,20 @@ class FieldDefPtr {
   // TODO(haberman): I think we want to move this into a FieldOptions container
   // when we add support for custom options (the FieldOptions struct will
   // contain both regular FieldOptions like "lazy" *and* custom options).
-  bool lazy() const { return upb_fielddef_lazy(ptr_); }
+  bool lazy() { return upb_fielddef_lazy(ptr_); }
 
   // For non-string, non-submessage fields, this indicates whether binary
   // protobufs are encoded in packed or non-packed format.
   //
   // TODO(haberman): see note above about putting options like this into a
   // FieldOptions container.
-  bool packed() const { return upb_fielddef_packed(ptr_); }
+  bool packed() { return upb_fielddef_packed(ptr_); }
 
   // An integer that can be used as an index into an array of fields for
   // whatever message this field belongs to.  Guaranteed to be less than
   // f->containing_type()->field_count().  May only be accessed once the def has
   // been finalized.
-  uint32_t index() const { return upb_fielddef_index(ptr_); }
+  uint32_t index() { return upb_fielddef_index(ptr_); }
 
   // The MessageDef to which this field belongs.
   //
@@ -70,27 +70,27 @@ class FieldDefPtr {
   // If the field has not yet been added to a MessageDef, you can set the name
   // of the containing type symbolically instead.  This is mostly useful for
   // extensions, where the extension is declared separately from the message.
-  MessageDefPtr containing_type() const;
+  MessageDefPtr containing_type();
 
   // The OneofDef to which this field belongs, or NULL if this field is not part
   // of a oneof.
-  OneofDefPtr containing_oneof() const;
+  OneofDefPtr containing_oneof();
 
   // The field's type according to the enum in descriptor.proto.  This is not
   // the same as UPB_TYPE_*, because it distinguishes between (for example)
   // INT32 and SINT32, whereas our "type" enum does not.  This return of
   // descriptor_type() is a function of type(), integer_format(), and
   // is_tag_delimited().
-  DescriptorType descriptor_type() const {
+  DescriptorType descriptor_type() {
     return upb_fielddef_descriptortype(ptr_);
   }
 
   // Convenient field type tests.
-  bool IsSubMessage() const { return upb_fielddef_issubmsg(ptr_); }
-  bool IsString() const { return upb_fielddef_isstring(ptr_); }
-  bool IsSequence() const { return upb_fielddef_isseq(ptr_); }
-  bool IsPrimitive() const { return upb_fielddef_isprimitive(ptr_); }
-  bool IsMap() const { return upb_fielddef_ismap(ptr_); }
+  bool IsSubMessage() { return upb_fielddef_issubmsg(ptr_); }
+  bool IsString() { return upb_fielddef_isstring(ptr_); }
+  bool IsSequence() { return upb_fielddef_isseq(ptr_); }
+  bool IsPrimitive() { return upb_fielddef_isprimitive(ptr_); }
+  bool IsMap() { return upb_fielddef_ismap(ptr_); }
 
   // Returns the non-string default value for this fielddef, which may either
   // be something the client set explicitly or the "default default" (0 for
@@ -98,25 +98,25 @@ class FieldDefPtr {
   // returned value, except for enum fields that are still mutable.
   //
   // Requires that the given function matches the field's current type.
-  int64_t default_int64() const { return upb_fielddef_defaultint64(ptr_); }
-  int32_t default_int32() const { return upb_fielddef_defaultint32(ptr_); }
-  uint64_t default_uint64() const { return upb_fielddef_defaultuint64(ptr_); }
-  uint32_t default_uint32() const { return upb_fielddef_defaultuint32(ptr_); }
-  bool default_bool() const { return upb_fielddef_defaultbool(ptr_); }
-  float default_float() const { return upb_fielddef_defaultfloat(ptr_); }
-  double default_double() const { return upb_fielddef_defaultdouble(ptr_); }
+  int64_t default_int64() { return upb_fielddef_defaultint64(ptr_); }
+  int32_t default_int32() { return upb_fielddef_defaultint32(ptr_); }
+  uint64_t default_uint64() { return upb_fielddef_defaultuint64(ptr_); }
+  uint32_t default_uint32() { return upb_fielddef_defaultuint32(ptr_); }
+  bool default_bool() { return upb_fielddef_defaultbool(ptr_); }
+  float default_float() { return upb_fielddef_defaultfloat(ptr_); }
+  double default_double() { return upb_fielddef_defaultdouble(ptr_); }
 
   // The resulting string is always NULL-terminated.  If non-NULL, the length
   // will be stored in *len.
-  const char* default_string(size_t* len) const {
+  const char* default_string(size_t* len) {
     return upb_fielddef_defaultstr(ptr_, len);
   }
 
   // Returns the enum or submessage def for this field, if any.  The field's
   // type must match (ie. you may only call enum_subdef() for fields where
   // type() == UPB_TYPE_ENUM).
-  EnumDefPtr enum_subdef() const;
-  MessageDefPtr message_subdef() const;
+  EnumDefPtr enum_subdef();
+  MessageDefPtr message_subdef();
 
  private:
   const upb_fielddef* ptr_;
@@ -128,70 +128,36 @@ class OneofDefPtr {
   OneofDefPtr() : ptr_(nullptr) {}
   explicit OneofDefPtr(const upb_oneofdef* ptr) : ptr_(ptr) {}
 
-  const upb_oneofdef* ptr() const { return ptr_; }
+  const upb_oneofdef* ptr() { return ptr_; }
   explicit operator bool() { return ptr_ != nullptr; }
 
-  // Returns the MessageDef that owns this OneofDef.
-  MessageDefPtr containing_type() const;
+  // Returns the MessageDef that contains this OneofDef.
+  MessageDefPtr containing_type();
 
-  // Returns the name of this oneof. This is the name used to look up the oneof
-  // by name once added to a message def.
-  const char* name() const { return upb_oneofdef_name(ptr_); }
+  // Returns the name of this oneof.
+  const char* name() { return upb_oneofdef_name(ptr_); }
 
-  // Returns the number of fields currently defined in the oneof.
-  int field_count() const { return upb_oneofdef_numfields(ptr_); }
+  // Returns the number of fields in the oneof.
+  int field_count() { return upb_oneofdef_numfields(ptr_); }
+  FieldDefPtr field(int i) { return FieldDefPtr(upb_oneofdef_field(ptr_, i)); }
 
   // Looks up by name.
-  FieldDefPtr FindFieldByName(const char* name, size_t len) const {
+  FieldDefPtr FindFieldByName(const char* name, size_t len) {
     return FieldDefPtr(upb_oneofdef_ntof(ptr_, name, len));
   }
-  FieldDefPtr FindFieldByName(const char* name) const {
+  FieldDefPtr FindFieldByName(const char* name) {
     return FieldDefPtr(upb_oneofdef_ntofz(ptr_, name));
   }
 
   template <class T>
-  FieldDefPtr FindFieldByName(const T& str) const {
+  FieldDefPtr FindFieldByName(const T& str) {
     return FindFieldByName(str.c_str(), str.size());
   }
 
   // Looks up by tag number.
-  FieldDefPtr FindFieldByNumber(uint32_t num) const {
+  FieldDefPtr FindFieldByNumber(uint32_t num) {
     return FieldDefPtr(upb_oneofdef_itof(ptr_, num));
   }
-
-  class const_iterator
-      : public std::iterator<std::forward_iterator_tag, FieldDefPtr> {
-   public:
-    void operator++() { upb_oneof_next(&iter_); }
-
-    FieldDefPtr operator*() const {
-      return FieldDefPtr(upb_oneof_iter_field(&iter_));
-    }
-
-    bool operator!=(const const_iterator& other) const {
-      return !upb_oneof_iter_isequal(&iter_, &other.iter_);
-    }
-
-    bool operator==(const const_iterator& other) const {
-      return upb_oneof_iter_isequal(&iter_, &other.iter_);
-    }
-
-   private:
-    friend class OneofDefPtr;
-
-    const_iterator() {}
-    explicit const_iterator(OneofDefPtr o) { upb_oneof_begin(&iter_, o.ptr()); }
-    static const_iterator end() {
-      const_iterator iter;
-      upb_oneof_iter_setdone(&iter.iter_);
-      return iter;
-    }
-
-    upb_oneof_iter iter_;
-  };
-
-  const_iterator begin() const { return const_iterator(*this); }
-  const_iterator end() const { return const_iterator::end(); }
 
  private:
   const upb_oneofdef* ptr_;
@@ -203,167 +169,115 @@ class MessageDefPtr {
   MessageDefPtr() : ptr_(nullptr) {}
   explicit MessageDefPtr(const upb_msgdef* ptr) : ptr_(ptr) {}
 
-  const upb_msgdef* ptr() const { return ptr_; }
-  explicit operator bool() const { return ptr_ != nullptr; }
+  const upb_msgdef* ptr() { return ptr_; }
+  explicit operator bool() { return ptr_ != nullptr; }
 
-  const char* full_name() const { return upb_msgdef_fullname(ptr_); }
-  const char* name() const { return upb_msgdef_name(ptr_); }
+  const char* full_name() { return upb_msgdef_fullname(ptr_); }
+  const char* name() { return upb_msgdef_name(ptr_); }
 
   // The number of fields that belong to the MessageDef.
-  int field_count() const { return upb_msgdef_numfields(ptr_); }
+  int field_count() { return upb_msgdef_numfields(ptr_); }
+  FieldDefPtr field(int i) { return FieldDefPtr(upb_msgdef_field(ptr_, i)); }
 
   // The number of oneofs that belong to the MessageDef.
-  int oneof_count() const { return upb_msgdef_numoneofs(ptr_); }
+  int oneof_count() { return upb_msgdef_numoneofs(ptr_); }
+  OneofDefPtr oneof(int i) { return OneofDefPtr(upb_msgdef_oneof(ptr_, i)); }
 
-  upb_syntax_t syntax() const { return upb_msgdef_syntax(ptr_); }
+  upb_syntax_t syntax() { return upb_msgdef_syntax(ptr_); }
 
   // These return null pointers if the field is not found.
-  FieldDefPtr FindFieldByNumber(uint32_t number) const {
+  FieldDefPtr FindFieldByNumber(uint32_t number) {
     return FieldDefPtr(upb_msgdef_itof(ptr_, number));
   }
-  FieldDefPtr FindFieldByName(const char* name, size_t len) const {
+  FieldDefPtr FindFieldByName(const char* name, size_t len) {
     return FieldDefPtr(upb_msgdef_ntof(ptr_, name, len));
   }
-  FieldDefPtr FindFieldByName(const char* name) const {
+  FieldDefPtr FindFieldByName(const char* name) {
     return FieldDefPtr(upb_msgdef_ntofz(ptr_, name));
   }
 
   template <class T>
-  FieldDefPtr FindFieldByName(const T& str) const {
+  FieldDefPtr FindFieldByName(const T& str) {
     return FindFieldByName(str.c_str(), str.size());
   }
 
-  OneofDefPtr FindOneofByName(const char* name, size_t len) const {
+  OneofDefPtr FindOneofByName(const char* name, size_t len) {
     return OneofDefPtr(upb_msgdef_ntoo(ptr_, name, len));
   }
 
-  OneofDefPtr FindOneofByName(const char* name) const {
+  OneofDefPtr FindOneofByName(const char* name) {
     return OneofDefPtr(upb_msgdef_ntooz(ptr_, name));
   }
 
   template <class T>
-  OneofDefPtr FindOneofByName(const T& str) const {
+  OneofDefPtr FindOneofByName(const T& str) {
     return FindOneofByName(str.c_str(), str.size());
   }
 
   // Is this message a map entry?
-  bool mapentry() const { return upb_msgdef_mapentry(ptr_); }
+  bool mapentry() { return upb_msgdef_mapentry(ptr_); }
 
   // Return the type of well known type message. UPB_WELLKNOWN_UNSPECIFIED for
   // non-well-known message.
-  upb_wellknowntype_t wellknowntype() const {
+  upb_wellknowntype_t wellknowntype() {
     return upb_msgdef_wellknowntype(ptr_);
   }
 
   // Whether is a number wrapper.
-  bool isnumberwrapper() const { return upb_msgdef_isnumberwrapper(ptr_); }
+  bool isnumberwrapper() { return upb_msgdef_isnumberwrapper(ptr_); }
 
-  // Iteration over fields.  The order is undefined.
-  class const_field_iterator
-      : public std::iterator<std::forward_iterator_tag, FieldDefPtr> {
+ private:
+  class FieldIter {
    public:
-    void operator++() { upb_msg_field_next(&iter_); }
+    explicit FieldIter(const upb_msgdef *m, int i) : m_(m), i_(i) {}
+    void operator++() { i_++; }
 
-    FieldDefPtr operator*() const {
-      return FieldDefPtr(upb_msg_iter_field(&iter_));
-    }
-
-    bool operator!=(const const_field_iterator& other) const {
-      return !upb_msg_field_iter_isequal(&iter_, &other.iter_);
-    }
-
-    bool operator==(const const_field_iterator& other) const {
-      return upb_msg_field_iter_isequal(&iter_, &other.iter_);
-    }
+    FieldDefPtr operator*() { return FieldDefPtr(upb_msgdef_field(m_, i_)); }
+    bool operator!=(const FieldIter& other) { return i_ != other.i_; }
+    bool operator==(const FieldIter& other) { return i_ == other.i_; }
 
    private:
-    friend class MessageDefPtr;
-
-    explicit const_field_iterator() {}
-
-    explicit const_field_iterator(MessageDefPtr msg) {
-      upb_msg_field_begin(&iter_, msg.ptr());
-    }
-
-    static const_field_iterator end() {
-      const_field_iterator iter;
-      upb_msg_field_iter_setdone(&iter.iter_);
-      return iter;
-    }
-
-    upb_msg_field_iter iter_;
+    const upb_msgdef *m_;
+    int i_;
   };
 
-  // Iteration over oneofs. The order is undefined.
-  class const_oneof_iterator
-      : public std::iterator<std::forward_iterator_tag, OneofDefPtr> {
+  class FieldAccessor {
    public:
-    void operator++() { upb_msg_oneof_next(&iter_); }
-
-    OneofDefPtr operator*() const {
-      return OneofDefPtr(upb_msg_iter_oneof(&iter_));
-    }
-
-    bool operator!=(const const_oneof_iterator& other) const {
-      return !upb_msg_oneof_iter_isequal(&iter_, &other.iter_);
-    }
-
-    bool operator==(const const_oneof_iterator& other) const {
-      return upb_msg_oneof_iter_isequal(&iter_, &other.iter_);
-    }
-
-   private:
-    friend class MessageDefPtr;
-
-    const_oneof_iterator() {}
-
-    explicit const_oneof_iterator(MessageDefPtr msg) {
-      upb_msg_oneof_begin(&iter_, msg.ptr());
-    }
-
-    static const_oneof_iterator end() {
-      const_oneof_iterator iter;
-      upb_msg_oneof_iter_setdone(&iter.iter_);
-      return iter;
-    }
-
-    upb_msg_oneof_iter iter_;
-  };
-
-  class ConstFieldAccessor {
-   public:
-    explicit ConstFieldAccessor(const upb_msgdef* md) : md_(md) {}
-    const_field_iterator begin() { return MessageDefPtr(md_).field_begin(); }
-    const_field_iterator end() { return MessageDefPtr(md_).field_end(); }
+    explicit FieldAccessor(const upb_msgdef* md) : md_(md) {}
+    FieldIter begin() { return FieldIter(md_, 0); }
+    FieldIter end() { return FieldIter(md_, upb_msgdef_fieldcount(md_)); }
 
    private:
     const upb_msgdef* md_;
   };
 
-  class ConstOneofAccessor {
+  class OneofIter {
    public:
-    explicit ConstOneofAccessor(const upb_msgdef* md) : md_(md) {}
-    const_oneof_iterator begin() { return MessageDefPtr(md_).oneof_begin(); }
-    const_oneof_iterator end() { return MessageDefPtr(md_).oneof_end(); }
+    explicit OneofIter(const upb_msgdef *m, int i) : m_(m), i_(i) {}
+    void operator++() { i_++; }
+
+    OneofDefPtr operator*() { return OneofDefPtr(upb_msgdef_oneof(m_, i_)); }
+    bool operator!=(const OneofIter& other) { return i_ != other.i_; }
+    bool operator==(const OneofIter& other) { return i_ == other.i_; }
+
+   private:
+    const upb_msgdef *m_;
+    int i_;
+  };
+
+  class OneofAccessor {
+   public:
+    explicit OneofAccessor(const upb_msgdef* md) : md_(md) {}
+    OneofIter begin() { return OneofIter(md_, 0); }
+    OneofIter end() { return OneofIter(md_, upb_msgdef_oneofcount(md_)); }
 
    private:
     const upb_msgdef* md_;
   };
 
-  const_field_iterator field_begin() const {
-    return const_field_iterator(*this);
-  }
-
-  const_field_iterator field_end() const { return const_field_iterator::end(); }
-
-  const_oneof_iterator oneof_begin() const {
-    return const_oneof_iterator(*this);
-  }
-
-  const_oneof_iterator oneof_end() const { return const_oneof_iterator::end(); }
-
-  ConstFieldAccessor fields() const { return ConstFieldAccessor(ptr()); }
-  ConstOneofAccessor oneofs() const { return ConstOneofAccessor(ptr()); }
+ public:
+  FieldAccessor fields() { return FieldAccessor(ptr()); }
+  OneofAccessor oneofs() { return OneofAccessor(ptr()); }
 
  private:
   const upb_msgdef* ptr_;
@@ -374,32 +288,32 @@ class EnumDefPtr {
   EnumDefPtr() : ptr_(nullptr) {}
   explicit EnumDefPtr(const upb_enumdef* ptr) : ptr_(ptr) {}
 
-  const upb_enumdef* ptr() const { return ptr_; }
-  explicit operator bool() const { return ptr_ != nullptr; }
+  const upb_enumdef* ptr() { return ptr_; }
+  explicit operator bool() { return ptr_ != nullptr; }
 
-  const char* full_name() const { return upb_enumdef_fullname(ptr_); }
-  const char* name() const { return upb_enumdef_name(ptr_); }
+  const char* full_name() { return upb_enumdef_fullname(ptr_); }
+  const char* name() { return upb_enumdef_name(ptr_); }
 
   // The value that is used as the default when no field default is specified.
   // If not set explicitly, the first value that was added will be used.
   // The default value must be a member of the enum.
   // Requires that value_count() > 0.
-  int32_t default_value() const { return upb_enumdef_default(ptr_); }
+  int32_t default_value() { return upb_enumdef_default(ptr_); }
 
   // Returns the number of values currently defined in the enum.  Note that
   // multiple names can refer to the same number, so this may be greater than
   // the total number of unique numbers.
-  int value_count() const { return upb_enumdef_numvals(ptr_); }
+  int value_count() { return upb_enumdef_numvals(ptr_); }
 
   // Lookups from name to integer, returning true if found.
-  bool FindValueByName(const char* name, int32_t* num) const {
+  bool FindValueByName(const char* name, int32_t* num) {
     return upb_enumdef_ntoiz(ptr_, name, num);
   }
 
   // Finds the name corresponding to the given number, or NULL if none was
   // found.  If more than one name corresponds to this number, returns the
   // first one that was added.
-  const char* FindValueByNumber(int32_t num) const {
+  const char* FindValueByNumber(int32_t num) {
     return upb_enumdef_iton(ptr_, num);
   }
 
@@ -432,31 +346,31 @@ class FileDefPtr {
  public:
   explicit FileDefPtr(const upb_filedef* ptr) : ptr_(ptr) {}
 
-  const upb_filedef* ptr() const { return ptr_; }
-  explicit operator bool() const { return ptr_ != nullptr; }
+  const upb_filedef* ptr() { return ptr_; }
+  explicit operator bool() { return ptr_ != nullptr; }
 
   // Get/set name of the file (eg. "foo/bar.proto").
-  const char* name() const { return upb_filedef_name(ptr_); }
+  const char* name() { return upb_filedef_name(ptr_); }
 
   // Package name for definitions inside the file (eg. "foo.bar").
-  const char* package() const { return upb_filedef_package(ptr_); }
+  const char* package() { return upb_filedef_package(ptr_); }
 
   // Sets the php class prefix which is prepended to all php generated classes
   // from this .proto. Default is empty.
-  const char* phpprefix() const { return upb_filedef_phpprefix(ptr_); }
+  const char* phpprefix() { return upb_filedef_phpprefix(ptr_); }
 
   // Use this option to change the namespace of php generated classes. Default
   // is empty. When this option is empty, the package name will be used for
   // determining the namespace.
-  const char* phpnamespace() const { return upb_filedef_phpnamespace(ptr_); }
+  const char* phpnamespace() { return upb_filedef_phpnamespace(ptr_); }
 
   // Syntax for the file.  Defaults to proto2.
-  upb_syntax_t syntax() const { return upb_filedef_syntax(ptr_); }
+  upb_syntax_t syntax() { return upb_filedef_syntax(ptr_); }
 
   // Get the list of dependencies from the file.  These are returned in the
   // order that they were added to the FileDefPtr.
-  int dependency_count() const { return upb_filedef_depcount(ptr_); }
-  const FileDefPtr dependency(int index) const {
+  int dependency_count() { return upb_filedef_depcount(ptr_); }
+  const FileDefPtr dependency(int index) {
     return FileDefPtr(upb_filedef_dep(ptr_, index));
   }
 
@@ -500,23 +414,23 @@ class SymbolTable {
   std::unique_ptr<upb_symtab, decltype(&upb_symtab_free)> ptr_;
 };
 
-inline MessageDefPtr FieldDefPtr::message_subdef() const {
+inline MessageDefPtr FieldDefPtr::message_subdef() {
   return MessageDefPtr(upb_fielddef_msgsubdef(ptr_));
 }
 
-inline MessageDefPtr FieldDefPtr::containing_type() const {
+inline MessageDefPtr FieldDefPtr::containing_type() {
   return MessageDefPtr(upb_fielddef_containingtype(ptr_));
 }
 
-inline MessageDefPtr OneofDefPtr::containing_type() const {
+inline MessageDefPtr OneofDefPtr::containing_type() {
   return MessageDefPtr(upb_oneofdef_containingtype(ptr_));
 }
 
-inline OneofDefPtr FieldDefPtr::containing_oneof() const {
+inline OneofDefPtr FieldDefPtr::containing_oneof() {
   return OneofDefPtr(upb_fielddef_containingoneof(ptr_));
 }
 
-inline EnumDefPtr FieldDefPtr::enum_subdef() const {
+inline EnumDefPtr FieldDefPtr::enum_subdef() {
   return EnumDefPtr(upb_fielddef_enumsubdef(ptr_));
 }
 

--- a/upb/handlers.c
+++ b/upb/handlers.c
@@ -359,7 +359,7 @@ struct upb_handlercache {
 
 const upb_handlers *upb_handlercache_get(upb_handlercache *c,
                                          const upb_msgdef *md) {
-  upb_msg_field_iter i;
+  int i, n;
   upb_value v;
   upb_handlers *h;
 
@@ -377,10 +377,9 @@ const upb_handlers *upb_handlercache_get(upb_handlercache *c,
 
   /* For each submessage field, get or create a handlers object and set it as
    * the subhandlers. */
-  for(upb_msg_field_begin(&i, md);
-      !upb_msg_field_done(&i);
-      upb_msg_field_next(&i)) {
-    upb_fielddef *f = upb_msg_iter_field(&i);
+  n = upb_msgdef_fieldcount(md);
+  for (i = 0; i < n; i++) {
+    const upb_fielddef *f = upb_msgdef_field(md, i);
 
     if (upb_fielddef_issubmsg(f)) {
       const upb_msgdef *subdef = upb_fielddef_msgsubdef(f);

--- a/upb/json/parser.rl
+++ b/upb/json/parser.rl
@@ -2858,7 +2858,7 @@ static void json_parser_reset(upb_json_parser *p) {
 
 static upb_json_parsermethod *parsermethod_new(upb_json_codecache *c,
                                                const upb_msgdef *md) {
-  upb_msg_field_iter i;
+  int i, n;
   upb_alloc *alloc = upb_arena_alloc(c->arena);
 
   upb_json_parsermethod *m = upb_malloc(alloc, sizeof(*m));
@@ -2873,10 +2873,9 @@ static upb_json_parsermethod *parsermethod_new(upb_json_codecache *c,
 
   /* Build name_table */
 
-  for(upb_msg_field_begin(&i, md);
-      !upb_msg_field_done(&i);
-      upb_msg_field_next(&i)) {
-    const upb_fielddef *f = upb_msg_iter_field(&i);
+  n = upb_msgdef_fieldcount(md);
+  for(i = 0; i < n; i++) {
+    const upb_fielddef *f = upb_msgdef_field(md, i);
     upb_value v = upb_value_constptr(f);
     const char *name;
 
@@ -2965,7 +2964,7 @@ const upb_json_parsermethod *upb_json_codecache_get(upb_json_codecache *c,
                                                     const upb_msgdef *md) {
   upb_json_parsermethod *m;
   upb_value v;
-  upb_msg_field_iter i;
+  int i, n;
   upb_alloc *alloc = upb_arena_alloc(c->arena);
 
   if (upb_inttable_lookupptr(&c->methods, md, &v)) {
@@ -2980,10 +2979,9 @@ const upb_json_parsermethod *upb_json_codecache_get(upb_json_codecache *c,
 
   /* Populate parser methods for all submessages, so the name tables will
    * be available during parsing. */
-  for(upb_msg_field_begin(&i, md);
-      !upb_msg_field_done(&i);
-      upb_msg_field_next(&i)) {
-    upb_fielddef *f = upb_msg_iter_field(&i);
+  n = upb_msgdef_fieldcount(md);
+  for(i = 0; i < n; i++) {
+    const upb_fielddef *f = upb_msgdef_field(md, i);
 
     if (upb_fielddef_issubmsg(f)) {
       const upb_msgdef *subdef = upb_fielddef_msgsubdef(f);

--- a/upb/json/printer.c
+++ b/upb/json/printer.c
@@ -1124,16 +1124,16 @@ void printer_sethandlers_timestamp(const void *closure, upb_handlers *h) {
 
 void printer_sethandlers_value(const void *closure, upb_handlers *h) {
   const upb_msgdef *md = upb_handlers_msgdef(h);
-  upb_msg_field_iter i;
+  int i, n;
 
   upb_handlerattr empty_attr = UPB_HANDLERATTR_INIT;
 
   upb_handlers_setstartmsg(h, printer_startmsg_noframe, &empty_attr);
   upb_handlers_setendmsg(h, printer_endmsg_noframe, &empty_attr);
 
-  upb_msg_field_begin(&i, md);
-  for(; !upb_msg_field_done(&i); upb_msg_field_next(&i)) {
-    const upb_fielddef *f = upb_msg_iter_field(&i);
+  n = upb_msgdef_fieldcount(md);
+  for (i = 0; i < n; i++) {
+    const upb_fielddef *f = upb_msgdef_field(md, i);
 
     switch (upb_fielddef_type(f)) {
       case UPB_TYPE_ENUM:
@@ -1222,7 +1222,7 @@ void printer_sethandlers(const void *closure, upb_handlers *h) {
   const upb_msgdef *md = upb_handlers_msgdef(h);
   bool is_mapentry = upb_msgdef_mapentry(md);
   upb_handlerattr empty_attr = UPB_HANDLERATTR_INIT;
-  upb_msg_field_iter i;
+  int i, n;
   const upb_json_printercache *cache = closure;
   const bool preserve_fieldnames = cache->preserve_fieldnames;
 
@@ -1287,9 +1287,9 @@ void printer_sethandlers(const void *closure, upb_handlers *h) {
     }                                                                         \
     break;
 
-  upb_msg_field_begin(&i, md);
-  for(; !upb_msg_field_done(&i); upb_msg_field_next(&i)) {
-    const upb_fielddef *f = upb_msg_iter_field(&i);
+  n = upb_msgdef_fieldcount(md);
+  for (i = 0; i < n; i++) {
+    const upb_fielddef *f = upb_msgdef_field(md, i);
 
     upb_handlerattr name_attr = UPB_HANDLERATTR_INIT;
     name_attr.handler_data = newstrpc(h, f, preserve_fieldnames);

--- a/upb/json_encode.c
+++ b/upb/json_encode.c
@@ -648,10 +648,10 @@ static void jsonenc_msgfields(jsonenc *e, const upb_msg *msg,
 
   if (e->options & UPB_JSONENC_EMITDEFAULTS) {
     /* Iterate over all fields. */
-    upb_msg_field_iter i;
-    for (upb_msg_field_begin(&i, m); !upb_msg_field_done(&i);
-         upb_msg_field_next(&i)) {
-      f = upb_msg_iter_field(&i);
+    int i = 0;
+    int n = upb_msgdef_fieldcount(m);
+    for (i = 0; i < n; i++) {
+      f = upb_msgdef_field(m, i);
       jsonenc_fieldval(e, f, upb_msg_get(msg, f), &first);
     }
   } else {

--- a/upb/pb/compile_decoder.c
+++ b/upb/pb/compile_decoder.c
@@ -701,7 +701,7 @@ static void compile_method(compiler *c, upb_pbdecodermethod *method) {
   const upb_handlers *h;
   const upb_msgdef *md;
   uint32_t* start_pc;
-  upb_msg_field_iter i;
+  int i, n;
   upb_value val;
 
   UPB_ASSERT(method);
@@ -718,10 +718,9 @@ static void compile_method(compiler *c, upb_pbdecodermethod *method) {
   putsel(c, OP_STARTMSG, UPB_STARTMSG_SELECTOR, h);
  label(c, LABEL_FIELD);
   start_pc = c->pc;
-  for(upb_msg_field_begin(&i, md);
-      !upb_msg_field_done(&i);
-      upb_msg_field_next(&i)) {
-    const upb_fielddef *f = upb_msg_iter_field(&i);
+  n = upb_msgdef_fieldcount(md);
+  for(i = 0; i < n; i++) {
+    const upb_fielddef *f = upb_msgdef_field(md, i);
     upb_fieldtype_t type = upb_fielddef_type(f);
 
     if (type == UPB_TYPE_MESSAGE && !(haslazyhandlers(h, f) && c->lazy)) {
@@ -765,7 +764,7 @@ static void compile_method(compiler *c, upb_pbdecodermethod *method) {
  * Generates a new method for every destination handlers reachable from "h". */
 static void find_methods(compiler *c, const upb_handlers *h) {
   upb_value v;
-  upb_msg_field_iter i;
+  int i, n;
   const upb_msgdef *md;
   upb_pbdecodermethod *method;
 
@@ -777,10 +776,9 @@ static void find_methods(compiler *c, const upb_handlers *h) {
 
   /* Find submethods. */
   md = upb_handlers_msgdef(h);
-  for(upb_msg_field_begin(&i, md);
-      !upb_msg_field_done(&i);
-      upb_msg_field_next(&i)) {
-    const upb_fielddef *f = upb_msg_iter_field(&i);
+  n = upb_msgdef_fieldcount(md);
+  for (i = 0; i < n; i++) {
+    const upb_fielddef *f = upb_msgdef_field(md, i);
     const upb_handlers *sub_h;
     if (upb_fielddef_type(f) == UPB_TYPE_MESSAGE &&
         (sub_h = upb_handlers_getsubhandlers(h, f)) != NULL) {

--- a/upb/pb/encoder.c
+++ b/upb/pb/encoder.c
@@ -437,7 +437,7 @@ T(sint64,   int64_t,  upb_zzenc_64, encode_varint)
 #include <stdio.h>
 static void newhandlers_callback(const void *closure, upb_handlers *h) {
   const upb_msgdef *m;
-  upb_msg_field_iter i;
+  int i, n;
 
   UPB_UNUSED(closure);
 
@@ -446,10 +446,9 @@ static void newhandlers_callback(const void *closure, upb_handlers *h) {
   upb_handlers_setunknown(h, encode_unknown, NULL);
 
   m = upb_handlers_msgdef(h);
-  for(upb_msg_field_begin(&i, m);
-      !upb_msg_field_done(&i);
-      upb_msg_field_next(&i)) {
-    const upb_fielddef *f = upb_msg_iter_field(&i);
+  n = upb_msgdef_fieldcount(m);
+  for(i = 0; i < n; i++) {
+    const upb_fielddef *f = upb_msgdef_field(m, i);
     bool packed = upb_fielddef_isseq(f) && upb_fielddef_isprimitive(f) &&
                   upb_fielddef_packed(f);
     upb_handlerattr attr = UPB_HANDLERATTR_INIT;

--- a/upb/pb/textprinter.c
+++ b/upb/pb/textprinter.c
@@ -252,16 +252,15 @@ err:
 
 static void onmreg(const void *c, upb_handlers *h) {
   const upb_msgdef *m = upb_handlers_msgdef(h);
-  upb_msg_field_iter i;
+  int i, n;
   UPB_UNUSED(c);
 
   upb_handlers_setstartmsg(h, textprinter_startmsg, NULL);
   upb_handlers_setendmsg(h, textprinter_endmsg, NULL);
 
-  for(upb_msg_field_begin(&i, m);
-      !upb_msg_field_done(&i);
-      upb_msg_field_next(&i)) {
-    upb_fielddef *f = upb_msg_iter_field(&i);
+  n = upb_msgdef_fieldcount(m);
+  for(i = 0; i < n; i++) {
+    const upb_fielddef *f = upb_msgdef_field(m, i);
     upb_handlerattr attr = UPB_HANDLERATTR_INIT;
     attr.handler_data = f;
     switch (upb_fielddef_type(f)) {

--- a/upb/reflection.c
+++ b/upb/reflection.c
@@ -207,11 +207,12 @@ void upb_msg_clear(upb_msg *msg, const upb_msgdef *m) {
 bool upb_msg_next(const upb_msg *msg, const upb_msgdef *m,
                   const upb_symtab *ext_pool, const upb_fielddef **out_f,
                   upb_msgval *out_val, size_t *iter) {
-  size_t i = *iter;
+  int i = *iter;
+  int n = upb_msgdef_fieldcount(m);
   const upb_msgval zero = {0};
-  const upb_fielddef *f;
   UPB_UNUSED(ext_pool);
-  while ((f = _upb_msgdef_field(m, (int)++i)) != NULL) {
+  while (++i < n) {
+    const upb_fielddef *f = upb_msgdef_field(m, i);
     upb_msgval val = _upb_msg_getraw(msg, f);
 
     /* Skip field if unset or empty. */


### PR DESCRIPTION
Old iteration over fields:

```
  upb_msg_field_iter i;
  for(upb_msg_field_begin(&i, m);
      !upb_msg_field_done(&i);	
      upb_msg_field_next(&i)) {	
    const upb_fielddef *f = upb_msg_iter_field(&i);	
    // ...	
  }
```

New iteration over fields:

```
  int i, n;
  n = upb_msgdef_fieldcount(m);
  for (int i = 0; i < n; i++) {
    const upb_fielddef *f = upb_msgdef_field(m, i);
    // ...
  }  
```

This change brings upb more into line with proto2's APIs. The new APIs are simpler and more predictable as they follow .proto file ordering.

The old functions are deprecated. They will be removed once legacy callers (primarily Ruby & PHP) have been updated to the new APIs.