### PR TITLE
Updated rules_fuzzing which brings GCC compatibility.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -45,9 +45,9 @@ system_python(
 
 http_archive(
     name = "rules_fuzzing",
-    sha256 = "127d7c45e9b7520b3c42145b3cb1b8c26477cdaed0521b02a0298907339fefa1",
-    strip_prefix = "rules_fuzzing-0.2.0",
-    urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/v0.2.0.zip"],
+    sha256 = "e1b54211f7cee604194db080a8765220d3ef5db2a873fded429ce13e74d93a6b",
+    strip_prefix = "rules_fuzzing-4bafba51ffd9d418d236adb61de36fda1a90e764",
+    urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/4bafba51ffd9d418d236adb61de36fda1a90e764.zip"],
 )
 
 load("@rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -139,12 +139,6 @@ cc_test(
     ],
 )
 
-# OSS-Fuzz test
-config_setting(
-    name = "is_clang",
-    flag_values = {"@bazel_tools//tools/cpp:compiler": "clang"},
-)
-
 cc_fuzz_test(
     name = "file_descriptor_parsenew_fuzzer",
     srcs = ["file_descriptor_parsenew_fuzzer.cc"],
@@ -152,10 +146,6 @@ cc_fuzz_test(
         "//:descriptor_upb_proto",
         "//:upb",
     ],
-    target_compatible_with = select({
-        ":is_clang": [],
-        "//conditions:default": ["@platforms//:incompatible"]
-    }),
 )
 
 upb_proto_library(


### PR DESCRIPTION
The fix we are pulling in is: https://github.com/bazelbuild/rules_fuzzing/pull/177

With GCC compatibility, we no longer need to disable the rule under Clang.