### PR TITLE
Adds CIFuzz

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,29 @@
+name: CIFuzz
+on: [pull_request]
+jobs:
+ Fuzzing:
+   runs-on: ubuntu-latest
+   strategy:
+     fail-fast: false
+     matrix:
+       sanitizer: [address, undefined]
+   steps:
+   - name: Build Fuzzers (${{ matrix.sanitizer }})
+     uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+     with:
+       oss-fuzz-project-name: 'upb'
+       dry-run: false
+       sanitizer: ${{ matrix.sanitizer }}
+   - name: Run Fuzzers (${{ matrix.sanitizer }})
+     uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+     with:
+       oss-fuzz-project-name: 'upb'
+       fuzz-seconds: 600
+       dry-run: false
+       sanitizer: ${{ matrix.sanitizer }}
+   - name: Upload Crash
+     uses: actions/upload-artifact@v1
+     if: failure()
+     with:
+       name: ${{ matrix.sanitizer }}-artifacts
+       path: ./out/artifacts


### PR DESCRIPTION
Now that upb got integrated into oss-fuzz by https://github.com/google/oss-fuzz/pull/4914, it is possible to have CIFuzz cf https://google.github.io/oss-fuzz/getting-started/continuous-integration/

CIFuzz is a GitHub action/CI job that runs the project's fuzz targets on pull requests, and so can prevent bugs from reaching the main branch.

I'll be happy to provide more info if needed