### PR TITLE
Adds upb_strtable_tryinsert() to increase the efficiency of descriptor loading.

### DIFF
--- a/benchmarks/compare.py
+++ b/benchmarks/compare.py
@@ -54,7 +54,7 @@ def Run(cmd):
   subprocess.check_call(cmd, shell=True)
 
 def Benchmark(outbase, bench_cpu=True, runs=12, fasttable=False):
-  tmpfile = "/tmp/bench-output.json"
+  tmpfile = outbase + ".json"
   Run("rm -rf {}".format(tmpfile))
   #Run("CC=clang bazel test ...")
   if fasttable:
@@ -95,11 +95,11 @@ if len(sys.argv) > 1:
     pass
 
 # Benchmark our current directory first, since it's more likely to be broken.
-Benchmark("/tmp/new", bench_cpu, fasttable=fasttable)
+Benchmark("/tmp/bench-new", bench_cpu, fasttable=fasttable)
 
 # Benchmark the baseline.
 with GitWorktree(baseline):
-  Benchmark("/tmp/old", bench_cpu, fasttable=fasttable)
+  Benchmark("/tmp/bench-old", bench_cpu, fasttable=fasttable)
 
 print()
 print()

--- a/tests/bindings/lua/test_upb.lua
+++ b/tests/bindings/lua/test_upb.lua
@@ -91,7 +91,7 @@ function test_def_readers()
   -- enum
   local e = test_messages_proto3['TestAllTypesProto3.NestedEnum']
   assert_true(#e > 3 and #e < 10)
-  assert_equal(2, e:value("BAZ"):number())
+  assert_equal(2, e:lookup("BAZ"):number())
 end
 
 function test_msg_map()

--- a/upb/def.h
+++ b/upb/def.h
@@ -161,17 +161,6 @@ UPB_INLINE const upb_fielddef *upb_oneofdef_ntofz(const upb_oneofdef *o,
 }
 const upb_fielddef *upb_oneofdef_itof(const upb_oneofdef *o, uint32_t num);
 
-/* DEPRECATED, slated for removal. */
-int upb_oneofdef_numfields(const upb_oneofdef *o);
-void upb_oneof_begin(upb_oneof_iter *iter, const upb_oneofdef *o);
-void upb_oneof_next(upb_oneof_iter *iter);
-bool upb_oneof_done(upb_oneof_iter *iter);
-upb_fielddef *upb_oneof_iter_field(const upb_oneof_iter *iter);
-void upb_oneof_iter_setdone(upb_oneof_iter *iter);
-bool upb_oneof_iter_isequal(const upb_oneof_iter *iter1,
-                            const upb_oneof_iter *iter2);
-/* END DEPRECATED */
-
 /* upb_msgdef *****************************************************************/
 
 typedef upb_inttable_iter upb_msg_field_iter;
@@ -238,26 +227,6 @@ UPB_INLINE bool upb_msgdef_lookupnamez(const upb_msgdef *m, const char *name,
 const upb_fielddef *upb_msgdef_lookupjsonname(const upb_msgdef *m,
                                               const char *name, size_t len);
 
-/* DEPRECATED, slated for removal */
-int upb_msgdef_numfields(const upb_msgdef *m);
-int upb_msgdef_numoneofs(const upb_msgdef *m);
-int upb_msgdef_numrealoneofs(const upb_msgdef *m);
-void upb_msg_field_begin(upb_msg_field_iter *iter, const upb_msgdef *m);
-void upb_msg_field_next(upb_msg_field_iter *iter);
-bool upb_msg_field_done(const upb_msg_field_iter *iter);
-upb_fielddef *upb_msg_iter_field(const upb_msg_field_iter *iter);
-void upb_msg_field_iter_setdone(upb_msg_field_iter *iter);
-bool upb_msg_field_iter_isequal(const upb_msg_field_iter * iter1,
-                                const upb_msg_field_iter * iter2);
-void upb_msg_oneof_begin(upb_msg_oneof_iter * iter, const upb_msgdef *m);
-void upb_msg_oneof_next(upb_msg_oneof_iter * iter);
-bool upb_msg_oneof_done(const upb_msg_oneof_iter *iter);
-const upb_oneofdef *upb_msg_iter_oneof(const upb_msg_oneof_iter *iter);
-void upb_msg_oneof_iter_setdone(upb_msg_oneof_iter * iter);
-bool upb_msg_oneof_iter_isequal(const upb_msg_oneof_iter *iter1,
-                                const upb_msg_oneof_iter *iter2);
-/* END DEPRECATED */
-
 /* upb_enumdef ****************************************************************/
 
 typedef upb_strtable_iter upb_enum_iter;
@@ -272,15 +241,6 @@ const upb_enumvaldef *upb_enumdef_value(const upb_enumdef *e, int i);
 const upb_enumvaldef *upb_enumdef_lookupname(const upb_enumdef *e,
                                              const char *name, size_t len);
 const upb_enumvaldef *upb_enumdef_lookupnum(const upb_enumdef *e, int32_t num);
-
-/* DEPRECATED, slated for removal */
-int upb_enumdef_numvals(const upb_enumdef *e);
-void upb_enum_begin(upb_enum_iter *iter, const upb_enumdef *e);
-void upb_enum_next(upb_enum_iter *iter);
-bool upb_enum_done(upb_enum_iter *iter);
-const char *upb_enum_iter_name(upb_enum_iter *iter);
-int32_t upb_enum_iter_number(upb_enum_iter *iter);
-/* END DEPRECATED */
 
 // Convenience wrapper.
 UPB_INLINE const upb_enumvaldef *upb_enumdef_lookupnamez(const upb_enumdef *e,

--- a/upb/def.hpp
+++ b/upb/def.hpp
@@ -167,7 +167,7 @@ class OneofDefPtr {
   const char* name() const { return upb_oneofdef_name(ptr_); }
 
   // Returns the number of fields in the oneof.
-  int field_count() const { return upb_oneofdef_numfields(ptr_); }
+  int field_count() const { return upb_oneofdef_fieldcount(ptr_); }
   FieldDefPtr field(int i) const { return FieldDefPtr(upb_oneofdef_field(ptr_, i)); }
 
   // Looks up by name.
@@ -205,11 +205,11 @@ class MessageDefPtr {
   const char* name() const { return upb_msgdef_name(ptr_); }
 
   // The number of fields that belong to the MessageDef.
-  int field_count() const { return upb_msgdef_numfields(ptr_); }
+  int field_count() const { return upb_msgdef_fieldcount(ptr_); }
   FieldDefPtr field(int i) const { return FieldDefPtr(upb_msgdef_field(ptr_, i)); }
 
   // The number of oneofs that belong to the MessageDef.
-  int oneof_count() const { return upb_msgdef_numoneofs(ptr_); }
+  int oneof_count() const { return upb_msgdef_oneofcount(ptr_); }
   OneofDefPtr oneof(int i) const { return OneofDefPtr(upb_msgdef_oneof(ptr_, i)); }
 
   upb_syntax_t syntax() const { return upb_msgdef_syntax(ptr_); }
@@ -345,7 +345,7 @@ class EnumDefPtr {
   // Returns the number of values currently defined in the enum.  Note that
   // multiple names can refer to the same number, so this may be greater than
   // the total number of unique numbers.
-  int value_count() const { return upb_enumdef_numvals(ptr_); }
+  int value_count() const { return upb_enumdef_valuecount(ptr_); }
 
   // Lookups from name to integer, returning true if found.
   EnumValDefPtr FindValueByName(const char* name) const {
@@ -358,23 +358,6 @@ class EnumDefPtr {
   EnumValDefPtr FindValueByNumber(int32_t num) const {
     return EnumValDefPtr(upb_enumdef_lookupnum(ptr_, num));
   }
-
-  // Iteration over name/value pairs.  The order is undefined.
-  // Adding an enum val invalidates any iterators.
-  //
-  // TODO: make compatible with range-for, with elements as pairs?
-  class Iterator {
-   public:
-    explicit Iterator(EnumDefPtr e) { upb_enum_begin(&iter_, e.ptr()); }
-
-    int32_t number() { return upb_enum_iter_number(&iter_); }
-    const char* name() { return upb_enum_iter_name(&iter_); }
-    bool Done() { return upb_enum_done(&iter_); }
-    void Next() { return upb_enum_next(&iter_); }
-
-   private:
-    upb_enum_iter iter_;
-  };
 
  private:
   const upb_enumdef* ptr_;

--- a/upb/table_internal.h
+++ b/upb/table_internal.h
@@ -230,6 +230,15 @@ bool upb_inttable_insert(upb_inttable *t, uintptr_t key, upb_value val,
 bool upb_strtable_insert(upb_strtable *t, const char *key, size_t len,
                          upb_value val, upb_arena *a);
 
+typedef enum {
+  kUpbTableSuccess = 0,
+  kUpbTableDuplicate = 1,
+  kUpbTableOom = 2,
+} upb_tryinsert_status;
+
+upb_tryinsert_status upb_strtable_tryinsert(upb_strtable *t, const char *key,
+                                            upb_value val, upb_arena *a);
+
 /* Looks up key in this table, returning "true" if the key was found.
  * If v is non-NULL, copies the value for this key into *v. */
 bool upb_inttable_lookup(const upb_inttable *t, uintptr_t key, upb_value *v);


### PR DESCRIPTION
This PR adds a `upb_strtable_tryinsert()` function to `upb_strtable`, to avoid a double lookup in cases where we are wanting to insert but detect duplicates. The existing function `upb_strtable_insert()` requires as a precondition that the key does not exist in the table, forcing a lookup followed by insert. `upb_strtable_tryinsert()` will return a status code if the key already existed.

This also removes some deprecated functions in `upb/def.h`. I don't expect that gRPC is using these (they only use reflection for parsing and serializing JSON, not to actually inspect the schema), so I don't expect this to be an intrusive change.

This PR regains most but not all of the performance lost in https://github.com/protocolbuffers/upb/pull/416 when we load descriptors.

```
name                                      old time/op  new time/op  delta
ArenaOneAlloc                             21.4ns ± 0%  20.9ns ± 0%   -2.55%  (p=0.000 n=12+12)
ArenaInitialBlockOneAlloc                 6.28ns ± 0%  6.94ns ± 0%  +10.46%  (p=0.000 n=12+12)
LoadDescriptor_Upb                        54.8µs ± 1%  48.8µs ± 1%  -10.91%  (p=0.000 n=12+12)
LoadAdsDescriptor_Upb                     3.49ms ± 3%  3.23ms ± 0%   -7.56%  (p=0.000 n=12+11)
LoadDescriptor_Proto2                      239µs ± 0%   239µs ± 0%   +0.08%  (p=0.028 n=12+12)
LoadAdsDescriptor_Proto2                  14.7ms ± 0%  14.7ms ± 0%   +0.19%  (p=0.000 n=10+10)
Parse_Upb_FileDesc<UseArena,Copy>         11.0µs ± 0%  10.1µs ± 0%   -8.63%  (p=0.000 n=11+12)
Parse_Upb_FileDesc<UseArena,Alias>        9.37µs ± 0%  8.65µs ± 0%   -7.75%  (p=0.000 n=11+12)
Parse_Upb_FileDesc<InitBlock,Copy>        10.5µs ± 0%   9.6µs ± 0%   -8.57%  (p=0.000 n=12+12)
Parse_Upb_FileDesc<InitBlock,Alias>       8.87µs ± 0%  8.30µs ± 0%   -6.44%  (p=0.000 n=12+12)
Parse_Proto2<FileDesc,NoArena,Copy>       29.6µs ± 0%  29.4µs ± 0%   -0.63%  (p=0.000 n=12+12)
Parse_Proto2<FileDesc,UseArena,Copy>      20.9µs ± 2%  20.8µs ± 3%     ~     (p=0.266 n=12+12)
Parse_Proto2<FileDesc,InitBlock,Copy>     16.7µs ± 0%  16.7µs ± 0%     ~     (p=0.143 n=12+12)
Parse_Proto2<FileDescSV,InitBlock,Alias>  16.8µs ± 0%  16.8µs ± 0%   -0.10%  (p=0.003 n=10+10)
SerializeDescriptor_Proto2                5.33µs ± 1%  5.36µs ± 1%     ~     (p=0.219 n=12+12)
SerializeDescriptor_Upb                   12.4µs ± 0%  12.5µs ± 0%   +0.26%  (p=0.000 n=12+12)


    FILE SIZE        VM SIZE    
 --------------  -------------- 
  +7.3%    +742  +7.6%    +696    upb/table.c
    [NEW]    +743  [NEW]    +696    upb_strtable_tryinsert
    +6.1%      +7  [ = ]       0    upb_inttable_init
    -0.2%      -8  [ = ]       0    upb_inttable_compact
  +0.1%      +1  [ = ]       0    [section .strtab]
  -1.8%    -336  -2.1%    -336    upb/def.c
    -2.2%     -64  -2.3%     -64    create_msgdef
    -7.1%     -96  -7.3%     -96    create_enumdef
    -9.1%    -176  -9.3%    -176    create_fielddef
 -13.7%    -359  [ = ]       0    [Unmapped]
  +0.0%     +48  +0.3%    +360    TOTAL
```

I can't explain why some unrelated benchmarks (like arena and parse) are showing wide swings. It seems to be a benchmarking artifact, possible related to alignment.