### PR TITLE
Fixes for JSON encoder when emitting default values.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -187,7 +187,10 @@ cc_library(
         "upb/json_encode.h",
     ],
     copts = UPB_DEFAULT_COPTS,
-    visibility = ["//tests:__pkg__"],
+    visibility = [
+        "//tests:__pkg__",
+        "//upb/bindings/lua:__pkg__",
+    ],
     deps = [
         ":port",
         ":reflection",

--- a/tests/bindings/lua/test_upb.lua
+++ b/tests/bindings/lua/test_upb.lua
@@ -695,6 +695,12 @@ function test_encode_skipunknown()
   assert_true(#upb.encode(empty_with_unknown, {upb.ENCODE_SKIPUNKNOWN}) == 0)
 end
 
+function test_json_emit_defaults()
+  local msg = test_messages_proto3.TestAllTypesProto3()
+  local json = upb.json_encode(msg, {upb.JSONENC_EMITDEFAULTS})
+  print(json)
+end
+
 function test_gc()
   local top = test_messages_proto3.TestAllTypesProto3()
   local n = 100

--- a/tests/bindings/lua/test_upb.lua
+++ b/tests/bindings/lua/test_upb.lua
@@ -698,7 +698,6 @@ end
 function test_json_emit_defaults()
   local msg = test_messages_proto3.TestAllTypesProto3()
   local json = upb.json_encode(msg, {upb.JSONENC_EMITDEFAULTS})
-  print(json)
 end
 
 function test_gc()

--- a/upb/bindings/lua/BUILD
+++ b/upb/bindings/lua/BUILD
@@ -19,6 +19,7 @@ cc_library(
     copts = UPB_DEFAULT_COPTS,
     visibility = ["//visibility:public"],
     deps = [
+        "//:json",
         "//:reflection",
         "//:textformat",
         "//:upb",

--- a/upb/bindings/lua/def.c
+++ b/upb/bindings/lua/def.c
@@ -497,7 +497,7 @@ static int lupb_msgdef_tostring(lua_State *L) {
 }
 
 static const struct luaL_Reg lupb_msgdef_mm[] = {
-  {"__call", lupb_msg_pushnew},
+  {"__call", lupb_msgdef_call},
   {"__index", lupb_msgdef_index},
   {"__len", lupb_msgdef_fieldcount},
   {"__tostring", lupb_msgdef_tostring},

--- a/upb/bindings/lua/upb.h
+++ b/upb/bindings/lua/upb.h
@@ -75,7 +75,7 @@ void lupb_def_registertypes(lua_State *L);
 
 /** From msg.c. ***************************************************************/
 
-int lupb_msg_pushnew(lua_State *L);
+int lupb_msgdef_call(lua_State *L);
 upb_arena *lupb_arena_pushnew(lua_State *L);
 
 void lupb_msg_registertypes(lua_State *L);


### PR DESCRIPTION
The JSON encoder had a bug where it would segfault when using `UPB_JSONENC_EMITDEFAULTS`. It would recurse into NULL arrays and sub-messages.

This PR fixes the bug and adds Lua code to exercise the fix.