### PR TITLE
Spell out deps explicitly

### DIFF
--- a/tests/BUILD
+++ b/tests/BUILD
@@ -86,12 +86,18 @@ upb_proto_reflection_library(
     deps = ["test_cpp_proto"],
 )
 
+upb_proto_reflection_library(
+    name = "test_cpp_upb_proto_reflection",
+    deps = ["test_cpp_proto"],
+)
+
 cc_test(
     name = "test_cpp",
     srcs = ["test_cpp.cc"],
     copts = UPB_DEFAULT_CPPOPTS,
     deps = [
         ":test_cpp_upb_proto",
+        ":test_cpp_upb_proto_reflection",
         ":upb_test",
         "//:json",
         "//:port",


### PR DESCRIPTION
Google internal bazel is more strict about deps, so both reflection and
non need to be spelled out explicitly.