### PR TITLE
Install additional packages to run test on Bazel CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -2,6 +2,8 @@
 tasks:
   ubuntu:
     platform: ubuntu1804
+    shell_commands:
+    - "sudo apt -y update && sudo apt -y install libreadline-dev cmake"
     test_targets:
     - //...
   macos:


### PR DESCRIPTION
The ubuntu task has been red for a long time on Bazel CI caused by `cmake: command not found`. It used to work fine since `cmake` was preinstalled on the containers.

However, instead of preinstalling a lot of dependencies, we want to only have minimal packages preinstalled and let projects can just install whatever they need in config files. bazelbuild/continuous-integration#1214

This PR adds the shell commands to install `cmake`.

Example run: https://buildkite.com/bazel/upb/builds/886#93cd29b0-c46b-4563-9330-47fc301c5312.

Note that macos test failed because of other issues.