### PR TITLE
Fixed upb encoder for field numbers > 2**28.

### DIFF
--- a/tests/bindings/lua/test.proto
+++ b/tests/bindings/lua/test.proto
@@ -22,3 +22,7 @@ message UnpackedTest {
   repeated fixed32 f32_packed = 4 [packed = false];
   repeated fixed64 f64_packed = 5 [packed = false];
 }
+
+message TestLargeFieldNumber {
+  optional int32 i32 = 456214797;
+}

--- a/tests/bindings/lua/test_upb.lua
+++ b/tests/bindings/lua/test_upb.lua
@@ -706,6 +706,14 @@ function test_encode_depth_limit()
   assert_error(function() upb.encode(msg) end)
 end
 
+function test_large_field_number()
+  local msg = upb_test.TestLargeFieldNumber()
+  msg.i32 = 5
+  local serialized = upb.encode(msg)
+  local msg2 = upb.decode(upb_test.TestLargeFieldNumber, serialized)
+  assert_equal(msg.i32, msg2.i32)
+end
+
 function test_gc()
   local top = test_messages_proto3.TestAllTypesProto3()
   local n = 100

--- a/upb/encode.c
+++ b/upb/encode.c
@@ -134,7 +134,8 @@ static void encode_float(upb_encstate *e, float d) {
   encode_fixed32(e, u32);
 }
 
-static void encode_tag(upb_encstate *e, int field_number, int wire_type) {
+static void encode_tag(upb_encstate *e, uint32_t field_number,
+                       uint8_t wire_type) {
   encode_varint(e, (field_number << 3) | wire_type);
 }
 


### PR DESCRIPTION
The encoder was improperly sign-extending the tag to 64 bits.