### PR TITLE
Benchmarks for descriptor loading time.

### DIFF
--- a/tests/benchmark.cc
+++ b/tests/benchmark.cc
@@ -30,7 +30,7 @@ static void BM_ArenaInitialBlockOneAlloc(benchmark::State& state) {
 }
 BENCHMARK(BM_ArenaInitialBlockOneAlloc);
 
-static void BM_LoadDescriptor(benchmark::State& state) {
+static void BM_LoadDescriptor_Upb(benchmark::State& state) {
   for (auto _ : state) {
     upb::SymbolTable symtab;
     upb::Arena arena;
@@ -44,7 +44,24 @@ static void BM_LoadDescriptor(benchmark::State& state) {
     }
   }
 }
-BENCHMARK(BM_LoadDescriptor);
+BENCHMARK(BM_LoadDescriptor_Upb);
+
+static void BM_LoadDescriptor_Proto2(benchmark::State& state) {
+  for (auto _ : state) {
+    protobuf::Arena arena;
+    protobuf::StringPiece input(descriptor.data,descriptor.size);
+    auto proto = protobuf::Arena::CreateMessage<protobuf::FileDescriptorProto>(
+        &arena);
+    protobuf::DescriptorPool pool;
+    bool ok = proto->ParseFrom<protobuf::MessageLite::kMergePartial>(input) &&
+              pool.BuildFile(*proto) != nullptr;
+    if (!ok) {
+      printf("Failed to add file.\n");
+      exit(1);
+    }
+  }
+}
+BENCHMARK(BM_LoadDescriptor_Proto2);
 
 static void BM_ParseDescriptor_Upb_LargeInitialBlock(benchmark::State& state) {
   size_t bytes = 0;

--- a/tests/benchmark.cc
+++ b/tests/benchmark.cc
@@ -43,6 +43,7 @@ static void BM_LoadDescriptor_Upb(benchmark::State& state) {
       exit(1);
     }
   }
+  state.SetBytesProcessed(state.iterations() * descriptor.size);
 }
 BENCHMARK(BM_LoadDescriptor_Upb);
 
@@ -60,6 +61,7 @@ static void BM_LoadDescriptor_Proto2(benchmark::State& state) {
       exit(1);
     }
   }
+  state.SetBytesProcessed(state.iterations() * descriptor.size);
 }
 BENCHMARK(BM_LoadDescriptor_Proto2);
 

--- a/tests/benchmark.cc
+++ b/tests/benchmark.cc
@@ -4,6 +4,7 @@
 #include "google/protobuf/descriptor.upb.h"
 #include "google/protobuf/descriptor.upbdefs.h"
 #include "google/protobuf/descriptor.pb.h"
+#include "upb/def.hpp"
 
 upb_strview descriptor = google_protobuf_descriptor_proto_upbdefinit.descriptor;
 namespace protobuf = ::google::protobuf;
@@ -28,6 +29,22 @@ static void BM_ArenaInitialBlockOneAlloc(benchmark::State& state) {
   }
 }
 BENCHMARK(BM_ArenaInitialBlockOneAlloc);
+
+static void BM_LoadDescriptor(benchmark::State& state) {
+  for (auto _ : state) {
+    upb::SymbolTable symtab;
+    upb::Arena arena;
+    google_protobuf_FileDescriptorProto* file_proto =
+        google_protobuf_FileDescriptorProto_parse(descriptor.data,
+                                                  descriptor.size, arena.ptr());
+    upb::FileDefPtr file_def = symtab.AddFile(file_proto, NULL);
+    if (!file_def) {
+      printf("Failed to add file.\n");
+      exit(1);
+    }
+  }
+}
+BENCHMARK(BM_LoadDescriptor);
 
 static void BM_ParseDescriptor_Upb_LargeInitialBlock(benchmark::State& state) {
   size_t bytes = 0;


### PR DESCRIPTION
Current output on my machine:

```
-----------------------------------------------------------------------------------------
Benchmark                                                  Time           CPU Iterations
-----------------------------------------------------------------------------------------
BM_ArenaOneAlloc                                          21 ns         21 ns   33344552
BM_ArenaInitialBlockOneAlloc                               6 ns          6 ns  115948084
BM_LoadDescriptor_Upb                                 107286 ns     107275 ns       6512   67.5731MB/s
BM_LoadDescriptor_Proto2                              240539 ns     240537 ns       2909   30.1362MB/s
BM_ParseDescriptor_Upb_LargeInitialBlock               11500 ns      11499 ns      60864   630.377MB/s
BM_ParseDescriptor_Upb                                 11920 ns      11920 ns      58676   608.123MB/s
BM_ParseDescriptor_Proto2_NoArena                      31338 ns      31336 ns      22389   231.325MB/s
BM_ParseDescriptor_Proto2_Arena                        21622 ns      21622 ns      32472    335.26MB/s
BM_ParseDescriptor_Proto2_Arena_LargeInitialBlock      17799 ns      17798 ns      39266   407.288MB/s
BM_SerializeDescriptor_Proto2                           4943 ns       4942 ns     141050   1.43252GB/s
BM_SerializeDescriptor_Upb                             12262 ns      12261 ns      57131   591.195MB/s
```