### PR TITLE
Fixed quadratic memory usage in upb_array_append().

### DIFF
--- a/tests/bindings/lua/test_upb.lua
+++ b/tests/bindings/lua/test_upb.lua
@@ -321,6 +321,16 @@ function test_msg_array()
   assert_error_match("array expected", function() msg.repeated_int32 = print end)
 end
 
+function test_array_append()
+  local arr = upb.Array(upb.TYPE_INT32)
+  for i=1,200000 do
+    arr[i] = i
+  end
+  for i=1,200000 do
+    assert_equal(i, arr[i])
+  end
+end
+
 function test_msg_submsg()
   --msg = test_messages_proto3.TestAllTypesProto3()
   msg = test_messages_proto3['TestAllTypesProto3']()

--- a/upb/reflection.c
+++ b/upb/reflection.c
@@ -300,10 +300,9 @@ void upb_array_set(upb_array *arr, size_t i, upb_msgval val) {
 }
 
 bool upb_array_append(upb_array *arr, upb_msgval val, upb_arena *arena) {
-  if (!_upb_array_realloc(arr, arr->len + 1, arena)) {
+  if (!upb_array_resize(arr, arr->len + 1, arena)) {
     return false;
   }
-  arr->len++;
   upb_array_set(arr, arr->len - 1, val);
   return true;
 }


### PR DESCRIPTION
We were erroneously calling realloc() instead of resize(),
forcing the entire array to be reallocated for every array
append.