### PR TITLE
Optimized decoder and paved the way for parsing extensions.

### DIFF
--- a/cmake/google/protobuf/descriptor.upb.c
+++ b/cmake/google/protobuf/descriptor.upb.c
@@ -23,7 +23,7 @@ static const upb_msglayout_field google_protobuf_FileDescriptorSet__fields[1] = 
 const upb_msglayout google_protobuf_FileDescriptorSet_msginit = {
   &google_protobuf_FileDescriptorSet_submsgs[0],
   &google_protobuf_FileDescriptorSet__fields[0],
-  UPB_SIZE(8, 8), 1, false, 255,
+  UPB_SIZE(8, 8), 1, false, 1, 255,
 };
 
 static const upb_msglayout *const google_protobuf_FileDescriptorProto_submsgs[6] = {
@@ -53,7 +53,7 @@ static const upb_msglayout_field google_protobuf_FileDescriptorProto__fields[12]
 const upb_msglayout google_protobuf_FileDescriptorProto_msginit = {
   &google_protobuf_FileDescriptorProto_submsgs[0],
   &google_protobuf_FileDescriptorProto__fields[0],
-  UPB_SIZE(64, 128), 12, false, 255,
+  UPB_SIZE(64, 128), 12, false, 12, 255,
 };
 
 static const upb_msglayout *const google_protobuf_DescriptorProto_submsgs[7] = {
@@ -82,7 +82,7 @@ static const upb_msglayout_field google_protobuf_DescriptorProto__fields[10] = {
 const upb_msglayout google_protobuf_DescriptorProto_msginit = {
   &google_protobuf_DescriptorProto_submsgs[0],
   &google_protobuf_DescriptorProto__fields[0],
-  UPB_SIZE(48, 96), 10, false, 255,
+  UPB_SIZE(48, 96), 10, false, 10, 255,
 };
 
 static const upb_msglayout *const google_protobuf_DescriptorProto_ExtensionRange_submsgs[1] = {
@@ -98,7 +98,7 @@ static const upb_msglayout_field google_protobuf_DescriptorProto_ExtensionRange_
 const upb_msglayout google_protobuf_DescriptorProto_ExtensionRange_msginit = {
   &google_protobuf_DescriptorProto_ExtensionRange_submsgs[0],
   &google_protobuf_DescriptorProto_ExtensionRange__fields[0],
-  UPB_SIZE(16, 24), 3, false, 255,
+  UPB_SIZE(16, 24), 3, false, 3, 255,
 };
 
 static const upb_msglayout_field google_protobuf_DescriptorProto_ReservedRange__fields[2] = {
@@ -109,7 +109,7 @@ static const upb_msglayout_field google_protobuf_DescriptorProto_ReservedRange__
 const upb_msglayout google_protobuf_DescriptorProto_ReservedRange_msginit = {
   NULL,
   &google_protobuf_DescriptorProto_ReservedRange__fields[0],
-  UPB_SIZE(16, 16), 2, false, 255,
+  UPB_SIZE(16, 16), 2, false, 2, 255,
 };
 
 static const upb_msglayout *const google_protobuf_ExtensionRangeOptions_submsgs[1] = {
@@ -123,7 +123,7 @@ static const upb_msglayout_field google_protobuf_ExtensionRangeOptions__fields[1
 const upb_msglayout google_protobuf_ExtensionRangeOptions_msginit = {
   &google_protobuf_ExtensionRangeOptions_submsgs[0],
   &google_protobuf_ExtensionRangeOptions__fields[0],
-  UPB_SIZE(8, 8), 1, false, 255,
+  UPB_SIZE(8, 8), 1, false, 0, 255,
 };
 
 static const upb_msglayout *const google_protobuf_FieldDescriptorProto_submsgs[1] = {
@@ -147,7 +147,7 @@ static const upb_msglayout_field google_protobuf_FieldDescriptorProto__fields[11
 const upb_msglayout google_protobuf_FieldDescriptorProto_msginit = {
   &google_protobuf_FieldDescriptorProto_submsgs[0],
   &google_protobuf_FieldDescriptorProto__fields[0],
-  UPB_SIZE(72, 112), 11, false, 255,
+  UPB_SIZE(72, 112), 11, false, 10, 255,
 };
 
 static const upb_msglayout *const google_protobuf_OneofDescriptorProto_submsgs[1] = {
@@ -162,7 +162,7 @@ static const upb_msglayout_field google_protobuf_OneofDescriptorProto__fields[2]
 const upb_msglayout google_protobuf_OneofDescriptorProto_msginit = {
   &google_protobuf_OneofDescriptorProto_submsgs[0],
   &google_protobuf_OneofDescriptorProto__fields[0],
-  UPB_SIZE(16, 32), 2, false, 255,
+  UPB_SIZE(16, 32), 2, false, 2, 255,
 };
 
 static const upb_msglayout *const google_protobuf_EnumDescriptorProto_submsgs[3] = {
@@ -182,7 +182,7 @@ static const upb_msglayout_field google_protobuf_EnumDescriptorProto__fields[5] 
 const upb_msglayout google_protobuf_EnumDescriptorProto_msginit = {
   &google_protobuf_EnumDescriptorProto_submsgs[0],
   &google_protobuf_EnumDescriptorProto__fields[0],
-  UPB_SIZE(32, 64), 5, false, 255,
+  UPB_SIZE(32, 64), 5, false, 5, 255,
 };
 
 static const upb_msglayout_field google_protobuf_EnumDescriptorProto_EnumReservedRange__fields[2] = {
@@ -193,7 +193,7 @@ static const upb_msglayout_field google_protobuf_EnumDescriptorProto_EnumReserve
 const upb_msglayout google_protobuf_EnumDescriptorProto_EnumReservedRange_msginit = {
   NULL,
   &google_protobuf_EnumDescriptorProto_EnumReservedRange__fields[0],
-  UPB_SIZE(16, 16), 2, false, 255,
+  UPB_SIZE(16, 16), 2, false, 2, 255,
 };
 
 static const upb_msglayout *const google_protobuf_EnumValueDescriptorProto_submsgs[1] = {
@@ -209,7 +209,7 @@ static const upb_msglayout_field google_protobuf_EnumValueDescriptorProto__field
 const upb_msglayout google_protobuf_EnumValueDescriptorProto_msginit = {
   &google_protobuf_EnumValueDescriptorProto_submsgs[0],
   &google_protobuf_EnumValueDescriptorProto__fields[0],
-  UPB_SIZE(24, 32), 3, false, 255,
+  UPB_SIZE(24, 32), 3, false, 3, 255,
 };
 
 static const upb_msglayout *const google_protobuf_ServiceDescriptorProto_submsgs[2] = {
@@ -226,7 +226,7 @@ static const upb_msglayout_field google_protobuf_ServiceDescriptorProto__fields[
 const upb_msglayout google_protobuf_ServiceDescriptorProto_msginit = {
   &google_protobuf_ServiceDescriptorProto_submsgs[0],
   &google_protobuf_ServiceDescriptorProto__fields[0],
-  UPB_SIZE(24, 48), 3, false, 255,
+  UPB_SIZE(24, 48), 3, false, 3, 255,
 };
 
 static const upb_msglayout *const google_protobuf_MethodDescriptorProto_submsgs[1] = {
@@ -245,7 +245,7 @@ static const upb_msglayout_field google_protobuf_MethodDescriptorProto__fields[6
 const upb_msglayout google_protobuf_MethodDescriptorProto_msginit = {
   &google_protobuf_MethodDescriptorProto_submsgs[0],
   &google_protobuf_MethodDescriptorProto__fields[0],
-  UPB_SIZE(32, 64), 6, false, 255,
+  UPB_SIZE(32, 64), 6, false, 6, 255,
 };
 
 static const upb_msglayout *const google_protobuf_FileOptions_submsgs[1] = {
@@ -279,7 +279,7 @@ static const upb_msglayout_field google_protobuf_FileOptions__fields[21] = {
 const upb_msglayout google_protobuf_FileOptions_msginit = {
   &google_protobuf_FileOptions_submsgs[0],
   &google_protobuf_FileOptions__fields[0],
-  UPB_SIZE(104, 192), 21, false, 255,
+  UPB_SIZE(104, 192), 21, false, 1, 255,
 };
 
 static const upb_msglayout *const google_protobuf_MessageOptions_submsgs[1] = {
@@ -297,7 +297,7 @@ static const upb_msglayout_field google_protobuf_MessageOptions__fields[5] = {
 const upb_msglayout google_protobuf_MessageOptions_msginit = {
   &google_protobuf_MessageOptions_submsgs[0],
   &google_protobuf_MessageOptions__fields[0],
-  UPB_SIZE(16, 16), 5, false, 255,
+  UPB_SIZE(16, 16), 5, false, 3, 255,
 };
 
 static const upb_msglayout *const google_protobuf_FieldOptions_submsgs[1] = {
@@ -317,7 +317,7 @@ static const upb_msglayout_field google_protobuf_FieldOptions__fields[7] = {
 const upb_msglayout google_protobuf_FieldOptions_msginit = {
   &google_protobuf_FieldOptions_submsgs[0],
   &google_protobuf_FieldOptions__fields[0],
-  UPB_SIZE(24, 24), 7, false, 255,
+  UPB_SIZE(24, 24), 7, false, 3, 255,
 };
 
 static const upb_msglayout *const google_protobuf_OneofOptions_submsgs[1] = {
@@ -331,7 +331,7 @@ static const upb_msglayout_field google_protobuf_OneofOptions__fields[1] = {
 const upb_msglayout google_protobuf_OneofOptions_msginit = {
   &google_protobuf_OneofOptions_submsgs[0],
   &google_protobuf_OneofOptions__fields[0],
-  UPB_SIZE(8, 8), 1, false, 255,
+  UPB_SIZE(8, 8), 1, false, 0, 255,
 };
 
 static const upb_msglayout *const google_protobuf_EnumOptions_submsgs[1] = {
@@ -347,7 +347,7 @@ static const upb_msglayout_field google_protobuf_EnumOptions__fields[3] = {
 const upb_msglayout google_protobuf_EnumOptions_msginit = {
   &google_protobuf_EnumOptions_submsgs[0],
   &google_protobuf_EnumOptions__fields[0],
-  UPB_SIZE(8, 16), 3, false, 255,
+  UPB_SIZE(8, 16), 3, false, 0, 255,
 };
 
 static const upb_msglayout *const google_protobuf_EnumValueOptions_submsgs[1] = {
@@ -362,7 +362,7 @@ static const upb_msglayout_field google_protobuf_EnumValueOptions__fields[2] = {
 const upb_msglayout google_protobuf_EnumValueOptions_msginit = {
   &google_protobuf_EnumValueOptions_submsgs[0],
   &google_protobuf_EnumValueOptions__fields[0],
-  UPB_SIZE(8, 16), 2, false, 255,
+  UPB_SIZE(8, 16), 2, false, 1, 255,
 };
 
 static const upb_msglayout *const google_protobuf_ServiceOptions_submsgs[1] = {
@@ -377,7 +377,7 @@ static const upb_msglayout_field google_protobuf_ServiceOptions__fields[2] = {
 const upb_msglayout google_protobuf_ServiceOptions_msginit = {
   &google_protobuf_ServiceOptions_submsgs[0],
   &google_protobuf_ServiceOptions__fields[0],
-  UPB_SIZE(8, 16), 2, false, 255,
+  UPB_SIZE(8, 16), 2, false, 0, 255,
 };
 
 static const upb_msglayout *const google_protobuf_MethodOptions_submsgs[1] = {
@@ -393,7 +393,7 @@ static const upb_msglayout_field google_protobuf_MethodOptions__fields[3] = {
 const upb_msglayout google_protobuf_MethodOptions_msginit = {
   &google_protobuf_MethodOptions_submsgs[0],
   &google_protobuf_MethodOptions__fields[0],
-  UPB_SIZE(16, 24), 3, false, 255,
+  UPB_SIZE(16, 24), 3, false, 0, 255,
 };
 
 static const upb_msglayout *const google_protobuf_UninterpretedOption_submsgs[1] = {
@@ -413,7 +413,7 @@ static const upb_msglayout_field google_protobuf_UninterpretedOption__fields[7] 
 const upb_msglayout google_protobuf_UninterpretedOption_msginit = {
   &google_protobuf_UninterpretedOption_submsgs[0],
   &google_protobuf_UninterpretedOption__fields[0],
-  UPB_SIZE(64, 96), 7, false, 255,
+  UPB_SIZE(64, 96), 7, false, 0, 255,
 };
 
 static const upb_msglayout_field google_protobuf_UninterpretedOption_NamePart__fields[2] = {
@@ -424,7 +424,7 @@ static const upb_msglayout_field google_protobuf_UninterpretedOption_NamePart__f
 const upb_msglayout google_protobuf_UninterpretedOption_NamePart_msginit = {
   NULL,
   &google_protobuf_UninterpretedOption_NamePart__fields[0],
-  UPB_SIZE(16, 32), 2, false, 255,
+  UPB_SIZE(16, 32), 2, false, 2, 255,
 };
 
 static const upb_msglayout *const google_protobuf_SourceCodeInfo_submsgs[1] = {
@@ -438,7 +438,7 @@ static const upb_msglayout_field google_protobuf_SourceCodeInfo__fields[1] = {
 const upb_msglayout google_protobuf_SourceCodeInfo_msginit = {
   &google_protobuf_SourceCodeInfo_submsgs[0],
   &google_protobuf_SourceCodeInfo__fields[0],
-  UPB_SIZE(8, 8), 1, false, 255,
+  UPB_SIZE(8, 8), 1, false, 1, 255,
 };
 
 static const upb_msglayout_field google_protobuf_SourceCodeInfo_Location__fields[5] = {
@@ -452,7 +452,7 @@ static const upb_msglayout_field google_protobuf_SourceCodeInfo_Location__fields
 const upb_msglayout google_protobuf_SourceCodeInfo_Location_msginit = {
   NULL,
   &google_protobuf_SourceCodeInfo_Location__fields[0],
-  UPB_SIZE(32, 64), 5, false, 255,
+  UPB_SIZE(32, 64), 5, false, 4, 255,
 };
 
 static const upb_msglayout *const google_protobuf_GeneratedCodeInfo_submsgs[1] = {
@@ -466,7 +466,7 @@ static const upb_msglayout_field google_protobuf_GeneratedCodeInfo__fields[1] = 
 const upb_msglayout google_protobuf_GeneratedCodeInfo_msginit = {
   &google_protobuf_GeneratedCodeInfo_submsgs[0],
   &google_protobuf_GeneratedCodeInfo__fields[0],
-  UPB_SIZE(8, 8), 1, false, 255,
+  UPB_SIZE(8, 8), 1, false, 1, 255,
 };
 
 static const upb_msglayout_field google_protobuf_GeneratedCodeInfo_Annotation__fields[4] = {
@@ -479,7 +479,7 @@ static const upb_msglayout_field google_protobuf_GeneratedCodeInfo_Annotation__f
 const upb_msglayout google_protobuf_GeneratedCodeInfo_Annotation_msginit = {
   NULL,
   &google_protobuf_GeneratedCodeInfo_Annotation__fields[0],
-  UPB_SIZE(24, 48), 4, false, 255,
+  UPB_SIZE(24, 48), 4, false, 4, 255,
 };
 
 #include "upb/port_undef.inc"

--- a/upb/decode.c
+++ b/upb/decode.c
@@ -305,11 +305,12 @@ static const upb_msglayout_field *upb_find_field(const upb_msglayout *l,
 
   if (l == NULL) return &none;
 
-  size_t idx = (size_t)field_number - 1;  // 0 wraps to SIZE_MAX
+  size_t idx = ((size_t)field_number) - 1;  // 0 wraps to SIZE_MAX
   if (idx < l->dense_below) {
     goto found;
   }
 
+  /* Resume scanning from last_field_index since fields are usually in order. */
   int last = *last_field_index;
   for (idx = last; idx < l->field_count; idx++) {
     if (l->fields[idx].number == field_number) {
@@ -332,7 +333,7 @@ static const upb_msglayout_field *upb_find_field(const upb_msglayout *l,
 }
 
 static upb_msg *decode_newsubmsg(upb_decstate *d,
-                                 const upb_msglayout *const *submsgs,
+                                 upb_msglayout const *const *submsgs,
                                  const upb_msglayout_field *field) {
   const upb_msglayout *subl = submsgs[field->submsg_index];
   return _upb_msg_new_inl(subl, &d->arena);
@@ -365,7 +366,7 @@ static const char *decode_readstr(upb_decstate *d, const char *ptr, int size,
 UPB_FORCEINLINE
 static const char *decode_tosubmsg(upb_decstate *d, const char *ptr,
                                    upb_msg *submsg, 
-                                   const upb_msglayout *const *submsgs,
+                                   upb_msglayout const *const *submsgs,
                                    const upb_msglayout_field *field, int size) {
   const upb_msglayout *subl = submsgs[field->submsg_index];
   int saved_delta = decode_pushlimit(d, ptr, size);
@@ -397,7 +398,7 @@ static const char *decode_group(upb_decstate *d, const char *ptr,
 UPB_FORCEINLINE
 static const char *decode_togroup(upb_decstate *d, const char *ptr,
                                   upb_msg *submsg,
-                                  const upb_msglayout *const *submsgs,
+                                  upb_msglayout const *const *submsgs,
                                   const upb_msglayout_field *field) {
   const upb_msglayout *subl = submsgs[field->submsg_index];
   return decode_group(d, ptr, submsg, subl, field->number);
@@ -405,7 +406,7 @@ static const char *decode_togroup(upb_decstate *d, const char *ptr,
 
 static const char *decode_toarray(upb_decstate *d, const char *ptr,
                                   upb_msg *msg,
-                                  const upb_msglayout *const *submsgs,
+                                  upb_msglayout const *const *submsgs,
                                   const upb_msglayout_field *field, wireval *val,
                                   int op) {
   upb_array **arrp = UPB_PTR_AT(msg, field->offset, void);
@@ -494,7 +495,7 @@ static const char *decode_toarray(upb_decstate *d, const char *ptr,
 }
 
 static const char *decode_tomap(upb_decstate *d, const char *ptr, upb_msg *msg,
-                                const upb_msglayout *const *submsgs,
+                                upb_msglayout const *const *submsgs,
                                 const upb_msglayout_field *field, wireval *val) {
   upb_map **map_p = UPB_PTR_AT(msg, field->offset, upb_map *);
   upb_map *map = *map_p;
@@ -528,7 +529,7 @@ static const char *decode_tomap(upb_decstate *d, const char *ptr, upb_msg *msg,
 }
 
 static const char *decode_tomsg(upb_decstate *d, const char *ptr, upb_msg *msg,
-                                const upb_msglayout *const *submsgs,
+                                upb_msglayout const *const *submsgs,
                                 const upb_msglayout_field *field, wireval *val,
                                 int op) {
   void *mem = UPB_PTR_AT(msg, field->offset, void);

--- a/upb/def.c
+++ b/upb/def.c
@@ -1018,14 +1018,20 @@ static int field_number_cmp(const void *p1, const void *p2) {
   return f1->number - f2->number;
 }
 
-static void assign_layout_indices(const upb_msgdef *m, upb_msglayout_field *fields) {
+static void assign_layout_indices(const upb_msgdef *m, upb_msglayout *l,
+                                  upb_msglayout_field *fields) {
   int i;
   int n = upb_msgdef_numfields(m);
+  int dense_below = 0;
   for (i = 0; i < n; i++) {
     upb_fielddef *f = (upb_fielddef*)upb_msgdef_itof(m, fields[i].number);
     UPB_ASSERT(f);
     f->layout_index = i;
+    if (upb_fielddef_number(f) == i + 1) {
+      dense_below = upb_fielddef_number(f);
+    }
   }
+  l->dense_below = dense_below;
 }
 
 /* This function is the dynamic equivalent of message_layout.{cc,h} in upbc.
@@ -1197,7 +1203,7 @@ static void make_layout(symtab_addctx *ctx, const upb_msgdef *m) {
 
   /* Sort fields by number. */
   qsort(fields, upb_msgdef_numfields(m), sizeof(*fields), field_number_cmp);
-  assign_layout_indices(m, fields);
+  assign_layout_indices(m, l, fields);
 }
 
 static char *strviewdup(symtab_addctx *ctx, upb_strview view) {

--- a/upb/def.c
+++ b/upb/def.c
@@ -1027,7 +1027,7 @@ static void assign_layout_indices(const upb_msgdef *m, upb_msglayout *l,
     upb_fielddef *f = (upb_fielddef*)upb_msgdef_itof(m, fields[i].number);
     UPB_ASSERT(f);
     f->layout_index = i;
-    if (upb_fielddef_number(f) == i + 1) {
+    if (i <= 254 && upb_fielddef_number(f) == i + 1) {
       dense_below = upb_fielddef_number(f);
     }
   }

--- a/upb/def.c
+++ b/upb/def.c
@@ -1027,7 +1027,8 @@ static void assign_layout_indices(const upb_msgdef *m, upb_msglayout *l,
     upb_fielddef *f = (upb_fielddef*)upb_msgdef_itof(m, fields[i].number);
     UPB_ASSERT(f);
     f->layout_index = i;
-    if (i < UINT8_MAX && upb_fielddef_number(f) == i + 1) {
+    if (i < UINT8_MAX && fields[i].number == i + 1 &&
+        (i == 0 || fields[i-1].number == i)) {
       dense_below = i + 1;
     }
   }

--- a/upb/def.c
+++ b/upb/def.c
@@ -1027,8 +1027,8 @@ static void assign_layout_indices(const upb_msgdef *m, upb_msglayout *l,
     upb_fielddef *f = (upb_fielddef*)upb_msgdef_itof(m, fields[i].number);
     UPB_ASSERT(f);
     f->layout_index = i;
-    if (i <= 254 && upb_fielddef_number(f) == i + 1) {
-      dense_below = upb_fielddef_number(f);
+    if (i < UINT8_MAX && upb_fielddef_number(f) == i + 1) {
+      dense_below = i + 1;
     }
   }
   l->dense_below = dense_below;

--- a/upb/msg_internal.h
+++ b/upb/msg_internal.h
@@ -132,11 +132,7 @@ UPB_INLINE bool _upb_hasbit(const upb_msg *msg, size_t idx) {
 }
 
 UPB_INLINE void _upb_sethas(const upb_msg *msg, size_t idx) {
-  if (UPB_LIKELY(idx < 32)) {
-    (*UPB_PTR_AT(msg, 0, uint32_t)) |= (1UL << idx);
-  } else {
-    (*UPB_PTR_AT(msg, idx / 8, char)) |= (char)(1 << (idx % 8));
-  }
+  (*UPB_PTR_AT(msg, idx / 8, char)) |= (char)(1 << (idx % 8));
 }
 
 UPB_INLINE void _upb_clearhas(const upb_msg *msg, size_t idx) {

--- a/upb/msg_internal.h
+++ b/upb/msg_internal.h
@@ -65,6 +65,7 @@ struct upb_msglayout {
   uint16_t size;
   uint16_t field_count;
   bool extendable;
+  uint8_t dense_below;
   uint8_t table_mask;
   /* To constant-initialize the tables of variable length, we need a flexible
    * array member, and we need to compile in C99 mode. */
@@ -131,7 +132,11 @@ UPB_INLINE bool _upb_hasbit(const upb_msg *msg, size_t idx) {
 }
 
 UPB_INLINE void _upb_sethas(const upb_msg *msg, size_t idx) {
-  (*UPB_PTR_AT(msg, idx / 8, char)) |= (char)(1 << (idx % 8));
+  if (UPB_LIKELY(idx < 32)) {
+    (*UPB_PTR_AT(msg, 0, uint32_t)) |= (1UL << idx);
+  } else {
+    (*UPB_PTR_AT(msg, idx / 8, char)) |= (char)(1 << (idx % 8));
+  }
 }
 
 UPB_INLINE void _upb_clearhas(const upb_msg *msg, size_t idx) {


### PR DESCRIPTION
The primary motivation for this change is to avoid referring to the `upb_msglayout` object when we are trying to fetch the `upb_msglayout` object for a sub-message. This will help pave the way for parsing extensions. We also implement several optimizations so that we can make this change without regressing performance.

Normally we compute the layout for a sub-message field like so:

```c
const upb_msglayout *get_submsg_layout(
    const upb_msglayout *layout,
    const upb_msglayout_field *field) {
  return layout->submsgs[field->submsg_index]
}
```

The reason for this indirection is to avoid storing a pointer directly in `upb_msglayout_field`, as this would double its size (from 12 to 24 bytes on 64-bit architectures) which is wasteful as this pointer is only needed for message typed fields.

However `get_submsg_layout` as written above does not work for extensions, as they will not have entries in the message's `layout->submsgs` array by nature, and we want to avoid creating an entire fake `upb_msglayout` for each such extension since that would also be wasteful.

This change removes the dependency on `upb_msglayout` by passing down the `submsgs` array instead:

```c
const upb_msglayout *get_submsg_layout(
    const upb_msglayout *const *submsgs,
    const upb_msglayout_field *field) {
  return submsgs[field->submsg_index]
}
```

This will pave the way for parsing extensions, as we can more easily create an alternative `submsgs` array for extension fields without extra overhead or waste.

Along the way several optimizations presented themselves that allow a nice increase in performance:

1. Passing the parsed `wireval` by address instead of by value ended up avoiding an expensive and useless stack copy (this is on Clang, which was used for all measurements).
2. When field numbers are densely packed, we can find a field by number with a single indexed lookup instead of linear search. At codegen time we can compute the maximum field number that will allow such an indexed lookup.
3. For fields that do require linear search, we can start the linear search at the location where we found the previous field, taking advantage of the fact that field numbers are generally increasing.
4. When the hasbit index is less than 32 (the common case) we can use a less expensive code sequence to set it.
5. We check for the hasbit case before the oneof case, as optional fields are more common than oneof fields.

Benchmark results indicate a 20-25% reduction in parse time with a small code size increase:

```
name                                      old time/op  new time/op  delta
ArenaOneAlloc                             21.3ns ± 0%  21.9ns ± 1%   +3.08%  (p=0.000 n=11+12)
ArenaInitialBlockOneAlloc                 6.32ns ± 0%  6.32ns ± 0%     ~     (p=0.219 n=12+12)
LoadDescriptor_Upb                        53.5µs ± 1%  51.2µs ± 2%   -4.30%  (p=0.000 n=12+12)
LoadAdsDescriptor_Upb                     2.75ms ± 0%  2.67ms ± 2%   -2.68%  (p=0.000 n=10+10)
LoadDescriptor_Proto2                      240µs ± 0%   239µs ± 0%   -0.22%  (p=0.000 n=12+12)
LoadAdsDescriptor_Proto2                  12.6ms ± 0%  12.8ms ± 0%   +1.17%  (p=0.000 n=12+11)
Parse_Upb_FileDesc<UseArena,Copy>         13.2µs ± 0%  10.1µs ± 0%  -23.85%  (p=0.000 n=12+12)
Parse_Upb_FileDesc<UseArena,Alias>        11.5µs ± 0%   8.8µs ± 0%  -22.92%  (p=0.000 n=11+11)
Parse_Upb_FileDesc<InitBlock,Copy>        12.7µs ± 0%   9.6µs ± 0%  -24.68%  (p=0.000 n=11+12)
Parse_Upb_FileDesc<InitBlock,Alias>       11.0µs ± 0%   8.5µs ± 0%  -22.89%  (p=0.000 n=12+11)
Parse_Proto2<FileDesc,NoArena,Copy>       29.3µs ± 0%  29.4µs ± 0%   +0.30%  (p=0.001 n=12+12)
Parse_Proto2<FileDesc,UseArena,Copy>      20.4µs ± 2%  21.1µs ± 2%   +3.38%  (p=0.000 n=12+12)
Parse_Proto2<FileDesc,InitBlock,Copy>     16.5µs ± 0%  17.5µs ± 0%   +5.98%  (p=0.000 n=12+12)
Parse_Proto2<FileDescSV,InitBlock,Alias>  16.2µs ± 0%  17.4µs ± 0%   +7.52%  (p=0.000 n=12+11)
SerializeDescriptor_Proto2                5.35µs ± 1%  5.47µs ± 1%   +2.19%  (p=0.000 n=12+12)
SerializeDescriptor_Upb                   12.9µs ± 0%  13.1µs ± 0%   +1.41%  (p=0.000 n=12+11)


    FILE SIZE        VM SIZE    
 --------------  -------------- 
  +0.6%     +64  +0.6%     +64    upb/decode.c
    +0.7%     +64  +0.7%     +64    decode_msg
  +0.3%     +48  +0.3%     +48    upb/def.c
    +1.1%     +48  +1.1%     +48    _upb_symtab_addfile
  -3.6%    -112  [ = ]       0    [Unmapped]
  [ = ]       0  +0.1%    +112    TOTAL
```