### PR TITLE
Make Bazel rule ":json" publicly visible

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -187,10 +187,7 @@ cc_library(
         "upb/json_encode.h",
     ],
     copts = UPB_DEFAULT_COPTS,
-    visibility = [
-        "//tests:__pkg__",
-        "//upb/bindings/lua:__pkg__",
-    ],
+    visibility = ["//visibility:public"],
     deps = [
         ":port",
         ":reflection",


### PR DESCRIPTION
The JSON conversion ability is needed for the gRPC Client Status Discovery Service effort, where gRPC Core needs to convert xDS resources in discovery responses to JSON strings.