### PR TITLE
Implemented upb_enumvaldef, for storing information about enumvals.

### DIFF
--- a/tests/bindings/lua/test_upb.lua
+++ b/tests/bindings/lua/test_upb.lua
@@ -91,7 +91,7 @@ function test_def_readers()
   -- enum
   local e = test_messages_proto3['TestAllTypesProto3.NestedEnum']
   assert_true(#e > 3 and #e < 10)
-  assert_equal(2, e:value("BAZ"))
+  assert_equal(2, e:value("BAZ"):number())
 end
 
 function test_msg_map()
@@ -715,6 +715,30 @@ function test_descriptor_error()
   }
   assert_error(function () symtab:add_file(upb.encode(file)) end)
   assert_nil(symtab:lookup_msg("ABC"))
+end
+
+function test_duplicate_enumval()
+  local symtab = upb.SymbolTable()
+  local file_proto = descriptor.FileDescriptorProto {
+    name = "test.proto",
+    message_type = upb.Array(descriptor.DescriptorProto, {
+      descriptor.DescriptorProto{
+        name = "ABC",
+      },
+    }),
+    enum_type = upb.Array(descriptor.EnumDescriptorProto, {
+      descriptor.EnumDescriptorProto{
+        name = "MyEnum",
+        value = upb.Array(descriptor.EnumValueDescriptorProto, {
+          descriptor.EnumValueDescriptorProto{
+            name = "ABC",
+            number = 1,
+          }
+        }),
+      },
+    })
+  }
+  assert_error(function () symtab:add_file(upb.encode(file_proto)) end)
 end
 
 function test_duplicate_filename_error()

--- a/upb/bindings/lua/msg.c
+++ b/upb/bindings/lua/msg.c
@@ -390,6 +390,7 @@ static int lupb_array_checkindex(lua_State *L, int narg, uint32_t max) {
  *   Array(message_type)
  */
 static int lupb_array_new(lua_State *L) {
+  int arg_count = lua_gettop(L);
   lupb_array *larray;
   upb_arena *arena;
 
@@ -410,6 +411,17 @@ static int lupb_array_new(lua_State *L) {
 
   larray->arr = upb_array_new(arena, larray->type);
   lupb_cacheset(L, larray->arr);
+
+  if (arg_count > 1) {
+    /* Set initial fields from table. */
+    int msg = arg_count + 1;
+    lua_pushnil(L);
+    while (lua_next(L, 2) != 0) {
+      lua_pushvalue(L, -2);  /* now stack is key, val, key */
+      lua_insert(L, -3);  /* now stack is key, key, val */
+      lua_settable(L, msg);
+    }
+  }
 
   return 1;
 }

--- a/upb/def.c
+++ b/upb/def.c
@@ -298,7 +298,7 @@ const upb_enumvaldef *upb_enumdef_lookupnum(const upb_enumdef *def, int32_t num)
 }
 
 const upb_enumvaldef *upb_enumdef_value(const upb_enumdef *e, int i) {
-  UPB_ASSERT(i >= 0 && i < e->value_count);
+  UPB_ASSERT(0 <= i && i < e->value_count);
   return &e->values[i];
 }
 
@@ -1773,7 +1773,7 @@ static void create_enumdef(
 
   e->file = ctx->file;
   e->defaultval = 0;
-  e->value_count = 0;
+  e->value_count = n;
   e->values = symtab_alloc(ctx, sizeof(*e->values) * n);
 
   if (n == 0) {
@@ -1783,7 +1783,7 @@ static void create_enumdef(
 
   for (i = 0; i < n; i++) {
     const google_protobuf_EnumValueDescriptorProto *val_proto = values[i];
-    upb_enumvaldef *val = (upb_enumvaldef*)&e->values[e->value_count++];
+    upb_enumvaldef *val = (upb_enumvaldef*)&e->values[i];
     upb_strview name = google_protobuf_EnumValueDescriptorProto_name(val_proto);
     upb_value v = upb_value_constptr(val);
 

--- a/upb/def.h
+++ b/upb/def.h
@@ -54,6 +54,8 @@ extern "C" {
 
 struct upb_enumdef;
 typedef struct upb_enumdef upb_enumdef;
+struct upb_enumvaldef;
+typedef struct upb_enumvaldef upb_enumvaldef;
 struct upb_fielddef;
 typedef struct upb_fielddef upb_fielddef;
 struct upb_filedef;
@@ -264,26 +266,34 @@ const char *upb_enumdef_fullname(const upb_enumdef *e);
 const char *upb_enumdef_name(const upb_enumdef *e);
 const upb_filedef *upb_enumdef_file(const upb_enumdef *e);
 int32_t upb_enumdef_default(const upb_enumdef *e);
+int upb_enumdef_valuecount(const upb_enumdef *e);
+const upb_enumvaldef *upb_enumdef_value(const upb_enumdef *e, int i);
+
+const upb_enumvaldef *upb_enumdef_lookupname(const upb_enumdef *e,
+                                             const char *name, size_t len);
+const upb_enumvaldef *upb_enumdef_lookupnum(const upb_enumdef *e, int32_t num);
+
+/* DEPRECATED, slated for removal */
 int upb_enumdef_numvals(const upb_enumdef *e);
-
-/* Enum lookups:
- * - ntoi:  look up a name with specified length.
- * - ntoiz: look up a name provided as a null-terminated string.
- * - iton:  look up an integer, returning the name as a null-terminated
- *          string. */
-bool upb_enumdef_ntoi(const upb_enumdef *e, const char *name, size_t len,
-                      int32_t *num);
-UPB_INLINE bool upb_enumdef_ntoiz(const upb_enumdef *e,
-                                  const char *name, int32_t *num) {
-  return upb_enumdef_ntoi(e, name, strlen(name), num);
-}
-const char *upb_enumdef_iton(const upb_enumdef *e, int32_t num);
-
 void upb_enum_begin(upb_enum_iter *iter, const upb_enumdef *e);
 void upb_enum_next(upb_enum_iter *iter);
 bool upb_enum_done(upb_enum_iter *iter);
 const char *upb_enum_iter_name(upb_enum_iter *iter);
 int32_t upb_enum_iter_number(upb_enum_iter *iter);
+/* END DEPRECATED */
+
+// Convenience wrapper.
+UPB_INLINE const upb_enumvaldef *upb_enumdef_lookupnamez(const upb_enumdef *e,
+                                                         const char *name) {
+  return upb_enumdef_lookupname(e, name, strlen(name));
+}
+
+/* upb_enumvaldef *************************************************************/
+
+const char *upb_enumvaldef_fullname(const upb_enumvaldef *e);
+const char *upb_enumvaldef_name(const upb_enumvaldef *e);
+int32_t upb_enumvaldef_number(const upb_enumvaldef *e);
+const upb_enumdef *upb_enumvaldef_enum(const upb_enumvaldef *e);
 
 /* upb_filedef ****************************************************************/
 
@@ -308,6 +318,8 @@ const upb_msgdef *upb_symtab_lookupmsg(const upb_symtab *s, const char *sym);
 const upb_msgdef *upb_symtab_lookupmsg2(
     const upb_symtab *s, const char *sym, size_t len);
 const upb_enumdef *upb_symtab_lookupenum(const upb_symtab *s, const char *sym);
+const upb_enumvaldef *upb_symtab_lookupenumval(const upb_symtab *s,
+                                               const char *sym);
 const upb_filedef *upb_symtab_lookupfile(const upb_symtab *s, const char *name);
 const upb_filedef *upb_symtab_lookupfile2(
     const upb_symtab *s, const char *name, size_t len);

--- a/upb/def.hpp
+++ b/upb/def.hpp
@@ -312,6 +312,19 @@ class MessageDefPtr {
   const upb_msgdef* ptr_;
 };
 
+class EnumValDefPtr {
+ public:
+  EnumValDefPtr() : ptr_(nullptr) {}
+  explicit EnumValDefPtr(const upb_enumvaldef* ptr) : ptr_(ptr) {}
+
+  int32_t number() const { return upb_enumvaldef_number(ptr_); }
+  const char *full_name() const { return upb_enumvaldef_fullname(ptr_); }
+  const char *name() const { return upb_enumvaldef_name(ptr_); }
+
+ private:
+  const upb_enumvaldef* ptr_;
+};
+
 class EnumDefPtr {
  public:
   EnumDefPtr() : ptr_(nullptr) {}
@@ -335,15 +348,15 @@ class EnumDefPtr {
   int value_count() const { return upb_enumdef_numvals(ptr_); }
 
   // Lookups from name to integer, returning true if found.
-  bool FindValueByName(const char* name, int32_t* num) const {
-    return upb_enumdef_ntoiz(ptr_, name, num);
+  const EnumValDefPtr FindValueByName(const char* name) const {
+    return EnumValDefPtr(upb_enumdef_lookupnamez(ptr_, name));
   }
 
   // Finds the name corresponding to the given number, or NULL if none was
   // found.  If more than one name corresponds to this number, returns the
   // first one that was added.
-  const char* FindValueByNumber(int32_t num) const {
-    return upb_enumdef_iton(ptr_, num);
+  const EnumValDefPtr FindValueByNumber(int32_t num) const {
+    return EnumValDefPtr(upb_enumdef_lookupnum(ptr_, num));
   }
 
   // Iteration over name/value pairs.  The order is undefined.

--- a/upb/def.hpp
+++ b/upb/def.hpp
@@ -348,14 +348,14 @@ class EnumDefPtr {
   int value_count() const { return upb_enumdef_numvals(ptr_); }
 
   // Lookups from name to integer, returning true if found.
-  const EnumValDefPtr FindValueByName(const char* name) const {
+  EnumValDefPtr FindValueByName(const char* name) const {
     return EnumValDefPtr(upb_enumdef_lookupnamez(ptr_, name));
   }
 
   // Finds the name corresponding to the given number, or NULL if none was
   // found.  If more than one name corresponds to this number, returns the
   // first one that was added.
-  const EnumValDefPtr FindValueByNumber(int32_t num) const {
+  EnumValDefPtr FindValueByNumber(int32_t num) const {
     return EnumValDefPtr(upb_enumdef_lookupnum(ptr_, num));
   }
 

--- a/upb/json_decode.c
+++ b/upb/json_decode.c
@@ -814,10 +814,13 @@ static upb_msgval jsondec_strfield(jsondec *d, const upb_fielddef *f) {
 static upb_msgval jsondec_enum(jsondec *d, const upb_fielddef *f) {
   switch (jsondec_peek(d)) {
     case JD_STRING: {
-      const upb_enumdef *e = upb_fielddef_enumsubdef(f);
       upb_strview str = jsondec_string(d);
+      const upb_enumdef *e = upb_fielddef_enumsubdef(f);
+      const upb_enumvaldef *ev = upb_enumdef_lookupname(e, str.data, str.size);
       upb_msgval val;
-      if (!upb_enumdef_ntoi(e, str.data, str.size, &val.int32_val)) {
+      if (ev) {
+        val.int32_val = upb_enumvaldef_number(ev);
+      } else {
         if (d->options & UPB_JSONDEC_IGNOREUNKNOWN) {
           val.int32_val = 0;
         } else {

--- a/upb/json_encode.c
+++ b/upb/json_encode.c
@@ -203,10 +203,10 @@ static void jsonenc_enum(int32_t val, const upb_fielddef *f, jsonenc *e) {
   if (strcmp(upb_enumdef_fullname(e_def), "google.protobuf.NullValue") == 0) {
     jsonenc_putstr(e, "null");
   } else {
-    const char *name = upb_enumdef_iton(e_def, val);
+    const upb_enumvaldef *ev = upb_enumdef_lookupnum(e_def, val);
 
-    if (name) {
-      jsonenc_printf(e, "\"%s\"", name);
+    if (ev) {
+      jsonenc_printf(e, "\"%s\"", upb_enumvaldef_name(ev));
     } else {
       jsonenc_printf(e, "%" PRId32, val);
     }

--- a/upb/text_encode.c
+++ b/upb/text_encode.c
@@ -102,10 +102,10 @@ static void txtenc_endfield(txtenc *e) {
 
 static void txtenc_enum(int32_t val, const upb_fielddef *f, txtenc *e) {
   const upb_enumdef *e_def = upb_fielddef_enumsubdef(f);
-  const char *name = upb_enumdef_iton(e_def, val);
+  const upb_enumvaldef *ev = upb_enumdef_lookupnum(e_def, val);
 
-  if (name) {
-    txtenc_printf(e, "%s", name);
+  if (ev) {
+    txtenc_printf(e, "%s", upb_enumvaldef_name(ev));
   } else {
     txtenc_printf(e, "%" PRId32, val);
   }


### PR DESCRIPTION
Previously `upb_enumdef` (the upb equivalent of `proto2::EnumDescriptor`) just contained `name -> number` and `number -> name` maps. There was no explicit def for each individual enum value.

We need `upb_enumvaldef` for two reasons:

1. (immediate need): we need to be able to look up all enum values underneath a given message. Thanks to proto's weird scoping rules, these enum values are *not* in the scope of the enum itself, so the `upb_enumdef`'s table cannot be used to perform this lookup. We unfortunately have to look up the enum values in the `upb_symtab` global map, since the value could come from any number of enums under the message.
2. (future need): Any enum value can have custom options attached, and we need a place to store these custom options.

There is minor code size growth, which is fine, but unfortunately this regresses the Ads benchmark for schema loading by 10%.

```
name                                      old time/op  new time/op  delta                                                                                                     
ArenaOneAlloc                             20.9ns ± 0%  21.4ns ± 1%   +2.25%  (p=0.000 n=12+12)           
ArenaInitialBlockOneAlloc                 6.29ns ± 0%  6.28ns ± 0%   -0.05%  (p=0.000 n=12+11)           
LoadDescriptor_Upb                        53.6µs ± 1%  54.8µs ± 1%   +2.24%  (p=0.000 n=12+12)           
LoadAdsDescriptor_Upb                     3.13ms ± 0%  3.45ms ± 0%  +10.22%  (p=0.000 n=12+11)           
LoadDescriptor_Proto2                      240µs ± 0%   239µs ± 0%   -0.48%  (p=0.000 n=12+12)           
LoadAdsDescriptor_Proto2                  14.5ms ± 0%  14.4ms ± 0%   -0.63%  (p=0.000 n=11+10)           
Parse_Upb_FileDesc<UseArena,Copy>         10.8µs ± 0%  11.1µs ± 0%   +3.24%  (p=0.000 n=12+11)           
Parse_Upb_FileDesc<UseArena,Alias>        9.00µs ± 0%  9.35µs ± 0%   +3.87%  (p=0.000 n=12+12)                                                                                
Parse_Upb_FileDesc<InitBlock,Copy>        10.3µs ± 0%  10.7µs ± 0%   +3.39%  (p=0.000 n=12+12)           
Parse_Upb_FileDesc<InitBlock,Alias>       8.67µs ± 0%  8.87µs ± 0%   +2.29%  (p=0.000 n=12+12)           
Parse_Proto2<FileDesc,NoArena,Copy>       29.3µs ± 0%  29.5µs ± 0%   +0.43%  (p=0.000 n=12+11)           
Parse_Proto2<FileDesc,UseArena,Copy>      20.4µs ± 2%  20.5µs ± 2%     ~     (p=0.319 n=12+12)           
Parse_Proto2<FileDesc,InitBlock,Copy>     16.7µs ± 0%  16.7µs ± 0%   -0.47%  (p=0.000 n=10+10)           
Parse_Proto2<FileDescSV,InitBlock,Alias>  16.8µs ± 0%  17.5µs ± 1%   +4.13%  (p=0.000 n=12+12)           
SerializeDescriptor_Proto2                5.31µs ± 1%  5.34µs ± 1%   +0.56%  (p=0.024 n=12+12)           
SerializeDescriptor_Upb                   12.2µs ± 0%  12.3µs ± 0%   +0.90%  (p=0.000 n=12+11)           
                                                                                                                                                                              
                                                                                                                                                                              
    FILE SIZE        VM SIZE                                                                                                                                                  
 --------------  --------------                                                                                                                                               
  +3.7%    +669  +3.6%    +568    upb/def.c                                                                                                                                   
     +43%    +416   +45%    +416    create_enumdef                                                                                                                            
    [NEW]    +148  [NEW]    +104    upb_enumvaldef_name                                                                                                                       
    [NEW]    +135  [NEW]     +88    upb_enumdef_lookupname                                                                                                                    
    [NEW]    +134  [NEW]     +88    upb_enumdef_lookupnum                                                                                                                     
    [NEW]    +102  [NEW]     +56    upb_enumvaldef_number                                                                                                                     
    +1.0%     +48  +1.1%     +48    _upb_symtab_addfile                                                                                                                       
    +0.6%     +16  +0.6%     +16    create_msgdef                                                                                                                             
    +1.1%     +16  +1.2%     +16    resolve_fielddef                                                                                                                          
    -7.6%      -8 -12.5%      -8    field_number_cmp                                                                                                                          
    -3.2%     -64  -3.3%     -64    create_fielddef                                                                                                                           
    [DEL]    -129  [DEL]     -88    upb_enumdef_iton                                                                                                                          
    [DEL]    -145  [DEL]    -104    upb_enumdef_ntoi                                                                                                                          
  +6.5%     +39  [ = ]       0    [section .strtab]                                                                                                                           
  +0.3%     +16  +0.3%     +16    upb/text_encode.c                                                                                                                           
    +1.7%     +16  +1.8%     +16    txtenc_field                                                                                                                              
  +0.6%     +15  [ = ]       0    upb/msg.c                                                                                                                                   
    +4.9%     +15  [ = ]       0    _upb_array_realloc                                                                                                                        
  -0.0%      -4  [ = ]       0    upb/table.c                                                                                                                                 
    +1.2%     +14  [ = ]       0    upb_inttable_insert                                                                                                                       
    +7.5%      +9  [ = ]       0    upb_strtable_iter_value                                                                                                                   
    +2.9%      +8  [ = ]       0    upb_strtable_lookup2                                                                                                                      
    +4.5%      +8  [ = ]       0    upb_strtable_next                                                                                                                         
    -0.2%      -1  [ = ]       0    upb_strtable_remove                                                                                                                       
    -0.2%      -7  [ = ]       0    upb_inttable_compact                                                                                                                      
    -5.8%      -7  [ = ]       0    upb_inttable_init                                                                                                                         
    -2.9%     -13  [ = ]       0    upb_inttable_sizedinit                                                                                                                    
    -5.6%     -15  [ = ]       0    upb_inttable_begin                                                                                                                        
  -0.5%     -15  [ = ]       0    tests/conformance_upb.c                                                                                                                     
    -6.8%     -15  [ = ]       0    main                                                                                                                                      
  -0.1%     -16  -0.1%     -16    upb/json_decode.c                                                                                                                           
    -0.8%     -16  -0.8%     -16    jsondec_value                                                                                                                             
  -0.5%     -32  -0.5%     -32    [section .rodata]                                                                                                                           
   -26.1%      -6 -26.1%      -6    parse_proto.msg                                                                                                                           
    -0.4%     -26  -0.4%     -26    [section .rodata]                                                                                                                         
  -0.5%     -35  [ = ]       0    bazel-out/k8-opt/bin/external/com_google_protobuf/google/protobuf/descriptor.upb.c
    -5.7%      -6  [ = ]       0    google_protobuf_EnumDescriptorProto_msginit                                                                                               
    -6.4%      -7  [ = ]       0    google_protobuf_DescriptorProto_ExtensionRange_msginit               
    -6.0%      -7  [ = ]       0    google_protobuf_EnumDescriptorProto_EnumReservedRange_msginit                                                                             
    -7.7%      -7  [ = ]       0    google_protobuf_EnumOptions_msginit                                                                                                       
    -7.6%      -8  [ = ]       0    google_protobuf_EnumValueDescriptorProto_msginit                                                                                          
 -17.0%    -533  [ = ]       0    [Unmapped]                                                                                                                                  
  +0.1%    +104  +0.4%    +536    TOTAL
```

Unfortunately I don't see an easy way around this. We're forced into the extra table entries by proto's weird enum scoping rules.