### PR TITLE
Updated to a new version of protobuf and fixed a few conformance tests.

### DIFF
--- a/bazel/workspace_deps.bzl
+++ b/bazel/workspace_deps.bzl
@@ -16,7 +16,7 @@ def upb_deps():
         git_repository,
         name = "com_google_protobuf",
         remote = "https://github.com/protocolbuffers/protobuf.git",
-        commit = "5f5efe50c5bef20042645b51a697f58b0704ac89",  # Need to use Git until proto3 optional is released
+        commit = "c8f76331abf682c289fa79f05b2ee39cc7bf5a48",  # Need to use Git until proto3 optional is released
     )
 
     maybe(

--- a/upb/json_decode.c
+++ b/upb/json_decode.c
@@ -798,12 +798,14 @@ static upb_msgval jsondec_enum(jsondec *d, const upb_fielddef *f) {
       return val;
     }
     case JD_NULL: {
-      UPB_ASSERT(jsondec_isnullvalue(f));
-      jsondec_null(d);
-      upb_msgval val;
-      val.int32_val = 0;
-      return val;
+      if (jsondec_isnullvalue(f)) {
+        upb_msgval val;
+        jsondec_null(d);
+        val.int32_val = 0;
+        return val;
+      }
     }
+      /* Fallthrough. */
     default:
       return jsondec_int(d, f);
   }

--- a/upb/json_encode.c
+++ b/upb/json_encode.c
@@ -167,12 +167,17 @@ static void jsonenc_duration(jsonenc *e, const upb_msg *msg, const upb_msgdef *m
 
 static void jsonenc_enum(int32_t val, const upb_fielddef *f, jsonenc *e) {
   const upb_enumdef *e_def = upb_fielddef_enumsubdef(f);
-  const char *name = upb_enumdef_iton(e_def, val);
 
-  if (name) {
-    jsonenc_printf(e, "\"%s\"", name);
+  if (strcmp(upb_enumdef_fullname(e_def), "google.protobuf.NullValue") == 0) {
+    jsonenc_putstr(e, "null");
   } else {
-    jsonenc_printf(e, "%" PRId32, val);
+    const char *name = upb_enumdef_iton(e_def, val);
+
+    if (name) {
+      jsonenc_printf(e, "\"%s\"", name);
+    } else {
+      jsonenc_printf(e, "%" PRId32, val);
+    }
   }
 }
 


### PR DESCRIPTION
When `google.protobuf.NullValue` appears on its own, we need to parse
and serialize it as plain JSON "null" value.