### PR TITLE
Added map sorting to binary and text encoders.

### DIFF
--- a/benchmarks/compare.py
+++ b/benchmarks/compare.py
@@ -58,7 +58,7 @@ def Benchmark(outbase, bench_cpu=True, runs=12, fasttable=False):
 
 
 baseline = "master"
-bench_cpu = True
+bench_cpu = False
 fasttable = False
 
 if len(sys.argv) > 1:

--- a/upb/bindings/lua/def.c
+++ b/upb/bindings/lua/def.c
@@ -53,12 +53,12 @@ static void lupb_wrapper_pushwrapper(lua_State *L, int narg, const void *def,
 /* lupb_msgdef_pushsubmsgdef()
  *
  * Pops the msgdef wrapper at the top of the stack and replaces it with a msgdef
- * wrapper for field |f| of this msgdef.
+ * wrapper for field |f| of this msgdef (submsg may not be direct, for example it
+ * may be the submessage of the map value).
  */
 void lupb_msgdef_pushsubmsgdef(lua_State *L, const upb_fielddef *f) {
   const upb_msgdef *m = upb_fielddef_msgsubdef(f);
   assert(m);
-  assert(upb_fielddef_containingtype(f) == lupb_msgdef_check(L, -1));
   lupb_wrapper_pushwrapper(L, -1, m, LUPB_MSGDEF);
   lua_replace(L, -2);  /* Replace msgdef with submsgdef. */
 }
@@ -337,6 +337,26 @@ static int lupb_msgdef_oneofcount(lua_State *L) {
   return 1;
 }
 
+static bool lupb_msgdef_pushnested(lua_State *L, int msgdef, int name) {
+  const upb_msgdef *m = lupb_msgdef_check(L, msgdef);
+  lupb_wrapper_pushsymtab(L, msgdef);
+  upb_symtab *symtab = lupb_symtab_check(L, -1);
+  lua_pop(L, 1);
+
+  /* Construct full package.Message.SubMessage name. */
+  lua_pushstring(L, upb_msgdef_fullname(m));
+  lua_pushstring(L, ".");
+  lua_pushvalue(L, name);
+  lua_concat(L, 3);
+  const char *nested_name = lua_tostring(L, -1);
+
+  /* Try lookup. */
+  const upb_msgdef *nested = upb_symtab_lookupmsg(symtab, nested_name);
+  if (!nested) return false;
+  lupb_wrapper_pushwrapper(L, msgdef, nested, LUPB_MSGDEF);
+  return true;
+}
+
 /* lupb_msgdef_field()
  *
  * Handles:
@@ -430,6 +450,13 @@ static int lupb_msgdef_fullname(lua_State *L) {
   return 1;
 }
 
+static int lupb_msgdef_index(lua_State *L) {
+  if (!lupb_msgdef_pushnested(L, 1, 2)) {
+    luaL_error(L, "No such nested message");
+  }
+  return 1;
+}
+
 static int lupb_msgoneofiter_next(lua_State *L) {
   const upb_msgdef *m = lupb_msgdef_check(L, lua_upvalueindex(1));
   int *index = lua_touserdata(L, lua_upvalueindex(2));
@@ -471,6 +498,7 @@ static int lupb_msgdef_tostring(lua_State *L) {
 
 static const struct luaL_Reg lupb_msgdef_mm[] = {
   {"__call", lupb_msg_pushnew},
+  {"__index", lupb_msgdef_index},
   {"__len", lupb_msgdef_fieldcount},
   {"__tostring", lupb_msgdef_tostring},
   {NULL, NULL}

--- a/upb/decode.h
+++ b/upb/decode.h
@@ -15,6 +15,8 @@ extern "C" {
 #endif
 
 enum {
+  /* If set, strings will alias the input buffer instead of copying into the
+   * arena. */
   UPB_DECODE_ALIAS = 1,
 };
 

--- a/upb/encode.h
+++ b/upb/encode.h
@@ -7,12 +7,32 @@
 
 #include "upb/msg.h"
 
+/* Must be last. */
+#include "upb/port_def.inc"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-char *upb_encode(const void *msg, const upb_msglayout *l, upb_arena *arena,
-                 size_t *size);
+enum {
+  /* If set, the results of serializing will be deterministic across all
+   * instances of this binary. There are no guarantees across different
+   * binary builds.
+   *
+   * If your proto contains maps, the encoder will need to malloc()/free()
+   * memory during encode. */
+  UPB_ENCODE_DETERMINISTIC = 1,
+};
+
+char *upb_encode_ex(const void *msg, const upb_msglayout *l, int options,
+                    upb_arena *arena, size_t *size);
+
+UPB_INLINE char *upb_encode(const void *msg, const upb_msglayout *l,
+                            upb_arena *arena, size_t *size) {
+  return upb_encode_ex(msg, l, 0, arena, size);
+}
+
+#include "upb/port_undef.inc"
 
 #ifdef __cplusplus
 }  /* extern "C" */

--- a/upb/msg.h
+++ b/upb/msg.h
@@ -9,11 +9,13 @@
 #define UPB_MSG_H_
 
 #include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "upb/table.int.h"
 #include "upb/upb.h"
 
+/* Must be last. */
 #include "upb/port_def.inc"
 
 #ifdef __cplusplus
@@ -551,6 +553,53 @@ UPB_INLINE void _upb_msg_map_set_value(void* msg, const void* val, size_t size) 
   } else {
     memcpy(&ent->val.val, val, size);
   }
+}
+
+/** _upb_mapsorter *************************************************************/
+
+/* _upb_mapsorter sorts maps and provides ordered iteration over the entries.
+ * Since maps can be recursive (map values can be messages which contain other maps).
+ * _upb_mapsorter can contain a stack of maps. */
+
+typedef struct {
+  upb_tabent const**entries;
+  int size;
+  int cap;
+} _upb_mapsorter;
+
+typedef struct {
+  int start;
+  int pos;
+  int end;
+} _upb_sortedmap;
+
+UPB_INLINE void _upb_mapsorter_init(_upb_mapsorter *s) {
+  s->entries = NULL;
+  s->size = 0;
+  s->cap = 0;
+}
+
+UPB_INLINE void _upb_mapsorter_destroy(_upb_mapsorter *s) {
+  if (s->entries) free(s->entries);
+}
+
+bool _upb_mapsorter_pushmap(_upb_mapsorter *s, upb_descriptortype_t key_type,
+                            const upb_map *map, _upb_sortedmap *sorted);
+
+UPB_INLINE void _upb_mapsorter_popmap(_upb_mapsorter *s, _upb_sortedmap *sorted) {
+  s->size = sorted->start;
+}
+
+UPB_INLINE bool _upb_sortedmap_next(_upb_mapsorter *s, const upb_map *map,
+                                    _upb_sortedmap *sorted,
+                                    upb_map_entry *ent) {
+  if (sorted->pos == sorted->end) return false;
+  const upb_tabent *tabent = s->entries[sorted->pos++];
+  upb_strview key = upb_tabstrview(tabent->key);
+  _upb_map_fromkey(key, &ent->k, map->key_size);
+  upb_value val = {tabent->val.val};
+  _upb_map_fromvalue(val, &ent->v, map->val_size);
+  return true;
 }
 
 #undef PTR_AT

--- a/upb/table.int.h
+++ b/upb/table.int.h
@@ -147,10 +147,17 @@ UPB_INLINE char *upb_tabstr(upb_tabkey key, uint32_t *len) {
   return mem + sizeof(*len);
 }
 
+UPB_INLINE upb_strview upb_tabstrview(upb_tabkey key) {
+  upb_strview ret;
+  uint32_t len;
+  ret.data = upb_tabstr(key, &len);
+  ret.size = len;
+  return ret;
+}
 
 /* upb_tabval *****************************************************************/
 
-typedef struct {
+typedef struct upb_tabval {
   uint64_t val;
 } upb_tabval;
 

--- a/upb/text_encode.c
+++ b/upb/text_encode.c
@@ -17,6 +17,7 @@ typedef struct {
   int indent_depth;
   int options;
   const upb_symtab *ext_pool;
+  _upb_mapsorter sorter;
 } txtenc;
 
 static void txtenc_msg(txtenc *e, const upb_msg *msg, const upb_msgdef *m);
@@ -187,6 +188,25 @@ static void txtenc_array(txtenc *e, const upb_array *arr,
   }
 }
 
+static void txtenc_mapentry(txtenc *e, upb_msgval key, upb_msgval val,
+                            const upb_fielddef *f) {
+  const upb_msgdef *entry = upb_fielddef_msgsubdef(f);
+  const upb_fielddef *key_f = upb_msgdef_field(entry, 0);
+  const upb_fielddef *val_f = upb_msgdef_field(entry, 1);
+  txtenc_indent(e);
+  txtenc_printf(e, "%s: {", upb_fielddef_name(f));
+  txtenc_endfield(e);
+  e->indent_depth++;
+
+  txtenc_field(e, key, key_f);
+  txtenc_field(e, val, val_f);
+
+  e->indent_depth--;
+  txtenc_indent(e);
+  txtenc_putstr(e, "}");
+  txtenc_endfield(e);
+}
+
 /*
  * Maps print as messages of key/value, etc.
  *
@@ -200,27 +220,28 @@ static void txtenc_array(txtenc *e, const upb_array *arr,
  *    }
  */
 static void txtenc_map(txtenc *e, const upb_map *map, const upb_fielddef *f) {
-  const upb_msgdef *entry = upb_fielddef_msgsubdef(f);
-  const upb_fielddef *key_f = upb_msgdef_itof(entry, 1);
-  const upb_fielddef *val_f = upb_msgdef_itof(entry, 2);
-  size_t iter = UPB_MAP_BEGIN;
+  if (e->options & UPB_TXTENC_NOSORT) {
+    size_t iter = UPB_MAP_BEGIN;
+    while (upb_mapiter_next(map, &iter)) {
+      upb_msgval key = upb_mapiter_key(map, iter);
+      upb_msgval val = upb_mapiter_value(map, iter);
+      txtenc_mapentry(e, key, val, f);
+    }
+  } else {
+    const upb_msgdef *entry = upb_fielddef_msgsubdef(f);
+    const upb_fielddef *key_f = upb_msgdef_field(entry, 0);
+    _upb_sortedmap sorted;
+    upb_map_entry ent;
 
-  while (upb_mapiter_next(map, &iter)) {
-    upb_msgval key = upb_mapiter_key(map, iter);
-    upb_msgval val = upb_mapiter_value(map, iter);
-
-    txtenc_indent(e);
-    txtenc_printf(e, "%s: {", upb_fielddef_name(f));
-    txtenc_endfield(e);
-    e->indent_depth++;
-
-    txtenc_field(e, key, key_f);
-    txtenc_field(e, val, val_f);
-
-    e->indent_depth--;
-    txtenc_indent(e);
-    txtenc_putstr(e, "}");
-    txtenc_endfield(e);
+    _upb_mapsorter_pushmap(&e->sorter, upb_fielddef_descriptortype(key_f), map,
+                           &sorted);
+    while (_upb_sortedmap_next(&e->sorter, map, &sorted, &ent)) {
+      upb_msgval key, val;
+      memcpy(&key, &ent.k, sizeof(key));
+      memcpy(&val, &ent.v, sizeof(val));
+      txtenc_mapentry(e, key, val, f);
+    }
+    _upb_mapsorter_popmap(&e->sorter, &sorted);
   }
 }
 
@@ -392,7 +413,9 @@ size_t upb_text_encode(const upb_msg *msg, const upb_msgdef *m,
   e.indent_depth = 0;
   e.options = options;
   e.ext_pool = ext_pool;
+  _upb_mapsorter_init(&e.sorter);
 
   txtenc_msg(&e, msg, m);
+  _upb_mapsorter_destroy(&e.sorter);
   return txtenc_nullz(&e, size);
 }

--- a/upb/text_encode.h
+++ b/upb/text_encode.h
@@ -13,7 +13,10 @@ enum {
   UPB_TXTENC_SINGLELINE = 1,
 
   /* When set, unknown fields are not printed. */
-  UPB_TXTENC_SKIPUNKNOWN = 2
+  UPB_TXTENC_SKIPUNKNOWN = 2,
+
+  /* When set, maps are *not* sorted (this avoids allocating tmp mem). */
+  UPB_TXTENC_NOSORT = 4
 };
 
 /* Encodes the given |msg| to text format.  The message's reflection is given in

--- a/upb/upb.h
+++ b/upb/upb.h
@@ -324,6 +324,10 @@ UPB_INLINE int _upb_lg2ceil(int x) {
 #endif
 }
 
+UPB_INLINE int _upb_lg2ceilsize(int x) {
+  return 1 << _upb_lg2ceil(x);
+}
+
 #include "upb/port_undef.inc"
 
 #ifdef __cplusplus


### PR DESCRIPTION
For the binary encoder, sorting is off by default.
For the text encoder, sorting is on by default.
Both defaults can be explicitly overridden.

This grows code size a bit. I think we could potentially
shave this (and other map-related code size) by having
the generated code inject a function pointer to the map-related
parsing/serialization code if maps are present.

```
    FILE SIZE        VM SIZE
 --------------  --------------
   +86% +1.07Ki   +71%    +768    upb/msg.c
    [NEW]    +391  [NEW]    +344    _upb_mapsorter_pushmap
    [NEW]    +158  [NEW]    +112    _upb_mapsorter_cmpstr
    [NEW]    +111  [NEW]     +64    _upb_mapsorter_cmpbool
    [NEW]    +110  [NEW]     +64    _upb_mapsorter_cmpi32
    [NEW]    +110  [NEW]     +64    _upb_mapsorter_cmpi64
    [NEW]    +110  [NEW]     +64    _upb_mapsorter_cmpu32
    [NEW]    +110  [NEW]     +64    _upb_mapsorter_cmpu64
    -3.6%      -8  -4.3%      -8    _upb_map_new
  +9.5%    +464  +9.2%    +424    upb/text_encode.c
    [NEW]    +656  [NEW]    +616    txtenc_mapentry
     +15%     +32   +20%     +32    upb_text_encode
   -20.1%    -224 -20.7%    -224    txtenc_msg
  +5.7%    +342  +5.3%    +296    upb/encode.c
    [NEW]    +344  [NEW]    +304    encode_mapentry
    [NEW]    +246  [NEW]    +208    upb_encode_ex
    [NEW]     +41  [NEW]     +16    upb_encode_ex.ch
    +0.7%      +8  +0.7%      +8    encode_scalar
    -1.0%     -32  -1.0%     -32    encode_message
    [DEL]     -38  [DEL]     -16    upb_encode.ch
    [DEL]    -227  [DEL]    -192    upb_encode
  +2.0%    +152  +2.2%    +152    upb/decode.c
     +44%    +128   +44%    +128    [section .rodata]
    +3.4%     +24  +3.4%     +24    _GLOBAL_OFFSET_TABLE_
  +0.6%    +107  +0.3%     +48    upb/def.c
    [NEW]    +100  [NEW]     +48    upb_fielddef_descriptortype
    +7.1%      +7  [ = ]       0    upb_fielddef_defaultint32
  +2.9%     +24  +2.9%     +24    [section .dynsym]
  +1.2%     +24  [ = ]       0    [section .symtab]
  +3.2%     +16  +3.2%     +16    [section .plt]
    [NEW]     +16  [NEW]     +16    memcmp@plt
  +0.5%     +16  +0.6%     +16    tests/conformance_upb.c
    +1.5%     +16  +1.6%     +16    DoTestIo
  +0.1%     +16  +0.1%     +16    upb/json_decode.c
    +0.4%     +16  +0.4%     +16    jsondec_wellknown
  +3.0%      +8  +3.0%      +8    [section .got.plt]
    +3.0%      +8  +3.0%      +8    _GLOBAL_OFFSET_TABLE_
  +1.6%      +7  +1.6%      +7    [section .dynstr]
  +1.8%      +4  +1.8%      +4    [section .hash]
  +0.5%      +3  +0.5%      +3    [LOAD #2 [RX]]
  +2.8%      +2  +2.8%      +2    [section .gnu.version]
 -60.0% -1.74Ki  [ = ]       0    [Unmapped]
  +0.3%    +496  +1.4% +1.74Ki    TOTAL
```