### PR TITLE
Fix build rules for more restrive deps checks

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -134,6 +134,7 @@ cc_library(
     hdrs = [
         "upb/decode_fast.h",
         "upb/msg.h",
+        "upb/msg.int.h",
         "upb/port_def.inc",
         "upb/port_undef.inc",
     ],

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -106,7 +106,7 @@ proto_library(
     ],
 )
 
-upb_proto_reflection_library(
+upb_proto_library(
     name = "test_cpp_upb_proto",
     deps = ["test_cpp_proto"],
 )


### PR DESCRIPTION
- add msg.int.h access for generated files
- actually declare reflective/non as different things