### PR TITLE
Drop C89/C90 support and MSVC prior to Visual Studio 2015.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -6,8 +6,8 @@ load(
 load(
     "//bazel:upb_proto_library.bzl",
     "upb_proto_library",
-    "upb_proto_reflection_library",
     "upb_proto_library_copts",
+    "upb_proto_reflection_library",
 )
 
 # copybara:strip_for_google3_begin
@@ -49,6 +49,7 @@ cc_library(
     srcs = [
         "upb/port.c",
     ],
+    copts = UPB_DEFAULT_COPTS,
     textual_hdrs = [
         "upb/port_def.inc",
         "upb/port_undef.inc",

--- a/BUILD
+++ b/BUILD
@@ -7,6 +7,7 @@ load(
     "//bazel:upb_proto_library.bzl",
     "upb_proto_library",
     "upb_proto_reflection_library",
+    "upb_proto_library_copts",
 )
 
 # copybara:strip_for_google3_begin
@@ -33,6 +34,12 @@ config_setting(
 config_setting(
     name = "windows",
     constraint_values = ["@bazel_tools//platforms:windows"],
+)
+
+upb_proto_library_copts(
+    name = "upb_proto_library_copts__for_generated_code_only_do_not_use",
+    copts = UPB_DEFAULT_COPTS,
+    visibility = ["//visibility:public"],
 )
 
 # Public C/C++ libraries #######################################################

--- a/BUILD
+++ b/BUILD
@@ -250,6 +250,7 @@ genrule(
     outs = ["upb/json/parser.c"],
     cmd = "$(location @ragel//:ragelc) -C -o upb/json/parser.c $< && mv upb/json/parser.c $@",
     tools = ["@ragel//:ragelc"],
+    visibility = ["//cmake:__pkg__"],
 )
 
 # Amalgamation #################################################################

--- a/bazel/build_defs.bzl
+++ b/bazel/build_defs.bzl
@@ -18,6 +18,7 @@ UPB_DEFAULT_COPTS = select({
     "//:windows": [],
     "//conditions:default": [
         # copybara:strip_for_google3_begin
+        "-std=c99",
         "-pedantic",
         "-Werror=pedantic",
         "-Wstrict-prototypes",

--- a/bazel/upb_proto_library.bzl
+++ b/bazel/upb_proto_library.bzl
@@ -52,7 +52,7 @@ def _filter_none(elems):
             out.append(elem)
     return out
 
-def _cc_library_func(ctx, name, hdrs, srcs, dep_ccinfos):
+def _cc_library_func(ctx, name, hdrs, srcs, copts, dep_ccinfos):
     """Like cc_library(), but callable from rules.
 
     Args:
@@ -88,6 +88,7 @@ def _cc_library_func(ctx, name, hdrs, srcs, dep_ccinfos):
         name = name,
         srcs = srcs,
         public_hdrs = hdrs,
+        user_compile_flags = copts,
         compilation_contexts = compilation_contexts,
         **blaze_only_args
     )
@@ -105,6 +106,22 @@ def _cc_library_func(ctx, name, hdrs, srcs, dep_ccinfos):
         compilation_context = compilation_context,
         linking_context = linking_context,
     )
+
+# Dummy rule to expose select() copts to aspects  ##############################
+
+_UpbProtoLibraryCopts = provider(
+    fields = {
+        "copts": "copts for upb_proto_library()",
+    },
+)
+
+def upb_proto_library_copts_impl(ctx):
+    return _UpbProtoLibraryCopts(copts = ctx.attr.copts)
+
+upb_proto_library_copts = rule(
+    implementation = upb_proto_library_copts_impl,
+    attrs = {"copts": attr.string_list(default = [])},
+)
 
 # upb_proto_library / upb_proto_reflection_library shared code #################
 
@@ -199,6 +216,7 @@ def _upb_proto_aspect_impl(target, ctx, cc_provider, file_provider):
         name = ctx.rule.attr.name + ctx.attr._ext,
         hdrs = files.hdrs,
         srcs = files.srcs,
+        copts = ctx.attr._copts[_UpbProtoLibraryCopts].copts,
         dep_ccinfos = dep_ccinfos,
     )
     return [cc_provider(cc_info = cc_info), file_provider(srcs = files)]
@@ -222,6 +240,9 @@ def _maybe_add(d):
 
 _upb_proto_library_aspect = aspect(
     attrs = _maybe_add({
+        "_copts": attr.label(
+            default = "//:upb_proto_library_copts__for_generated_code_only_do_not_use",
+        ),
         "_upbc": attr.label(
             executable = True,
             cfg = "host",
@@ -267,6 +288,9 @@ upb_proto_library = rule(
 
 _upb_proto_reflection_library_aspect = aspect(
     attrs = _maybe_add({
+        "_copts": attr.label(
+            default = "//:upb_proto_library_copts__for_generated_code_only_do_not_use",
+        ),
         "_upbc": attr.label(
             executable = True,
             cfg = "host",

--- a/cmake/BUILD
+++ b/cmake/BUILD
@@ -37,7 +37,7 @@ genrule(
 
 genrule(
     name = "copy_json_ragel",
-    srcs = ["upb/json/parser.c"],
+    srcs = ["//:upb/json/parser.c"],
     outs = ["generated-in/upb/json/parser.c"],
     cmd = "cp $< $@",
 )

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -12,6 +12,7 @@ cmake_minimum_required (VERSION 3.0)
 cmake_policy(SET CMP0048 NEW)
 
 project(upb)
+set(CMAKE_C_STANDARD 99)
 
 
 # Prevent CMake from setting -rdynamic on Linux (!!).

--- a/cmake/make_cmakelists.py
+++ b/cmake/make_cmakelists.py
@@ -166,6 +166,7 @@ class WorkspaceFileFunctions(object):
 
   def workspace(self, **kwargs):
     self.converter.prelude += "project(%s)\n" % (kwargs["name"])
+    self.converter.prelude += "set(CMAKE_C_STANDARD 99)\n"
 
   def http_archive(self, **kwargs):
     pass

--- a/cmake/make_cmakelists.py
+++ b/cmake/make_cmakelists.py
@@ -129,6 +129,9 @@ class BuildFileFunctions(object):
   def upb_proto_library(self, **kwargs):
     pass
 
+  def upb_proto_library_copts(self, **kwargs):
+    pass
+
   def upb_proto_reflection_library(self, **kwargs):
     pass
 

--- a/cmake/upb/json/parser.c
+++ b/cmake/upb/json/parser.c
@@ -953,7 +953,7 @@ static bool parse_number_from_buffer(upb_json_parser *p, const char *buf,
   upb_fieldtype_t type = upb_fielddef_type(p->top->f);
   double val;
   double dummy;
-  double inf = UPB_INFINITY;
+  double inf = INFINITY;
 
   errno = 0;
 

--- a/examples/bazel/BUILD
+++ b/examples/bazel/BUILD
@@ -17,4 +17,5 @@ cc_binary(
     name = "test_binary",
     srcs = ["test_binary.c"],
     deps = [":foo_upbproto"],
+    copts = ["-std=c99"],
 )

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -50,6 +50,7 @@ upb_proto_library(
 cc_test(
     name = "test_generated_code",
     srcs = ["test_generated_code.c"],
+    copts = UPB_DEFAULT_COPTS,
     deps = [
         ":empty_upbdefs_proto",
         ":test_messages_proto3_proto_upb",

--- a/tests/bindings/lua/BUILD
+++ b/tests/bindings/lua/BUILD
@@ -2,6 +2,10 @@ load(
     "//upb/bindings/lua:lua_proto_library.bzl",
     "lua_proto_library",
 )
+load(
+    "//bazel:build_defs.bzl",
+    "UPB_DEFAULT_COPTS",
+)
 
 licenses(["notice"])
 
@@ -20,6 +24,7 @@ cc_test(
         "@com_google_protobuf//:conformance_proto",
         "@com_google_protobuf//:descriptor_proto",
     ],
+    copts = UPB_DEFAULT_COPTS,
     linkstatic = 1,
     deps = [
         "//upb/bindings/lua:lupb",

--- a/tests/bindings/lua/main.c
+++ b/tests/bindings/lua/main.c
@@ -34,7 +34,7 @@ const char *init =
     "upb/bindings/lua/?.lua"
   "'";
 
-int main() {
+int main(int argc, char **argv) {
   int ret = 0;
   L = luaL_newstate();
   luaL_openlibs(L);

--- a/tests/pb/test_decoder.cc
+++ b/tests/pb/test_decoder.cc
@@ -113,7 +113,7 @@ using std::string;
 
 void vappendf(string* str, const char *format, va_list args) {
   va_list copy;
-  _upb_va_copy(copy, args);
+  va_copy(copy, args);
 
   int count = vsnprintf(NULL, 0, format, args);
   if (count >= 0)

--- a/tests/test_generated_code.c
+++ b/tests/test_generated_code.c
@@ -24,7 +24,7 @@ const int32_t test_int32_2 = -20;
 const int32_t test_int32_3 = 30;
 const int32_t test_int32_4 = -40;
 
-static void test_scalars() {
+static void test_scalars(void) {
   upb_arena *arena = upb_arena_new();
   protobuf_test_messages_proto3_TestAllTypesProto3 *msg =
       protobuf_test_messages_proto3_TestAllTypesProto3_new(arena);
@@ -117,7 +117,7 @@ static void check_string_map_one_entry(
   ASSERT(!const_ent);
 }
 
-static void test_string_double_map() {
+static void test_string_double_map(void) {
   upb_arena *arena = upb_arena_new();
   upb_strview serialized;
   upb_test_MapTest *msg = upb_test_MapTest_new(arena);
@@ -141,7 +141,7 @@ static void test_string_double_map() {
   upb_arena_free(arena);
 }
 
-static void test_string_map() {
+static void test_string_map(void) {
   upb_arena *arena = upb_arena_new();
   protobuf_test_messages_proto3_TestAllTypesProto3 *msg =
       protobuf_test_messages_proto3_TestAllTypesProto3_new(arena);
@@ -259,7 +259,7 @@ static void check_int32_map_one_entry(
   ASSERT(!const_ent);
 }
 
-static void test_int32_map() {
+static void test_int32_map(void) {
   upb_arena *arena = upb_arena_new();
   protobuf_test_messages_proto3_TestAllTypesProto3 *msg =
       protobuf_test_messages_proto3_TestAllTypesProto3_new(arena);
@@ -328,7 +328,7 @@ static void test_int32_map() {
   upb_arena_free(arena);
 }
 
-void test_repeated() {
+void test_repeated(void) {
   upb_arena *arena = upb_arena_new();
   protobuf_test_messages_proto3_TestAllTypesProto3 *msg =
       protobuf_test_messages_proto3_TestAllTypesProto3_new(arena);
@@ -347,7 +347,7 @@ void test_repeated() {
   upb_arena_free(arena);
 }
 
-void test_null_decode_buf() {
+void test_null_decode_buf(void) {
   upb_arena *arena = upb_arena_new();
   protobuf_test_messages_proto3_TestAllTypesProto3 *msg =
       protobuf_test_messages_proto3_TestAllTypesProto3_parse(NULL, 0, arena);
@@ -359,7 +359,7 @@ void test_null_decode_buf() {
   upb_arena_free(arena);
 }
 
-void test_status_truncation() {
+void test_status_truncation(void) {
   int i, j;
   upb_status status;
   upb_status status2;

--- a/upb/json/parser.rl
+++ b/upb/json/parser.rl
@@ -951,7 +951,7 @@ static bool parse_number_from_buffer(upb_json_parser *p, const char *buf,
   upb_fieldtype_t type = upb_fielddef_type(p->top->f);
   double val;
   double dummy;
-  double inf = UPB_INFINITY;
+  double inf = INFINITY;
 
   errno = 0;
 

--- a/upb/json/printer.c
+++ b/upb/json/printer.c
@@ -7,7 +7,9 @@
 
 #include <ctype.h>
 #include <inttypes.h>
+#include <math.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <string.h>
 #include <time.h>
 
@@ -139,7 +141,7 @@ static void putstring(upb_json_printer *p, const char *buf, size_t len) {
       char escape_buf[8];
       if (!escape) {
         unsigned char byte = (unsigned char)c;
-        _upb_snprintf(escape_buf, sizeof(escape_buf), "\\u%04x", (int)byte);
+        snprintf(escape_buf, sizeof(escape_buf), "\\u%04x", (int)byte);
         escape = escape_buf;
       }
 
@@ -178,53 +180,53 @@ const char neginf[] = "\"-Infinity\"";
 const char inf[] = "\"Infinity\"";
 
 static size_t fmt_double(double val, char* buf, size_t length) {
-  if (val == UPB_INFINITY) {
+  if (val == INFINITY) {
     CHKLENGTH(length >= strlen(inf));
     strcpy(buf, inf);
     return strlen(inf);
-  } else if (val == -UPB_INFINITY) {
+  } else if (val == -INFINITY) {
     CHKLENGTH(length >= strlen(neginf));
     strcpy(buf, neginf);
     return strlen(neginf);
   } else {
-    size_t n = _upb_snprintf(buf, length, "%.17g", val);
+    size_t n = snprintf(buf, length, "%.17g", val);
     CHKLENGTH(n > 0 && n < length);
     return n;
   }
 }
 
 static size_t fmt_float(float val, char* buf, size_t length) {
-  size_t n = _upb_snprintf(buf, length, "%.8g", val);
+  size_t n = snprintf(buf, length, "%.8g", val);
   CHKLENGTH(n > 0 && n < length);
   return n;
 }
 
 static size_t fmt_bool(bool val, char* buf, size_t length) {
-  size_t n = _upb_snprintf(buf, length, "%s", (val ? "true" : "false"));
+  size_t n = snprintf(buf, length, "%s", (val ? "true" : "false"));
   CHKLENGTH(n > 0 && n < length);
   return n;
 }
 
 static size_t fmt_int64_as_number(int64_t val, char* buf, size_t length) {
-  size_t n = _upb_snprintf(buf, length, "%" PRId64, val);
+  size_t n = snprintf(buf, length, "%" PRId64, val);
   CHKLENGTH(n > 0 && n < length);
   return n;
 }
 
 static size_t fmt_uint64_as_number(uint64_t val, char* buf, size_t length) {
-  size_t n = _upb_snprintf(buf, length, "%" PRIu64, val);
+  size_t n = snprintf(buf, length, "%" PRIu64, val);
   CHKLENGTH(n > 0 && n < length);
   return n;
 }
 
 static size_t fmt_int64_as_string(int64_t val, char* buf, size_t length) {
-  size_t n = _upb_snprintf(buf, length, "\"%" PRId64 "\"", val);
+  size_t n = snprintf(buf, length, "\"%" PRId64 "\"", val);
   CHKLENGTH(n > 0 && n < length);
   return n;
 }
 
 static size_t fmt_uint64_as_string(uint64_t val, char* buf, size_t length) {
-  size_t n = _upb_snprintf(buf, length, "\"%" PRIu64 "\"", val);
+  size_t n = snprintf(buf, length, "\"%" PRIu64 "\"", val);
   CHKLENGTH(n > 0 && n < length);
   return n;
 }
@@ -870,12 +872,12 @@ static bool printer_enddurationmsg(void *closure, const void *handler_data,
     return false;
   }
 
-  _upb_snprintf(buffer, sizeof(buffer), "%ld", (long)p->seconds);
+  snprintf(buffer, sizeof(buffer), "%ld", (long)p->seconds);
   base_len = strlen(buffer);
 
   if (p->nanos != 0) {
     char nanos_buffer[UPB_DURATION_MAX_NANO_LEN + 3];
-    _upb_snprintf(nanos_buffer, sizeof(nanos_buffer), "%.9f",
+    snprintf(nanos_buffer, sizeof(nanos_buffer), "%.9f",
                   p->nanos / 1000000000.0);
     /* Remove trailing 0. */
     for (i = UPB_DURATION_MAX_NANO_LEN + 2;
@@ -949,8 +951,8 @@ static bool printer_endtimestampmsg(void *closure, const void *handler_data,
            "%Y-%m-%dT%H:%M:%S", gmtime(&time));
   if (p->nanos != 0) {
     char nanos_buffer[UPB_TIMESTAMP_MAX_NANO_LEN + 3];
-    _upb_snprintf(nanos_buffer, sizeof(nanos_buffer), "%.9f",
-                  p->nanos / 1000000000.0);
+    snprintf(nanos_buffer, sizeof(nanos_buffer), "%.9f",
+             p->nanos / 1000000000.0);
     /* Remove trailing 0. */
     for (i = UPB_TIMESTAMP_MAX_NANO_LEN + 2;
          nanos_buffer[i] == '0'; i--) {

--- a/upb/json_decode.c
+++ b/upb/json_decode.c
@@ -5,6 +5,7 @@
 #include <float.h>
 #include <inttypes.h>
 #include <limits.h>
+#include <math.h>
 #include <setjmp.h>
 #include <stdlib.h>
 #include <string.h>
@@ -747,11 +748,11 @@ static upb_msgval jsondec_double(jsondec *d, const upb_fielddef *f) {
     case JD_STRING:
       str = jsondec_string(d);
       if (jsondec_streql(str, "NaN")) {
-        val.double_val = UPB_NAN;
+        val.double_val = NAN;
       } else if (jsondec_streql(str, "Infinity")) {
-        val.double_val = UPB_INFINITY;
+        val.double_val = INFINITY;
       } else if (jsondec_streql(str, "-Infinity")) {
-        val.double_val = -UPB_INFINITY;
+        val.double_val = -INFINITY;
       } else {
         val.double_val = strtod(str.data, NULL);
       }
@@ -761,7 +762,7 @@ static upb_msgval jsondec_double(jsondec *d, const upb_fielddef *f) {
   }
 
   if (upb_fielddef_type(f) == UPB_TYPE_FLOAT) {
-    if (val.double_val != UPB_INFINITY && val.double_val != -UPB_INFINITY &&
+    if (val.double_val != INFINITY && val.double_val != -INFINITY &&
         (val.double_val > FLT_MAX || val.double_val < -FLT_MAX)) {
       jsondec_err(d, "Float out of range");
     }

--- a/upb/json_encode.c
+++ b/upb/json_encode.c
@@ -4,14 +4,16 @@
 #include <ctype.h>
 #include <float.h>
 #include <inttypes.h>
+#include <math.h>
+#include <setjmp.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
-#include <setjmp.h>
 
 #include "upb/decode.h"
 #include "upb/reflection.h"
 
+/* Must be last. */
 #include "upb/port_def.inc"
 
 typedef struct {
@@ -76,7 +78,7 @@ static void jsonenc_printf(jsonenc *e, const char *fmt, ...) {
   va_list args;
 
   va_start(args, fmt);
-  n = _upb_vsnprintf(e->ptr, have, fmt, args);
+  n = vsnprintf(e->ptr, have, fmt, args);
   va_end(args);
 
   if (UPB_LIKELY(have > n)) {
@@ -268,9 +270,9 @@ static void jsonenc_string(jsonenc *e, upb_strview str) {
 }
 
 static void jsonenc_double(jsonenc *e, const char *fmt, double val) {
-  if (val == UPB_INFINITY) {
+  if (val == INFINITY) {
     jsonenc_putstr(e, "\"Infinity\"");
-  } else if (val == -UPB_INFINITY) {
+  } else if (val == -INFINITY) {
     jsonenc_putstr(e, "\"-Infinity\"");
   } else if (val != val) {
     jsonenc_putstr(e, "\"NaN\"");

--- a/upb/pb/textprinter.c
+++ b/upb/pb/textprinter.c
@@ -105,8 +105,8 @@ bool putf(upb_textprinter *p, const char *fmt, ...) {
   va_start(args, fmt);
 
   /* Run once to get the length of the string. */
-  _upb_va_copy(args_copy, args);
-  len = _upb_vsnprintf(NULL, 0, fmt, args_copy);
+  va_copy(args_copy, args);
+  len = vsnprintf(NULL, 0, fmt, args_copy);
   va_end(args_copy);
 
   /* + 1 for NULL terminator (vsprintf() requires it even if we don't). */

--- a/upb/pb/varint.int.h
+++ b/upb/pb/varint.int.h
@@ -150,9 +150,7 @@ UPB_INLINE uint64_t upb_vencode32(uint32_t val) {
   uint64_t ret = 0;
   UPB_ASSERT(bytes <= 5);
   memcpy(&ret, buf, bytes);
-#ifdef UPB_BIG_ENDIAN
-  ret = byteswap64(ret);
-#endif
+  ret = _upb_be_swap64(ret);
   UPB_ASSERT(ret <= 0xffffffffffU);
   return ret;
 }

--- a/upb/port_def.inc
+++ b/upb/port_def.inc
@@ -20,6 +20,15 @@
 *
 * This file is private and must not be included by users!
 */
+
+#if !(__STDC_VERSION__ >= 199901L || __cplusplus >= 201103L)
+#error upb requires C99 or C++11
+#endif
+
+#if (defined(_MSC_VER) && _MSC_VER < 1900)
+#error upb requires MSVC >= 2015.
+#endif
+
 #include <stdint.h>
 #include <stddef.h>
 
@@ -68,12 +77,6 @@
 #define UPB_UNLIKELY(x) (x)
 #endif
 
-/* Define UPB_BIG_ENDIAN manually if you're on big endian and your compiler
- * doesn't provide these preprocessor symbols. */
-#if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
-#define UPB_BIG_ENDIAN
-#endif
-
 /* Macros for function attributes on compilers that support them. */
 #ifdef __GNUC__
 #define UPB_FORCEINLINE __inline__ __attribute__((always_inline))
@@ -87,49 +90,6 @@
 #define UPB_FORCEINLINE
 #define UPB_NOINLINE
 #define UPB_NORETURN
-#endif
-
-#if __STDC_VERSION__ >= 199901L || __cplusplus >= 201103L
-/* C99/C++11 versions. */
-#include <stdio.h>
-#define _upb_snprintf snprintf
-#define _upb_vsnprintf vsnprintf
-#define _upb_va_copy(a, b) va_copy(a, b)
-#elif defined(_MSC_VER)
-/* Microsoft C/C++ versions. */
-#include <stdarg.h>
-#include <stdio.h>
-#if _MSC_VER < 1900
-int msvc_snprintf(char* s, size_t n, const char* format, ...);
-int msvc_vsnprintf(char* s, size_t n, const char* format, va_list arg);
-#define UPB_MSVC_VSNPRINTF
-#define _upb_snprintf msvc_snprintf
-#define _upb_vsnprintf msvc_vsnprintf
-#else
-#define _upb_snprintf snprintf
-#define _upb_vsnprintf vsnprintf
-#endif
-#define _upb_va_copy(a, b) va_copy(a, b)
-#elif defined __GNUC__
-/* A few hacky workarounds for functions not in C89.
- * For internal use only!
- * TODO(haberman): fix these by including our own implementations, or finding
- * another workaround.
- */
-#define _upb_snprintf __builtin_snprintf
-#define _upb_vsnprintf __builtin_vsnprintf
-#define _upb_va_copy(a, b) __va_copy(a, b)
-#else
-#error Need implementations of [v]snprintf and va_copy
-#endif
-
-#ifdef __cplusplus
-#if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__) || \
-    (defined(_MSC_VER) && _MSC_VER >= 1900)
-/* C++11 is present */
-#else
-#error upb requires C++11 for C++ support
-#endif
 #endif
 
 #define UPB_MAX(x, y) ((x) > (y) ? (x) : (y))
@@ -159,27 +119,10 @@ int msvc_vsnprintf(char* s, size_t n, const char* format, va_list arg);
 #define UPB_ASSERT(expr) assert(expr)
 #endif
 
-/* UPB_ASSERT_DEBUGVAR(): assert that uses functions or variables that only
- * exist in debug mode.  This turns into regular assert. */
-#define UPB_ASSERT_DEBUGVAR(expr) assert(expr)
-
 #if defined(__GNUC__) || defined(__clang__)
 #define UPB_UNREACHABLE() do { assert(0); __builtin_unreachable(); } while(0)
 #else
 #define UPB_UNREACHABLE() do { assert(0); } while(0)
-#endif
-
-/* UPB_INFINITY representing floating-point positive infinity. */
-#include <math.h>
-#ifdef INFINITY
-#define UPB_INFINITY INFINITY
-#else
-#define UPB_INFINITY (1.0 / 0.0)
-#endif
-#ifdef NAN
-#define UPB_NAN NAN
-#else
-#define UPB_NAN (0.0 / 0.0)
 #endif
 
 #if defined(__SANITIZE_ADDRESS__)

--- a/upb/port_undef.inc
+++ b/upb/port_undef.inc
@@ -18,14 +18,7 @@
 #undef UPB_UNUSED
 #undef UPB_ASSUME
 #undef UPB_ASSERT
-#undef UPB_ASSERT_DEBUGVAR
 #undef UPB_UNREACHABLE
-#undef UPB_INFINITY
-#undef UPB_NAN
-#undef UPB_MSVC_VSNPRINTF
-#undef _upb_snprintf
-#undef _upb_vsnprintf
-#undef _upb_va_copy
 #undef UPB_POISON_MEMORY_REGION
 #undef UPB_UNPOISON_MEMORY_REGION
 #undef UPB_ASAN

--- a/upb/text_encode.c
+++ b/upb/text_encode.c
@@ -43,7 +43,7 @@ static void txtenc_printf(txtenc *e, const char *fmt, ...) {
   va_list args;
 
   va_start(args, fmt);
-  n = _upb_vsnprintf(e->ptr, have, fmt, args);
+  n = vsnprintf(e->ptr, have, fmt, args);
   va_end(args);
 
   if (UPB_LIKELY(have > n)) {

--- a/upb/upb.c
+++ b/upb/upb.c
@@ -40,7 +40,7 @@ void upb_status_seterrf(upb_status *status, const char *fmt, ...) {
 void upb_status_vseterrf(upb_status *status, const char *fmt, va_list args) {
   if (!status) return;
   status->ok = false;
-  _upb_vsnprintf(status->msg, sizeof(status->msg), fmt, args);
+  vsnprintf(status->msg, sizeof(status->msg), fmt, args);
   status->msg[UPB_STATUS_MAX_MESSAGE - 1] = '\0';
 }
 
@@ -49,7 +49,7 @@ void upb_status_vappenderrf(upb_status *status, const char *fmt, va_list args) {
   if (!status) return;
   status->ok = false;
   len = strlen(status->msg);
-  _upb_vsnprintf(status->msg + len, sizeof(status->msg) - len, fmt, args);
+  vsnprintf(status->msg + len, sizeof(status->msg) - len, fmt, args);
   status->msg[UPB_STATUS_MAX_MESSAGE - 1] = '\0';
 }
 


### PR DESCRIPTION
upb previously attempted to support C89 and pre-2015 versions
of Visual Studio. This was to support older compilers with
limited C99 support (particularly MSVC). But as of last August,
even gRPC has dropped support for MSVC prior to 2015
https://github.com/grpc/grpc.io/commit/c87276d058d4a8464204bd12b7892f0f3bf0071d

Therefore it seems safe for upb to no longer attempt C89 support
(we were already not truly C89 compliant, with our use of "bool").
We now explicitly require C99 or greater and MSVC 2015 or greater.

This cleaned up port_def.inc a fair bit. I took the chance to
also remove some obsolete macros.