### PR TITLE
Fixed upbdefs error

### DIFF
--- a/bazel/upb_proto_library.bzl
+++ b/bazel/upb_proto_library.bzl
@@ -323,6 +323,7 @@ _upb_proto_reflection_library_aspect = aspect(
         ),
         "_upbdefs": attr.label_list(
             default = [
+                "//:generated_code_support__only_for_generated_code_do_not_use__i_give_permission_to_break_me",
                 "//:upb",
                 "//:reflection",
             ],


### PR DESCRIPTION
Fixed the internal error:
```
./blaze-out/k8-asan-fastbuild/bin/third_party/upb/tests/test_cpp.upbdefs.h:13:10: error: module //third_party/upb/tests:test_cpp_proto.upbdefs does not depend on a module exporting 'third_party/upb/upb/port_def.inc'
see http://go/cpp-features#layering_check; to fix run:
build_cleaner //third_party/upb/tests:test_cpp_proto.upbdefs
#include "third_party/upb/upb/port_def.inc"
         ^
```