### PR TITLE
A few minor cleanups

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -11,15 +11,7 @@ load(
     "upb_proto_reflection_library",
 )
 
-# copybara:strip_for_google3_begin
-load(
-    "@rules_proto//proto:defs.bzl",
-    "proto_library",
-)
-
-# copybara:strip_end
-
-licenses(["notice"])  # BSD (Google-authored w/ possible external contributions)
+licenses(["notice"])
 
 exports_files([
     "LICENSE",
@@ -212,6 +204,8 @@ cc_library(
 
 # Amalgamation #################################################################
 
+# copybara:strip_for_google3_begin
+
 py_binary(
     name = "amalgamate",
     srcs = ["tools/amalgamate.py"],
@@ -314,9 +308,6 @@ exports_files(
 filegroup(
     name = "cmake_files",
     srcs = glob([
-        "upb/json/parser.c",
-        "CMakeLists.txt",
-        "generated_for_cmake/**/*",
         "google/**/*",
         "upbc/**/*",
         "upb/**/*",
@@ -325,3 +316,5 @@ filegroup(
     ]),
     visibility = ["//cmake:__pkg__"],
 )
+
+# copybara:strip_end

--- a/upb/def.c
+++ b/upb/def.c
@@ -815,7 +815,6 @@ void upb_symtab_free(upb_symtab *s) {
 
 upb_symtab *upb_symtab_new(void) {
   upb_symtab *s = upb_gmalloc(sizeof(*s));
-  upb_alloc *alloc;
 
   if (!s) {
     return NULL;
@@ -823,7 +822,6 @@ upb_symtab *upb_symtab_new(void) {
 
   s->arena = upb_arena_new();
   s->bytes_loaded = 0;
-  alloc = upb_arena_alloc(s->arena);
 
   if (!upb_strtable_init(&s->syms, 32, s->arena) ||
       !upb_strtable_init(&s->files, 4, s->arena)) {
@@ -1401,8 +1399,7 @@ static void parse_default(symtab_addctx *ctx, const char *str, size_t len,
       break;
     }
     case UPB_TYPE_INT64: {
-      /* XXX: Need to write our own strtoll, since it's not available in c89. */
-      int64_t val = strtol(str, &end, 0);
+      long long val = strtoll(str, &end, 0);
       if (val > INT64_MAX || val < INT64_MIN || errno == ERANGE || *end) {
         goto invalid;
       }
@@ -1418,8 +1415,7 @@ static void parse_default(symtab_addctx *ctx, const char *str, size_t len,
       break;
     }
     case UPB_TYPE_UINT64: {
-      /* XXX: Need to write our own strtoull, since it's not available in c89. */
-      uint64_t val = strtoul(str, &end, 0);
+      unsigned long long val = strtoull(str, &end, 0);
       if (val > UINT64_MAX || errno == ERANGE || *end) {
         goto invalid;
       }
@@ -1435,8 +1431,7 @@ static void parse_default(symtab_addctx *ctx, const char *str, size_t len,
       break;
     }
     case UPB_TYPE_FLOAT: {
-      /* XXX: Need to write our own strtof, since it's not available in c89. */
-      float val = strtod(str, &end);
+      float val = strtof(str, &end);
       if (errno == ERANGE || *end) {
         goto invalid;
       }

--- a/upb/reflection.c
+++ b/upb/reflection.c
@@ -113,40 +113,7 @@ upb_msgval upb_msg_get(const upb_msg *msg, const upb_fielddef *f) {
   if (!upb_fielddef_haspresence(f) || upb_msg_has(msg, f)) {
     return _upb_msg_getraw(msg, f);
   } else {
-    /* TODO(haberman): change upb_fielddef to not require this switch(). */
-    upb_msgval val = {0};
-    switch (upb_fielddef_type(f)) {
-      case UPB_TYPE_INT32:
-      case UPB_TYPE_ENUM:
-        val.int32_val = upb_fielddef_defaultint32(f);
-        break;
-      case UPB_TYPE_INT64:
-        val.int64_val = upb_fielddef_defaultint64(f);
-        break;
-      case UPB_TYPE_UINT32:
-        val.uint32_val = upb_fielddef_defaultuint32(f);
-        break;
-      case UPB_TYPE_UINT64:
-        val.uint64_val = upb_fielddef_defaultuint64(f);
-        break;
-      case UPB_TYPE_FLOAT:
-        val.float_val = upb_fielddef_defaultfloat(f);
-        break;
-      case UPB_TYPE_DOUBLE:
-        val.double_val = upb_fielddef_defaultdouble(f);
-        break;
-      case UPB_TYPE_BOOL:
-        val.bool_val = upb_fielddef_defaultbool(f);
-        break;
-      case UPB_TYPE_STRING:
-      case UPB_TYPE_BYTES:
-        val.str_val.data = upb_fielddef_defaultstr(f, &val.str_val.size);
-        break;
-      case UPB_TYPE_MESSAGE:
-        val.msg_val = NULL;
-        break;
-    }
-    return val;
+    return upb_fielddef_default(f);
   }
 }
 

--- a/upb/table.c
+++ b/upb/table.c
@@ -25,7 +25,7 @@ static const double MAX_LOAD = 0.85;
  * cache effects).  The lower this is, the more memory we'll use. */
 static const double MIN_DENSITY = 0.1;
 
-bool is_pow2(uint64_t v) { return v == 0 || (v & (v - 1)) == 0; }
+static bool is_pow2(uint64_t v) { return v == 0 || (v & (v - 1)) == 0; }
 
 static upb_value _upb_value_val(uint64_t val) {
   upb_value ret;
@@ -33,16 +33,12 @@ static upb_value _upb_value_val(uint64_t val) {
   return ret;
 }
 
-int log2ceil(uint64_t v) {
+static int log2ceil(uint64_t v) {
   int ret = 0;
   bool pow2 = is_pow2(v);
   while (v >>= 1) ret++;
   ret = pow2 ? ret : ret + 1;  /* Ceiling. */
   return UPB_MIN(UPB_MAXARRSIZE, ret);
-}
-
-char *upb_strdup(const char *s, upb_arena *a) {
-  return upb_strdup2(s, strlen(s), a);
 }
 
 char *upb_strdup2(const char *s, size_t len, upb_arena *a) {

--- a/upb/table.int.h
+++ b/upb/table.int.h
@@ -37,8 +37,6 @@ typedef struct {
   uint64_t val;
 } upb_value;
 
-/* Like strdup(), which isn't always available since it's not ANSI C. */
-char *upb_strdup(const char *s, upb_arena *a);
 /* Variant that works with a length-delimited rather than NULL-delimited string,
  * as supported by strtable. */
 char *upb_strdup2(const char *s, size_t len, upb_arena *a);


### PR DESCRIPTION
- We can use `strto[u]ll()` now that we are C99
- `upb_msg_get()` is simplified now that `upb_fielddef_default()` is available.