### PR TITLE
Added test running instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,26 @@ Then in your `.c` file you can #include the generated header:
 /* Insert code that uses generated types. */
 ```
 
+## Running upb's tests
+
+When making changes to upd it's prudent to ensure that all tests are
+passing before, and after your change is applied. Run the tests by
+executing the following command.
+
+```bash
+$ bazel test --test_output=errors :all
+```
+
+## Old "handlers" interfaces
+
+This library contains several semi-deprecated interfaces (see BUILD
+file for more info about which interfaces are deprecated).  These
+deprecated interfaces are still used in some significant projects,
+such as the Ruby and PHP C bindings for protobuf in the [main protobuf
+repo](https://github.com/protocolbuffers/protobuf).  The goal is to
+migrate the Ruby/PHP bindings to use the newer, simpler interfaces
+instead.  Please do not use the old interfaces in new code.
+
 ## Lua bindings
 
 This repo has some Lua bindings for the core library.  These are


### PR DESCRIPTION
rebase with upstream repo to resolve branch naming issues with bazel-skylib's "main" branch