### PR TITLE
Added benchmark for loading ads descriptor.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,7 @@
 workspace(name = "upb")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
 load("//bazel:workspace_deps.bzl", "upb_deps")
 
 upb_deps()
@@ -36,4 +37,12 @@ http_archive(
     urls = ["https://github.com/google/benchmark/archive/16703ff83c1ae6d53e5155df3bb3ab0bc96083be.zip"],
     strip_prefix = "benchmark-16703ff83c1ae6d53e5155df3bb3ab0bc96083be",
     sha256 = "59f918c8ccd4d74b6ac43484467b500f1d64b40cc1010daa055375b322a43ba3",
+)
+
+new_git_repository(
+    name = "com_google_googleapis",
+    remote = "https://github.com/googleapis/googleapis.git",
+    branch = "master",
+    build_file = "//benchmarks:BUILD.googleapis",
+    patch_cmds = ["find google -type f -name BUILD.bazel -delete"],
 )

--- a/benchmarks/BUILD
+++ b/benchmarks/BUILD
@@ -27,11 +27,6 @@ upb_proto_reflection_library(
 )
 
 cc_proto_library(
-    name = "ads_cc_proto",
-    deps = ["@com_google_googleapis//:ads_proto"],
-)
-
-cc_proto_library(
     name = "benchmark_descriptor_cc_proto",
     deps = [":benchmark_descriptor_proto"],
 )
@@ -55,7 +50,6 @@ cc_binary(
         ":benchmark_descriptor_sv_cc_proto",
         ":benchmark_descriptor_upb_proto",
         ":benchmark_descriptor_upb_proto_reflection",
-        ":ads_cc_proto",
         ":ads_upb_proto_reflection",
         "//:descriptor_upb_proto",
         "//:reflection",

--- a/benchmarks/BUILD
+++ b/benchmarks/BUILD
@@ -21,6 +21,16 @@ upb_proto_reflection_library(
     deps = [":benchmark_descriptor_proto"],
 )
 
+upb_proto_reflection_library(
+    name = "ads_upb_proto_reflection",
+    deps = ["@com_google_googleapis//:ads_proto"],
+)
+
+cc_proto_library(
+    name = "ads_cc_proto",
+    deps = ["@com_google_googleapis//:ads_proto"],
+)
+
 cc_proto_library(
     name = "benchmark_descriptor_cc_proto",
     deps = [":benchmark_descriptor_proto"],
@@ -45,6 +55,8 @@ cc_binary(
         ":benchmark_descriptor_sv_cc_proto",
         ":benchmark_descriptor_upb_proto",
         ":benchmark_descriptor_upb_proto_reflection",
+        ":ads_cc_proto",
+        ":ads_upb_proto_reflection",
         "//:descriptor_upb_proto",
         "//:reflection",
         "@com_github_google_benchmark//:benchmark_main",

--- a/benchmarks/BUILD.googleapis
+++ b/benchmarks/BUILD.googleapis
@@ -1,0 +1,29 @@
+load(
+    "@rules_proto//proto:defs.bzl",
+    "proto_library",
+)
+
+proto_library(
+    name = "ads_proto",
+    srcs = glob([
+        "google/ads/googleads/v5/**/*.proto",
+        "google/api/**/*.proto",
+        "google/rpc/**/*.proto",
+        "google/longrunning/**/*.proto",
+        "google/logging/**/*.proto",
+    ]),
+    #srcs = ["google/ads/googleads/v5/services/google_ads_service.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+       "@com_google_protobuf//:any_proto",
+       "@com_google_protobuf//:empty_proto",
+       "@com_google_protobuf//:descriptor_proto",
+       "@com_google_protobuf//:field_mask_proto",
+       "@com_google_protobuf//:duration_proto",
+       "@com_google_protobuf//:timestamp_proto",
+       "@com_google_protobuf//:struct_proto",
+       "@com_google_protobuf//:api_proto",
+       "@com_google_protobuf//:type_proto",
+       "@com_google_protobuf//:wrappers_proto",
+    ],
+)

--- a/cmake/make_cmakelists.py
+++ b/cmake/make_cmakelists.py
@@ -177,6 +177,9 @@ class WorkspaceFileFunctions(object):
   def git_repository(self, **kwargs):
     pass
 
+  def new_git_repository(self, **kwargs):
+    pass
+
   def bazel_version_repository(self, **kwargs):
     pass
 

--- a/upb/def.c
+++ b/upb/def.c
@@ -118,6 +118,7 @@ struct upb_symtab {
   upb_arena *arena;
   upb_strtable syms;  /* full_name -> packed def ptr */
   upb_strtable files;  /* file_name -> upb_filedef* */
+  size_t bytes_loaded;
 };
 
 /* Inside a symtab we store tagged pointers to specific def types. */
@@ -2084,6 +2085,7 @@ upb_symtab *upb_symtab_new(void) {
   }
 
   s->arena = upb_arena_new();
+  s->bytes_loaded = 0;
   alloc = upb_arena_alloc(s->arena);
 
   if (!upb_strtable_init2(&s->syms, UPB_CTYPE_CONSTPTR, 32, alloc) ||
@@ -2187,6 +2189,7 @@ bool _upb_symtab_loaddefinit(upb_symtab *s, const upb_def_init *init) {
 
   file = google_protobuf_FileDescriptorProto_parse(
       init->descriptor.data, init->descriptor.size, arena);
+  s->bytes_loaded += init->descriptor.size;
 
   if (!file) {
     upb_status_seterrf(
@@ -2207,6 +2210,10 @@ err:
           upb_status_errmsg(&status));
   upb_arena_free(arena);
   return false;
+}
+
+size_t _upb_symtab_bytesloaded(const upb_symtab *s) {
+  return s->bytes_loaded;
 }
 
 #undef CHK

--- a/upb/def.h
+++ b/upb/def.h
@@ -293,6 +293,7 @@ int upb_symtab_filecount(const upb_symtab *s);
 const upb_filedef *upb_symtab_addfile(
     upb_symtab *s, const google_protobuf_FileDescriptorProto *file,
     upb_status *status);
+size_t _upb_symtab_bytesloaded(const upb_symtab *s);
 
 /* For generated code only: loads a generated descriptor. */
 typedef struct upb_def_init {


### PR DESCRIPTION
Generally this seems to track the speed of loading descriptor.proto.

```
----------------------------------------------------------------------------------------------------
Benchmark                                                             Time           CPU Iterations
----------------------------------------------------------------------------------------------------
BM_LoadDescriptor_Upb                                             59091 ns      59086 ns      11747   121.182MB/s
BM_LoadAdsDescriptor_Upb                                        4218587 ns    4218582 ns        166   120.544MB/s
BM_LoadDescriptor_Proto2                                         241083 ns     241049 ns       2903   29.7043MB/s
BM_LoadAdsDescriptor_Proto2                                    13442631 ns   13442099 ns         52   34.8975MB/s
```