### PR TITLE
JSON: Only perform multiple oneof check for non-null fields.

### DIFF
--- a/bazel/workspace_deps.bzl
+++ b/bazel/workspace_deps.bzl
@@ -36,8 +36,8 @@ def upb_deps():
     maybe(
         http_archive,
         name = "bazel_skylib",
-        strip_prefix = "bazel-skylib-master",
-        urls = ["https://github.com/bazelbuild/bazel-skylib/archive/master.tar.gz"],
+        strip_prefix = "bazel-skylib-main",
+        urls = ["https://github.com/bazelbuild/bazel-skylib/archive/main.tar.gz"],
     )
 
     maybe(

--- a/upb/json_decode.c
+++ b/upb/json_decode.c
@@ -939,15 +939,15 @@ static void jsondec_field(jsondec *d, upb_msg *msg, const upb_msgdef *m) {
     return;
   }
 
-  if (upb_fielddef_realcontainingoneof(f) &&
-      upb_msg_whichoneof(msg, upb_fielddef_containingoneof(f))) {
-    jsondec_err(d, "More than one field for this oneof.");
-  }
-
   if (jsondec_peek(d) == JD_NULL && !jsondec_isvalue(f)) {
     /* JSON "null" indicates a default value, so no need to set anything. */
     jsondec_null(d);
     return;
+  }
+
+  if (upb_fielddef_realcontainingoneof(f) &&
+      upb_msg_whichoneof(msg, upb_fielddef_containingoneof(f))) {
+    jsondec_err(d, "More than one field for this oneof.");
   }
 
   preserved = d->debug_field;


### PR DESCRIPTION
This allows payloads like:

```
{"oneofUint32": null, "oneofString": "test"}
```

This will fix https://github.com/protocolbuffers/protobuf/issues/8464 once it is imported to Ruby.

Also fixed the Bazel BUILD (Fixes: https://github.com/protocolbuffers/upb/issues/385)