### PR TITLE
Bugfix for JSON decoding: only check real oneofs for duplicates.

### DIFF
--- a/upb/json_decode.c
+++ b/upb/json_decode.c
@@ -910,7 +910,7 @@ static void jsondec_field(jsondec *d, upb_msg *msg, const upb_msgdef *m) {
     return;
   }
 
-  if (upb_fielddef_containingoneof(f) &&
+  if (upb_fielddef_realcontainingoneof(f) &&
       upb_msg_whichoneof(msg, upb_fielddef_containingoneof(f))) {
     jsondec_err(d, "More than one field for this oneof.");
   }


### PR DESCRIPTION
Also fixed upb_msg_whichoneof() to work properly for synthetic
fields, and to be simpler in general.