### PR TITLE
Fix macOS build for XCode 11.3

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,6 @@
+# temporary fix for https://github.com/bazelbuild/bazel/issues/12905 on macOS
+build --features=-debug_prefix_map_pwd_is_dot
+
 # Use our custom-configured c++ toolchain.
 
 build:m32 --copt=-m32 --linkopt=-m32

--- a/BUILD
+++ b/BUILD
@@ -134,7 +134,7 @@ cc_library(
     hdrs = [
         "upb/decode_fast.h",
         "upb/msg.h",
-        "upb/msg.int.h",
+        "upb/msg_internal.h",
         "upb/port_def.inc",
         "upb/port_undef.inc",
     ],


### PR DESCRIPTION
This also fixes the build break in https://github.com/protocolbuffers/upb/issues/385