### PR TITLE
Added a fix for locales that output ',' as decimal separator.

### DIFF
--- a/tests/bindings/lua/test_upb.lua
+++ b/tests/bindings/lua/test_upb.lua
@@ -747,6 +747,17 @@ function test_json_emit_defaults()
   local json = upb.json_encode(msg, {upb.JSONENC_EMITDEFAULTS})
 end
 
+function test_json_locale()
+  local msg = test_messages_proto3.TestAllTypesProto3()
+  msg.optional_double = 1.1
+  local original_locale = os.setlocale(nil)
+  os.setlocale("C")
+  local json = upb.json_encode(msg)
+  os.setlocale("de_DE.utf8")
+  assert_equal(json, upb.json_encode(msg))
+  os.setlocale(original_locale)  -- Restore.
+end
+
 function test_encode_depth_limit()
   local msg = test_messages_proto3.TestAllTypesProto3()
   msg.recursive_message = msg

--- a/upb/json_encode.c
+++ b/upb/json_encode.c
@@ -307,7 +307,17 @@ static void jsonenc_double(jsonenc *e, const char *fmt, double val) {
   } else if (val != val) {
     jsonenc_putstr(e, "\"NaN\"");
   } else {
+    char *p = e->ptr;
     jsonenc_printf(e, fmt, val);
+
+    /* printf() is dependent on locales; sadly there is no easy and portable way
+     * to avoid this. This little post-processing step will translate 1,2 -> 1.2
+     * since JSON needs the latter. Arguably a hack, but it is simple and the
+     * alternatives are far more complicated, platform-dependent, and/or larger
+     * in code size. */
+    for (char *end = e->ptr; p < end; p++) {
+      if (*p == ',') *p = '.';
+    }
   }
 }
 


### PR DESCRIPTION
Fix for https://github.com/protocolbuffers/protobuf/issues/8179