### PR TITLE
Added depth limit checking to upb_encode().

### DIFF
--- a/tests/bindings/lua/test_upb.lua
+++ b/tests/bindings/lua/test_upb.lua
@@ -700,6 +700,12 @@ function test_json_emit_defaults()
   local json = upb.json_encode(msg, {upb.JSONENC_EMITDEFAULTS})
 end
 
+function test_encode_depth_limit()
+  local msg = test_messages_proto3.TestAllTypesProto3()
+  msg.recursive_message = msg
+  assert_error(function() upb.encode(msg) end)
+end
+
 function test_gc()
   local top = test_messages_proto3.TestAllTypesProto3()
   local n = 100

--- a/upb/encode.h
+++ b/upb/encode.h
@@ -27,6 +27,8 @@ enum {
   UPB_ENCODE_SKIPUNKNOWN = 2,
 };
 
+#define UPB_ENCODE_MAXDEPTH(depth) ((depth) << 16)
+
 char *upb_encode_ex(const void *msg, const upb_msglayout *l, int options,
                     upb_arena *arena, size_t *size);
 


### PR DESCRIPTION
This can catch infinite recursion due to loops,
or just excessively deep message trees.

The depth limit is configurable, but defaults to 64.