### PR TITLE
Fixed bug in addunknown and added ASAN poisoning.

### DIFF
--- a/tests/bindings/lua/test_upb.lua
+++ b/tests/bindings/lua/test_upb.lua
@@ -481,6 +481,13 @@ function test_numeric_map()
   end
 end
 
+function test_unknown()
+  local bytes = string.rep("\x38\x00", 10000)
+  for i=1,1000 do
+    local msg = upb.decode(test_messages_proto3.TestAllTypesProto3, bytes)
+  end
+end
+
 function test_foo()
   local symtab = upb.SymbolTable()
   local filename = "external/com_google_protobuf/descriptor_proto-descriptor-set.proto.bin"

--- a/upb/msg.c
+++ b/upb/msg.c
@@ -36,11 +36,12 @@ bool _upb_msg_addunknown(upb_msg *msg, const char *data, size_t len,
     in->unknown->len = 0;
   } else if (in->unknown->size - in->unknown->len < len) {
     size_t need = in->unknown->len + len;
-    size_t size = in->unknown->size;;
+    size_t size = in->unknown->size;
     while (size < need)  size *= 2;
     in->unknown = upb_arena_realloc(
         arena, in->unknown, in->unknown->size + overhead, size + overhead);
     if (!in->unknown) return false;
+    in->unknown->size = size;
   }
   memcpy(UPB_PTR_AT(in->unknown + 1, in->unknown->len, char), data, len);
   in->unknown->len += len;

--- a/upb/port_def.inc
+++ b/upb/port_def.inc
@@ -182,7 +182,6 @@ int msvc_vsnprintf(char* s, size_t n, const char* format, va_list arg);
 #define UPB_NAN (0.0 / 0.0)
 #endif
 
-// User code should use macros instead of functions.
 #if defined(__SANITIZE_ADDRESS__)
 #define UPB_ASAN 1
 #ifdef __cplusplus

--- a/upb/port_def.inc
+++ b/upb/port_def.inc
@@ -181,3 +181,26 @@ int msvc_vsnprintf(char* s, size_t n, const char* format, va_list arg);
 #else
 #define UPB_NAN (0.0 / 0.0)
 #endif
+
+// User code should use macros instead of functions.
+#if defined(__SANITIZE_ADDRESS__)
+#define UPB_ASAN 1
+#ifdef __cplusplus
+extern "C" {
+#endif
+void __asan_poison_memory_region(void const volatile *addr, size_t size);
+void __asan_unpoison_memory_region(void const volatile *addr, size_t size);
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif
+#define UPB_POISON_MEMORY_REGION(addr, size) \
+  __asan_poison_memory_region((addr), (size))
+#define UPB_UNPOISON_MEMORY_REGION(addr, size) \
+  __asan_unpoison_memory_region((addr), (size))
+#else
+#define UPB_ASAN 0
+#define UPB_POISON_MEMORY_REGION(addr, size) \
+  ((void)(addr), (void)(size))
+#define UPB_UNPOISON_MEMORY_REGION(addr, size) \
+  ((void)(addr), (void)(size))
+#endif 

--- a/upb/port_undef.inc
+++ b/upb/port_undef.inc
@@ -28,3 +28,4 @@
 #undef _upb_va_copy
 #undef UPB_POISON_MEMORY_REGION
 #undef UPB_UNPOISON_MEMORY_REGION
+#undef UPB_ASAN

--- a/upb/port_undef.inc
+++ b/upb/port_undef.inc
@@ -26,3 +26,5 @@
 #undef _upb_snprintf
 #undef _upb_vsnprintf
 #undef _upb_va_copy
+#undef UPB_POISON_MEMORY_REGION
+#undef UPB_UNPOISON_MEMORY_REGION


### PR DESCRIPTION
ASAN poisoning will help detect errors where users are reading/writing past their arena allocation.

For now we don't poison initial blocks, because then we would have to track them.

The next step would be to track the `upb_alloc*` of each block, so initial blocks can have a `upb_alloc*` of `NULL`. This will also solve the bug of fusing arenas with different allocators.

ASAN poisoning showed a bug in `_upb_msg_addunknown`, which I fixed.