### PR TITLE
Added support for extensions.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -215,6 +215,27 @@ cc_library(
     ],
 )
 
+cc_test(
+    name = "msg_test",
+    srcs = ["upb/msg_test.cc"],
+    deps = [
+        "@com_google_googletest//:gtest_main",
+        ":msg_test_upb_proto_reflection",
+        ":json",
+    ],
+)
+
+proto_library(
+    name = "msg_test_proto",
+    srcs = ["upb/msg_test.proto"],
+    deps = ["@com_google_protobuf//:test_messages_proto3_proto"],
+)
+
+upb_proto_reflection_library(
+    name = "msg_test_upb_proto_reflection",
+    deps = [":msg_test_proto"],
+)
+
 # Internal C/C++ libraries #####################################################
 
 cc_library(

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Like the main protobuf implementation in C++, it supports:
 - reflection
 - binary & JSON wire formats
 - text format serialization
-- all standard features of protobufs (oneofs, maps, unknown fields, etc.)
+- all standard features of protobufs (oneofs, maps, unknown fields, extensions,
+  etc.)
 - full conformance with the protobuf conformance tests
 
 upb also supports some features that C++ does not:
@@ -36,9 +37,8 @@ upb also supports some features that C++ does not:
 - **fast reflection-based parsing:** messages loaded at runtime parse
   just as fast as compiled-in messages.
 
-However there are some features it does not support:
+However there are a few features it does not support:
 
-- proto2 extensions (coming soon!)
 - text format parsing
 - deep descriptor verification: upb's descriptor validation is not as exhaustive
   as `protoc`.

--- a/cmake/google/protobuf/descriptor.upb.c
+++ b/cmake/google/protobuf/descriptor.upb.c
@@ -12,474 +12,511 @@
 
 #include "upb/port_def.inc"
 
-static const upb_msglayout *const google_protobuf_FileDescriptorSet_submsgs[1] = {
-  &google_protobuf_FileDescriptorProto_msginit,
+static const upb_msglayout_sub google_protobuf_FileDescriptorSet_submsgs[1] = {
+  {.submsg = &google_protobuf_FileDescriptorProto_msginit},
 };
 
 static const upb_msglayout_field google_protobuf_FileDescriptorSet__fields[1] = {
-  {1, UPB_SIZE(0, 0), 0, 0, 11, _UPB_MODE_ARRAY},
+  {1, UPB_SIZE(0, 0), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
 };
 
 const upb_msglayout google_protobuf_FileDescriptorSet_msginit = {
   &google_protobuf_FileDescriptorSet_submsgs[0],
   &google_protobuf_FileDescriptorSet__fields[0],
-  UPB_SIZE(8, 8), 1, false, 1, 255,
+  UPB_SIZE(8, 8), 1, _UPB_MSGEXT_NONE, 1, 255,
 };
 
-static const upb_msglayout *const google_protobuf_FileDescriptorProto_submsgs[6] = {
-  &google_protobuf_DescriptorProto_msginit,
-  &google_protobuf_EnumDescriptorProto_msginit,
-  &google_protobuf_FieldDescriptorProto_msginit,
-  &google_protobuf_FileOptions_msginit,
-  &google_protobuf_ServiceDescriptorProto_msginit,
-  &google_protobuf_SourceCodeInfo_msginit,
+static const upb_msglayout_sub google_protobuf_FileDescriptorProto_submsgs[6] = {
+  {.submsg = &google_protobuf_DescriptorProto_msginit},
+  {.submsg = &google_protobuf_EnumDescriptorProto_msginit},
+  {.submsg = &google_protobuf_FieldDescriptorProto_msginit},
+  {.submsg = &google_protobuf_FileOptions_msginit},
+  {.submsg = &google_protobuf_ServiceDescriptorProto_msginit},
+  {.submsg = &google_protobuf_SourceCodeInfo_msginit},
 };
 
 static const upb_msglayout_field google_protobuf_FileDescriptorProto__fields[12] = {
-  {1, UPB_SIZE(4, 8), 1, 0, 12, _UPB_MODE_SCALAR},
-  {2, UPB_SIZE(12, 24), 2, 0, 12, _UPB_MODE_SCALAR},
-  {3, UPB_SIZE(36, 72), 0, 0, 12, _UPB_MODE_ARRAY},
-  {4, UPB_SIZE(40, 80), 0, 0, 11, _UPB_MODE_ARRAY},
-  {5, UPB_SIZE(44, 88), 0, 1, 11, _UPB_MODE_ARRAY},
-  {6, UPB_SIZE(48, 96), 0, 4, 11, _UPB_MODE_ARRAY},
-  {7, UPB_SIZE(52, 104), 0, 2, 11, _UPB_MODE_ARRAY},
-  {8, UPB_SIZE(28, 56), 3, 3, 11, _UPB_MODE_SCALAR},
-  {9, UPB_SIZE(32, 64), 4, 5, 11, _UPB_MODE_SCALAR},
-  {10, UPB_SIZE(56, 112), 0, 0, 5, _UPB_MODE_ARRAY},
-  {11, UPB_SIZE(60, 120), 0, 0, 5, _UPB_MODE_ARRAY},
-  {12, UPB_SIZE(20, 40), 5, 0, 12, _UPB_MODE_SCALAR},
+  {1, UPB_SIZE(4, 8), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {2, UPB_SIZE(12, 24), 2, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {3, UPB_SIZE(36, 72), 0, 0, 12, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {4, UPB_SIZE(40, 80), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {5, UPB_SIZE(44, 88), 0, 1, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {6, UPB_SIZE(48, 96), 0, 4, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {7, UPB_SIZE(52, 104), 0, 2, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {8, UPB_SIZE(28, 56), 3, 3, 11, _UPB_MODE_SCALAR | (_UPB_REP_PTR << 6)},
+  {9, UPB_SIZE(32, 64), 4, 5, 11, _UPB_MODE_SCALAR | (_UPB_REP_PTR << 6)},
+  {10, UPB_SIZE(56, 112), 0, 0, 5, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {11, UPB_SIZE(60, 120), 0, 0, 5, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {12, UPB_SIZE(20, 40), 5, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
 };
 
 const upb_msglayout google_protobuf_FileDescriptorProto_msginit = {
   &google_protobuf_FileDescriptorProto_submsgs[0],
   &google_protobuf_FileDescriptorProto__fields[0],
-  UPB_SIZE(64, 128), 12, false, 12, 255,
+  UPB_SIZE(64, 128), 12, _UPB_MSGEXT_NONE, 12, 255,
 };
 
-static const upb_msglayout *const google_protobuf_DescriptorProto_submsgs[7] = {
-  &google_protobuf_DescriptorProto_msginit,
-  &google_protobuf_DescriptorProto_ExtensionRange_msginit,
-  &google_protobuf_DescriptorProto_ReservedRange_msginit,
-  &google_protobuf_EnumDescriptorProto_msginit,
-  &google_protobuf_FieldDescriptorProto_msginit,
-  &google_protobuf_MessageOptions_msginit,
-  &google_protobuf_OneofDescriptorProto_msginit,
+static const upb_msglayout_sub google_protobuf_DescriptorProto_submsgs[7] = {
+  {.submsg = &google_protobuf_DescriptorProto_msginit},
+  {.submsg = &google_protobuf_DescriptorProto_ExtensionRange_msginit},
+  {.submsg = &google_protobuf_DescriptorProto_ReservedRange_msginit},
+  {.submsg = &google_protobuf_EnumDescriptorProto_msginit},
+  {.submsg = &google_protobuf_FieldDescriptorProto_msginit},
+  {.submsg = &google_protobuf_MessageOptions_msginit},
+  {.submsg = &google_protobuf_OneofDescriptorProto_msginit},
 };
 
 static const upb_msglayout_field google_protobuf_DescriptorProto__fields[10] = {
-  {1, UPB_SIZE(4, 8), 1, 0, 12, _UPB_MODE_SCALAR},
-  {2, UPB_SIZE(16, 32), 0, 4, 11, _UPB_MODE_ARRAY},
-  {3, UPB_SIZE(20, 40), 0, 0, 11, _UPB_MODE_ARRAY},
-  {4, UPB_SIZE(24, 48), 0, 3, 11, _UPB_MODE_ARRAY},
-  {5, UPB_SIZE(28, 56), 0, 1, 11, _UPB_MODE_ARRAY},
-  {6, UPB_SIZE(32, 64), 0, 4, 11, _UPB_MODE_ARRAY},
-  {7, UPB_SIZE(12, 24), 2, 5, 11, _UPB_MODE_SCALAR},
-  {8, UPB_SIZE(36, 72), 0, 6, 11, _UPB_MODE_ARRAY},
-  {9, UPB_SIZE(40, 80), 0, 2, 11, _UPB_MODE_ARRAY},
-  {10, UPB_SIZE(44, 88), 0, 0, 12, _UPB_MODE_ARRAY},
+  {1, UPB_SIZE(4, 8), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {2, UPB_SIZE(16, 32), 0, 4, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {3, UPB_SIZE(20, 40), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {4, UPB_SIZE(24, 48), 0, 3, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {5, UPB_SIZE(28, 56), 0, 1, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {6, UPB_SIZE(32, 64), 0, 4, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {7, UPB_SIZE(12, 24), 2, 5, 11, _UPB_MODE_SCALAR | (_UPB_REP_PTR << 6)},
+  {8, UPB_SIZE(36, 72), 0, 6, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {9, UPB_SIZE(40, 80), 0, 2, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {10, UPB_SIZE(44, 88), 0, 0, 12, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
 };
 
 const upb_msglayout google_protobuf_DescriptorProto_msginit = {
   &google_protobuf_DescriptorProto_submsgs[0],
   &google_protobuf_DescriptorProto__fields[0],
-  UPB_SIZE(48, 96), 10, false, 10, 255,
+  UPB_SIZE(48, 96), 10, _UPB_MSGEXT_NONE, 10, 255,
 };
 
-static const upb_msglayout *const google_protobuf_DescriptorProto_ExtensionRange_submsgs[1] = {
-  &google_protobuf_ExtensionRangeOptions_msginit,
+static const upb_msglayout_sub google_protobuf_DescriptorProto_ExtensionRange_submsgs[1] = {
+  {.submsg = &google_protobuf_ExtensionRangeOptions_msginit},
 };
 
 static const upb_msglayout_field google_protobuf_DescriptorProto_ExtensionRange__fields[3] = {
-  {1, UPB_SIZE(4, 4), 1, 0, 5, _UPB_MODE_SCALAR},
-  {2, UPB_SIZE(8, 8), 2, 0, 5, _UPB_MODE_SCALAR},
-  {3, UPB_SIZE(12, 16), 3, 0, 11, _UPB_MODE_SCALAR},
+  {1, UPB_SIZE(4, 4), 1, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
+  {2, UPB_SIZE(8, 8), 2, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
+  {3, UPB_SIZE(12, 16), 3, 0, 11, _UPB_MODE_SCALAR | (_UPB_REP_PTR << 6)},
 };
 
 const upb_msglayout google_protobuf_DescriptorProto_ExtensionRange_msginit = {
   &google_protobuf_DescriptorProto_ExtensionRange_submsgs[0],
   &google_protobuf_DescriptorProto_ExtensionRange__fields[0],
-  UPB_SIZE(16, 24), 3, false, 3, 255,
+  UPB_SIZE(16, 24), 3, _UPB_MSGEXT_NONE, 3, 255,
 };
 
 static const upb_msglayout_field google_protobuf_DescriptorProto_ReservedRange__fields[2] = {
-  {1, UPB_SIZE(4, 4), 1, 0, 5, _UPB_MODE_SCALAR},
-  {2, UPB_SIZE(8, 8), 2, 0, 5, _UPB_MODE_SCALAR},
+  {1, UPB_SIZE(4, 4), 1, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
+  {2, UPB_SIZE(8, 8), 2, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
 };
 
 const upb_msglayout google_protobuf_DescriptorProto_ReservedRange_msginit = {
   NULL,
   &google_protobuf_DescriptorProto_ReservedRange__fields[0],
-  UPB_SIZE(16, 16), 2, false, 2, 255,
+  UPB_SIZE(16, 16), 2, _UPB_MSGEXT_NONE, 2, 255,
 };
 
-static const upb_msglayout *const google_protobuf_ExtensionRangeOptions_submsgs[1] = {
-  &google_protobuf_UninterpretedOption_msginit,
+static const upb_msglayout_sub google_protobuf_ExtensionRangeOptions_submsgs[1] = {
+  {.submsg = &google_protobuf_UninterpretedOption_msginit},
 };
 
 static const upb_msglayout_field google_protobuf_ExtensionRangeOptions__fields[1] = {
-  {999, UPB_SIZE(0, 0), 0, 0, 11, _UPB_MODE_ARRAY},
+  {999, UPB_SIZE(0, 0), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
 };
 
 const upb_msglayout google_protobuf_ExtensionRangeOptions_msginit = {
   &google_protobuf_ExtensionRangeOptions_submsgs[0],
   &google_protobuf_ExtensionRangeOptions__fields[0],
-  UPB_SIZE(8, 8), 1, false, 0, 255,
+  UPB_SIZE(8, 8), 1, _UPB_MSGEXT_EXTENDABLE, 0, 255,
 };
 
-static const upb_msglayout *const google_protobuf_FieldDescriptorProto_submsgs[1] = {
-  &google_protobuf_FieldOptions_msginit,
+static const upb_msglayout_sub google_protobuf_FieldDescriptorProto_submsgs[1] = {
+  {.submsg = &google_protobuf_FieldOptions_msginit},
 };
 
 static const upb_msglayout_field google_protobuf_FieldDescriptorProto__fields[11] = {
-  {1, UPB_SIZE(24, 24), 1, 0, 12, _UPB_MODE_SCALAR},
-  {2, UPB_SIZE(32, 40), 2, 0, 12, _UPB_MODE_SCALAR},
-  {3, UPB_SIZE(12, 12), 3, 0, 5, _UPB_MODE_SCALAR},
-  {4, UPB_SIZE(4, 4), 4, 0, 14, _UPB_MODE_SCALAR},
-  {5, UPB_SIZE(8, 8), 5, 0, 14, _UPB_MODE_SCALAR},
-  {6, UPB_SIZE(40, 56), 6, 0, 12, _UPB_MODE_SCALAR},
-  {7, UPB_SIZE(48, 72), 7, 0, 12, _UPB_MODE_SCALAR},
-  {8, UPB_SIZE(64, 104), 8, 0, 11, _UPB_MODE_SCALAR},
-  {9, UPB_SIZE(16, 16), 9, 0, 5, _UPB_MODE_SCALAR},
-  {10, UPB_SIZE(56, 88), 10, 0, 12, _UPB_MODE_SCALAR},
-  {17, UPB_SIZE(20, 20), 11, 0, 8, _UPB_MODE_SCALAR},
+  {1, UPB_SIZE(24, 24), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {2, UPB_SIZE(32, 40), 2, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {3, UPB_SIZE(12, 12), 3, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
+  {4, UPB_SIZE(4, 4), 4, 0, 14, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
+  {5, UPB_SIZE(8, 8), 5, 0, 14, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
+  {6, UPB_SIZE(40, 56), 6, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {7, UPB_SIZE(48, 72), 7, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {8, UPB_SIZE(64, 104), 8, 0, 11, _UPB_MODE_SCALAR | (_UPB_REP_PTR << 6)},
+  {9, UPB_SIZE(16, 16), 9, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
+  {10, UPB_SIZE(56, 88), 10, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {17, UPB_SIZE(20, 20), 11, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
 };
 
 const upb_msglayout google_protobuf_FieldDescriptorProto_msginit = {
   &google_protobuf_FieldDescriptorProto_submsgs[0],
   &google_protobuf_FieldDescriptorProto__fields[0],
-  UPB_SIZE(72, 112), 11, false, 10, 255,
+  UPB_SIZE(72, 112), 11, _UPB_MSGEXT_NONE, 10, 255,
 };
 
-static const upb_msglayout *const google_protobuf_OneofDescriptorProto_submsgs[1] = {
-  &google_protobuf_OneofOptions_msginit,
+static const upb_msglayout_sub google_protobuf_OneofDescriptorProto_submsgs[1] = {
+  {.submsg = &google_protobuf_OneofOptions_msginit},
 };
 
 static const upb_msglayout_field google_protobuf_OneofDescriptorProto__fields[2] = {
-  {1, UPB_SIZE(4, 8), 1, 0, 12, _UPB_MODE_SCALAR},
-  {2, UPB_SIZE(12, 24), 2, 0, 11, _UPB_MODE_SCALAR},
+  {1, UPB_SIZE(4, 8), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {2, UPB_SIZE(12, 24), 2, 0, 11, _UPB_MODE_SCALAR | (_UPB_REP_PTR << 6)},
 };
 
 const upb_msglayout google_protobuf_OneofDescriptorProto_msginit = {
   &google_protobuf_OneofDescriptorProto_submsgs[0],
   &google_protobuf_OneofDescriptorProto__fields[0],
-  UPB_SIZE(16, 32), 2, false, 2, 255,
+  UPB_SIZE(16, 32), 2, _UPB_MSGEXT_NONE, 2, 255,
 };
 
-static const upb_msglayout *const google_protobuf_EnumDescriptorProto_submsgs[3] = {
-  &google_protobuf_EnumDescriptorProto_EnumReservedRange_msginit,
-  &google_protobuf_EnumOptions_msginit,
-  &google_protobuf_EnumValueDescriptorProto_msginit,
+static const upb_msglayout_sub google_protobuf_EnumDescriptorProto_submsgs[3] = {
+  {.submsg = &google_protobuf_EnumDescriptorProto_EnumReservedRange_msginit},
+  {.submsg = &google_protobuf_EnumOptions_msginit},
+  {.submsg = &google_protobuf_EnumValueDescriptorProto_msginit},
 };
 
 static const upb_msglayout_field google_protobuf_EnumDescriptorProto__fields[5] = {
-  {1, UPB_SIZE(4, 8), 1, 0, 12, _UPB_MODE_SCALAR},
-  {2, UPB_SIZE(16, 32), 0, 2, 11, _UPB_MODE_ARRAY},
-  {3, UPB_SIZE(12, 24), 2, 1, 11, _UPB_MODE_SCALAR},
-  {4, UPB_SIZE(20, 40), 0, 0, 11, _UPB_MODE_ARRAY},
-  {5, UPB_SIZE(24, 48), 0, 0, 12, _UPB_MODE_ARRAY},
+  {1, UPB_SIZE(4, 8), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {2, UPB_SIZE(16, 32), 0, 2, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {3, UPB_SIZE(12, 24), 2, 1, 11, _UPB_MODE_SCALAR | (_UPB_REP_PTR << 6)},
+  {4, UPB_SIZE(20, 40), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {5, UPB_SIZE(24, 48), 0, 0, 12, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
 };
 
 const upb_msglayout google_protobuf_EnumDescriptorProto_msginit = {
   &google_protobuf_EnumDescriptorProto_submsgs[0],
   &google_protobuf_EnumDescriptorProto__fields[0],
-  UPB_SIZE(32, 64), 5, false, 5, 255,
+  UPB_SIZE(32, 64), 5, _UPB_MSGEXT_NONE, 5, 255,
 };
 
 static const upb_msglayout_field google_protobuf_EnumDescriptorProto_EnumReservedRange__fields[2] = {
-  {1, UPB_SIZE(4, 4), 1, 0, 5, _UPB_MODE_SCALAR},
-  {2, UPB_SIZE(8, 8), 2, 0, 5, _UPB_MODE_SCALAR},
+  {1, UPB_SIZE(4, 4), 1, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
+  {2, UPB_SIZE(8, 8), 2, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
 };
 
 const upb_msglayout google_protobuf_EnumDescriptorProto_EnumReservedRange_msginit = {
   NULL,
   &google_protobuf_EnumDescriptorProto_EnumReservedRange__fields[0],
-  UPB_SIZE(16, 16), 2, false, 2, 255,
+  UPB_SIZE(16, 16), 2, _UPB_MSGEXT_NONE, 2, 255,
 };
 
-static const upb_msglayout *const google_protobuf_EnumValueDescriptorProto_submsgs[1] = {
-  &google_protobuf_EnumValueOptions_msginit,
+static const upb_msglayout_sub google_protobuf_EnumValueDescriptorProto_submsgs[1] = {
+  {.submsg = &google_protobuf_EnumValueOptions_msginit},
 };
 
 static const upb_msglayout_field google_protobuf_EnumValueDescriptorProto__fields[3] = {
-  {1, UPB_SIZE(8, 8), 1, 0, 12, _UPB_MODE_SCALAR},
-  {2, UPB_SIZE(4, 4), 2, 0, 5, _UPB_MODE_SCALAR},
-  {3, UPB_SIZE(16, 24), 3, 0, 11, _UPB_MODE_SCALAR},
+  {1, UPB_SIZE(8, 8), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {2, UPB_SIZE(4, 4), 2, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
+  {3, UPB_SIZE(16, 24), 3, 0, 11, _UPB_MODE_SCALAR | (_UPB_REP_PTR << 6)},
 };
 
 const upb_msglayout google_protobuf_EnumValueDescriptorProto_msginit = {
   &google_protobuf_EnumValueDescriptorProto_submsgs[0],
   &google_protobuf_EnumValueDescriptorProto__fields[0],
-  UPB_SIZE(24, 32), 3, false, 3, 255,
+  UPB_SIZE(24, 32), 3, _UPB_MSGEXT_NONE, 3, 255,
 };
 
-static const upb_msglayout *const google_protobuf_ServiceDescriptorProto_submsgs[2] = {
-  &google_protobuf_MethodDescriptorProto_msginit,
-  &google_protobuf_ServiceOptions_msginit,
+static const upb_msglayout_sub google_protobuf_ServiceDescriptorProto_submsgs[2] = {
+  {.submsg = &google_protobuf_MethodDescriptorProto_msginit},
+  {.submsg = &google_protobuf_ServiceOptions_msginit},
 };
 
 static const upb_msglayout_field google_protobuf_ServiceDescriptorProto__fields[3] = {
-  {1, UPB_SIZE(4, 8), 1, 0, 12, _UPB_MODE_SCALAR},
-  {2, UPB_SIZE(16, 32), 0, 0, 11, _UPB_MODE_ARRAY},
-  {3, UPB_SIZE(12, 24), 2, 1, 11, _UPB_MODE_SCALAR},
+  {1, UPB_SIZE(4, 8), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {2, UPB_SIZE(16, 32), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {3, UPB_SIZE(12, 24), 2, 1, 11, _UPB_MODE_SCALAR | (_UPB_REP_PTR << 6)},
 };
 
 const upb_msglayout google_protobuf_ServiceDescriptorProto_msginit = {
   &google_protobuf_ServiceDescriptorProto_submsgs[0],
   &google_protobuf_ServiceDescriptorProto__fields[0],
-  UPB_SIZE(24, 48), 3, false, 3, 255,
+  UPB_SIZE(24, 48), 3, _UPB_MSGEXT_NONE, 3, 255,
 };
 
-static const upb_msglayout *const google_protobuf_MethodDescriptorProto_submsgs[1] = {
-  &google_protobuf_MethodOptions_msginit,
+static const upb_msglayout_sub google_protobuf_MethodDescriptorProto_submsgs[1] = {
+  {.submsg = &google_protobuf_MethodOptions_msginit},
 };
 
 static const upb_msglayout_field google_protobuf_MethodDescriptorProto__fields[6] = {
-  {1, UPB_SIZE(4, 8), 1, 0, 12, _UPB_MODE_SCALAR},
-  {2, UPB_SIZE(12, 24), 2, 0, 12, _UPB_MODE_SCALAR},
-  {3, UPB_SIZE(20, 40), 3, 0, 12, _UPB_MODE_SCALAR},
-  {4, UPB_SIZE(28, 56), 4, 0, 11, _UPB_MODE_SCALAR},
-  {5, UPB_SIZE(1, 1), 5, 0, 8, _UPB_MODE_SCALAR},
-  {6, UPB_SIZE(2, 2), 6, 0, 8, _UPB_MODE_SCALAR},
+  {1, UPB_SIZE(4, 8), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {2, UPB_SIZE(12, 24), 2, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {3, UPB_SIZE(20, 40), 3, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {4, UPB_SIZE(28, 56), 4, 0, 11, _UPB_MODE_SCALAR | (_UPB_REP_PTR << 6)},
+  {5, UPB_SIZE(1, 1), 5, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
+  {6, UPB_SIZE(2, 2), 6, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
 };
 
 const upb_msglayout google_protobuf_MethodDescriptorProto_msginit = {
   &google_protobuf_MethodDescriptorProto_submsgs[0],
   &google_protobuf_MethodDescriptorProto__fields[0],
-  UPB_SIZE(32, 64), 6, false, 6, 255,
+  UPB_SIZE(32, 64), 6, _UPB_MSGEXT_NONE, 6, 255,
 };
 
-static const upb_msglayout *const google_protobuf_FileOptions_submsgs[1] = {
-  &google_protobuf_UninterpretedOption_msginit,
+static const upb_msglayout_sub google_protobuf_FileOptions_submsgs[1] = {
+  {.submsg = &google_protobuf_UninterpretedOption_msginit},
 };
 
 static const upb_msglayout_field google_protobuf_FileOptions__fields[21] = {
-  {1, UPB_SIZE(20, 24), 1, 0, 12, _UPB_MODE_SCALAR},
-  {8, UPB_SIZE(28, 40), 2, 0, 12, _UPB_MODE_SCALAR},
-  {9, UPB_SIZE(4, 4), 3, 0, 14, _UPB_MODE_SCALAR},
-  {10, UPB_SIZE(8, 8), 4, 0, 8, _UPB_MODE_SCALAR},
-  {11, UPB_SIZE(36, 56), 5, 0, 12, _UPB_MODE_SCALAR},
-  {16, UPB_SIZE(9, 9), 6, 0, 8, _UPB_MODE_SCALAR},
-  {17, UPB_SIZE(10, 10), 7, 0, 8, _UPB_MODE_SCALAR},
-  {18, UPB_SIZE(11, 11), 8, 0, 8, _UPB_MODE_SCALAR},
-  {20, UPB_SIZE(12, 12), 9, 0, 8, _UPB_MODE_SCALAR},
-  {23, UPB_SIZE(13, 13), 10, 0, 8, _UPB_MODE_SCALAR},
-  {27, UPB_SIZE(14, 14), 11, 0, 8, _UPB_MODE_SCALAR},
-  {31, UPB_SIZE(15, 15), 12, 0, 8, _UPB_MODE_SCALAR},
-  {36, UPB_SIZE(44, 72), 13, 0, 12, _UPB_MODE_SCALAR},
-  {37, UPB_SIZE(52, 88), 14, 0, 12, _UPB_MODE_SCALAR},
-  {39, UPB_SIZE(60, 104), 15, 0, 12, _UPB_MODE_SCALAR},
-  {40, UPB_SIZE(68, 120), 16, 0, 12, _UPB_MODE_SCALAR},
-  {41, UPB_SIZE(76, 136), 17, 0, 12, _UPB_MODE_SCALAR},
-  {42, UPB_SIZE(16, 16), 18, 0, 8, _UPB_MODE_SCALAR},
-  {44, UPB_SIZE(84, 152), 19, 0, 12, _UPB_MODE_SCALAR},
-  {45, UPB_SIZE(92, 168), 20, 0, 12, _UPB_MODE_SCALAR},
-  {999, UPB_SIZE(100, 184), 0, 0, 11, _UPB_MODE_ARRAY},
+  {1, UPB_SIZE(20, 24), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {8, UPB_SIZE(28, 40), 2, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {9, UPB_SIZE(4, 4), 3, 0, 14, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
+  {10, UPB_SIZE(8, 8), 4, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
+  {11, UPB_SIZE(36, 56), 5, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {16, UPB_SIZE(9, 9), 6, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
+  {17, UPB_SIZE(10, 10), 7, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
+  {18, UPB_SIZE(11, 11), 8, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
+  {20, UPB_SIZE(12, 12), 9, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
+  {23, UPB_SIZE(13, 13), 10, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
+  {27, UPB_SIZE(14, 14), 11, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
+  {31, UPB_SIZE(15, 15), 12, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
+  {36, UPB_SIZE(44, 72), 13, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {37, UPB_SIZE(52, 88), 14, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {39, UPB_SIZE(60, 104), 15, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {40, UPB_SIZE(68, 120), 16, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {41, UPB_SIZE(76, 136), 17, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {42, UPB_SIZE(16, 16), 18, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
+  {44, UPB_SIZE(84, 152), 19, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {45, UPB_SIZE(92, 168), 20, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {999, UPB_SIZE(100, 184), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
 };
 
 const upb_msglayout google_protobuf_FileOptions_msginit = {
   &google_protobuf_FileOptions_submsgs[0],
   &google_protobuf_FileOptions__fields[0],
-  UPB_SIZE(104, 192), 21, false, 1, 255,
+  UPB_SIZE(104, 192), 21, _UPB_MSGEXT_EXTENDABLE, 1, 255,
 };
 
-static const upb_msglayout *const google_protobuf_MessageOptions_submsgs[1] = {
-  &google_protobuf_UninterpretedOption_msginit,
+static const upb_msglayout_sub google_protobuf_MessageOptions_submsgs[1] = {
+  {.submsg = &google_protobuf_UninterpretedOption_msginit},
 };
 
 static const upb_msglayout_field google_protobuf_MessageOptions__fields[5] = {
-  {1, UPB_SIZE(1, 1), 1, 0, 8, _UPB_MODE_SCALAR},
-  {2, UPB_SIZE(2, 2), 2, 0, 8, _UPB_MODE_SCALAR},
-  {3, UPB_SIZE(3, 3), 3, 0, 8, _UPB_MODE_SCALAR},
-  {7, UPB_SIZE(4, 4), 4, 0, 8, _UPB_MODE_SCALAR},
-  {999, UPB_SIZE(8, 8), 0, 0, 11, _UPB_MODE_ARRAY},
+  {1, UPB_SIZE(1, 1), 1, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
+  {2, UPB_SIZE(2, 2), 2, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
+  {3, UPB_SIZE(3, 3), 3, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
+  {7, UPB_SIZE(4, 4), 4, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
+  {999, UPB_SIZE(8, 8), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
 };
 
 const upb_msglayout google_protobuf_MessageOptions_msginit = {
   &google_protobuf_MessageOptions_submsgs[0],
   &google_protobuf_MessageOptions__fields[0],
-  UPB_SIZE(16, 16), 5, false, 3, 255,
+  UPB_SIZE(16, 16), 5, _UPB_MSGEXT_EXTENDABLE, 3, 255,
 };
 
-static const upb_msglayout *const google_protobuf_FieldOptions_submsgs[1] = {
-  &google_protobuf_UninterpretedOption_msginit,
+static const upb_msglayout_sub google_protobuf_FieldOptions_submsgs[1] = {
+  {.submsg = &google_protobuf_UninterpretedOption_msginit},
 };
 
 static const upb_msglayout_field google_protobuf_FieldOptions__fields[7] = {
-  {1, UPB_SIZE(4, 4), 1, 0, 14, _UPB_MODE_SCALAR},
-  {2, UPB_SIZE(12, 12), 2, 0, 8, _UPB_MODE_SCALAR},
-  {3, UPB_SIZE(13, 13), 3, 0, 8, _UPB_MODE_SCALAR},
-  {5, UPB_SIZE(14, 14), 4, 0, 8, _UPB_MODE_SCALAR},
-  {6, UPB_SIZE(8, 8), 5, 0, 14, _UPB_MODE_SCALAR},
-  {10, UPB_SIZE(15, 15), 6, 0, 8, _UPB_MODE_SCALAR},
-  {999, UPB_SIZE(16, 16), 0, 0, 11, _UPB_MODE_ARRAY},
+  {1, UPB_SIZE(4, 4), 1, 0, 14, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
+  {2, UPB_SIZE(12, 12), 2, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
+  {3, UPB_SIZE(13, 13), 3, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
+  {5, UPB_SIZE(14, 14), 4, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
+  {6, UPB_SIZE(8, 8), 5, 0, 14, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
+  {10, UPB_SIZE(15, 15), 6, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
+  {999, UPB_SIZE(16, 16), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
 };
 
 const upb_msglayout google_protobuf_FieldOptions_msginit = {
   &google_protobuf_FieldOptions_submsgs[0],
   &google_protobuf_FieldOptions__fields[0],
-  UPB_SIZE(24, 24), 7, false, 3, 255,
+  UPB_SIZE(24, 24), 7, _UPB_MSGEXT_EXTENDABLE, 3, 255,
 };
 
-static const upb_msglayout *const google_protobuf_OneofOptions_submsgs[1] = {
-  &google_protobuf_UninterpretedOption_msginit,
+static const upb_msglayout_sub google_protobuf_OneofOptions_submsgs[1] = {
+  {.submsg = &google_protobuf_UninterpretedOption_msginit},
 };
 
 static const upb_msglayout_field google_protobuf_OneofOptions__fields[1] = {
-  {999, UPB_SIZE(0, 0), 0, 0, 11, _UPB_MODE_ARRAY},
+  {999, UPB_SIZE(0, 0), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
 };
 
 const upb_msglayout google_protobuf_OneofOptions_msginit = {
   &google_protobuf_OneofOptions_submsgs[0],
   &google_protobuf_OneofOptions__fields[0],
-  UPB_SIZE(8, 8), 1, false, 0, 255,
+  UPB_SIZE(8, 8), 1, _UPB_MSGEXT_EXTENDABLE, 0, 255,
 };
 
-static const upb_msglayout *const google_protobuf_EnumOptions_submsgs[1] = {
-  &google_protobuf_UninterpretedOption_msginit,
+static const upb_msglayout_sub google_protobuf_EnumOptions_submsgs[1] = {
+  {.submsg = &google_protobuf_UninterpretedOption_msginit},
 };
 
 static const upb_msglayout_field google_protobuf_EnumOptions__fields[3] = {
-  {2, UPB_SIZE(1, 1), 1, 0, 8, _UPB_MODE_SCALAR},
-  {3, UPB_SIZE(2, 2), 2, 0, 8, _UPB_MODE_SCALAR},
-  {999, UPB_SIZE(4, 8), 0, 0, 11, _UPB_MODE_ARRAY},
+  {2, UPB_SIZE(1, 1), 1, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
+  {3, UPB_SIZE(2, 2), 2, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
+  {999, UPB_SIZE(4, 8), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
 };
 
 const upb_msglayout google_protobuf_EnumOptions_msginit = {
   &google_protobuf_EnumOptions_submsgs[0],
   &google_protobuf_EnumOptions__fields[0],
-  UPB_SIZE(8, 16), 3, false, 0, 255,
+  UPB_SIZE(8, 16), 3, _UPB_MSGEXT_EXTENDABLE, 0, 255,
 };
 
-static const upb_msglayout *const google_protobuf_EnumValueOptions_submsgs[1] = {
-  &google_protobuf_UninterpretedOption_msginit,
+static const upb_msglayout_sub google_protobuf_EnumValueOptions_submsgs[1] = {
+  {.submsg = &google_protobuf_UninterpretedOption_msginit},
 };
 
 static const upb_msglayout_field google_protobuf_EnumValueOptions__fields[2] = {
-  {1, UPB_SIZE(1, 1), 1, 0, 8, _UPB_MODE_SCALAR},
-  {999, UPB_SIZE(4, 8), 0, 0, 11, _UPB_MODE_ARRAY},
+  {1, UPB_SIZE(1, 1), 1, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
+  {999, UPB_SIZE(4, 8), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
 };
 
 const upb_msglayout google_protobuf_EnumValueOptions_msginit = {
   &google_protobuf_EnumValueOptions_submsgs[0],
   &google_protobuf_EnumValueOptions__fields[0],
-  UPB_SIZE(8, 16), 2, false, 1, 255,
+  UPB_SIZE(8, 16), 2, _UPB_MSGEXT_EXTENDABLE, 1, 255,
 };
 
-static const upb_msglayout *const google_protobuf_ServiceOptions_submsgs[1] = {
-  &google_protobuf_UninterpretedOption_msginit,
+static const upb_msglayout_sub google_protobuf_ServiceOptions_submsgs[1] = {
+  {.submsg = &google_protobuf_UninterpretedOption_msginit},
 };
 
 static const upb_msglayout_field google_protobuf_ServiceOptions__fields[2] = {
-  {33, UPB_SIZE(1, 1), 1, 0, 8, _UPB_MODE_SCALAR},
-  {999, UPB_SIZE(4, 8), 0, 0, 11, _UPB_MODE_ARRAY},
+  {33, UPB_SIZE(1, 1), 1, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
+  {999, UPB_SIZE(4, 8), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
 };
 
 const upb_msglayout google_protobuf_ServiceOptions_msginit = {
   &google_protobuf_ServiceOptions_submsgs[0],
   &google_protobuf_ServiceOptions__fields[0],
-  UPB_SIZE(8, 16), 2, false, 0, 255,
+  UPB_SIZE(8, 16), 2, _UPB_MSGEXT_EXTENDABLE, 0, 255,
 };
 
-static const upb_msglayout *const google_protobuf_MethodOptions_submsgs[1] = {
-  &google_protobuf_UninterpretedOption_msginit,
+static const upb_msglayout_sub google_protobuf_MethodOptions_submsgs[1] = {
+  {.submsg = &google_protobuf_UninterpretedOption_msginit},
 };
 
 static const upb_msglayout_field google_protobuf_MethodOptions__fields[3] = {
-  {33, UPB_SIZE(8, 8), 1, 0, 8, _UPB_MODE_SCALAR},
-  {34, UPB_SIZE(4, 4), 2, 0, 14, _UPB_MODE_SCALAR},
-  {999, UPB_SIZE(12, 16), 0, 0, 11, _UPB_MODE_ARRAY},
+  {33, UPB_SIZE(8, 8), 1, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
+  {34, UPB_SIZE(4, 4), 2, 0, 14, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
+  {999, UPB_SIZE(12, 16), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
 };
 
 const upb_msglayout google_protobuf_MethodOptions_msginit = {
   &google_protobuf_MethodOptions_submsgs[0],
   &google_protobuf_MethodOptions__fields[0],
-  UPB_SIZE(16, 24), 3, false, 0, 255,
+  UPB_SIZE(16, 24), 3, _UPB_MSGEXT_EXTENDABLE, 0, 255,
 };
 
-static const upb_msglayout *const google_protobuf_UninterpretedOption_submsgs[1] = {
-  &google_protobuf_UninterpretedOption_NamePart_msginit,
+static const upb_msglayout_sub google_protobuf_UninterpretedOption_submsgs[1] = {
+  {.submsg = &google_protobuf_UninterpretedOption_NamePart_msginit},
 };
 
 static const upb_msglayout_field google_protobuf_UninterpretedOption__fields[7] = {
-  {2, UPB_SIZE(56, 80), 0, 0, 11, _UPB_MODE_ARRAY},
-  {3, UPB_SIZE(32, 32), 1, 0, 12, _UPB_MODE_SCALAR},
-  {4, UPB_SIZE(8, 8), 2, 0, 4, _UPB_MODE_SCALAR},
-  {5, UPB_SIZE(16, 16), 3, 0, 3, _UPB_MODE_SCALAR},
-  {6, UPB_SIZE(24, 24), 4, 0, 1, _UPB_MODE_SCALAR},
-  {7, UPB_SIZE(40, 48), 5, 0, 12, _UPB_MODE_SCALAR},
-  {8, UPB_SIZE(48, 64), 6, 0, 12, _UPB_MODE_SCALAR},
+  {2, UPB_SIZE(56, 80), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {3, UPB_SIZE(32, 32), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {4, UPB_SIZE(8, 8), 2, 0, 4, _UPB_MODE_SCALAR | (_UPB_REP_8BYTE << 6)},
+  {5, UPB_SIZE(16, 16), 3, 0, 3, _UPB_MODE_SCALAR | (_UPB_REP_8BYTE << 6)},
+  {6, UPB_SIZE(24, 24), 4, 0, 1, _UPB_MODE_SCALAR | (_UPB_REP_8BYTE << 6)},
+  {7, UPB_SIZE(40, 48), 5, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {8, UPB_SIZE(48, 64), 6, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
 };
 
 const upb_msglayout google_protobuf_UninterpretedOption_msginit = {
   &google_protobuf_UninterpretedOption_submsgs[0],
   &google_protobuf_UninterpretedOption__fields[0],
-  UPB_SIZE(64, 96), 7, false, 0, 255,
+  UPB_SIZE(64, 96), 7, _UPB_MSGEXT_NONE, 0, 255,
 };
 
 static const upb_msglayout_field google_protobuf_UninterpretedOption_NamePart__fields[2] = {
-  {1, UPB_SIZE(4, 8), 1, 0, 12, _UPB_MODE_SCALAR},
-  {2, UPB_SIZE(1, 1), 2, 0, 8, _UPB_MODE_SCALAR},
+  {1, UPB_SIZE(4, 8), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {2, UPB_SIZE(1, 1), 2, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
 };
 
 const upb_msglayout google_protobuf_UninterpretedOption_NamePart_msginit = {
   NULL,
   &google_protobuf_UninterpretedOption_NamePart__fields[0],
-  UPB_SIZE(16, 32), 2, false, 2, 255,
+  UPB_SIZE(16, 32), 2, _UPB_MSGEXT_NONE, 2, 255,
 };
 
-static const upb_msglayout *const google_protobuf_SourceCodeInfo_submsgs[1] = {
-  &google_protobuf_SourceCodeInfo_Location_msginit,
+static const upb_msglayout_sub google_protobuf_SourceCodeInfo_submsgs[1] = {
+  {.submsg = &google_protobuf_SourceCodeInfo_Location_msginit},
 };
 
 static const upb_msglayout_field google_protobuf_SourceCodeInfo__fields[1] = {
-  {1, UPB_SIZE(0, 0), 0, 0, 11, _UPB_MODE_ARRAY},
+  {1, UPB_SIZE(0, 0), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
 };
 
 const upb_msglayout google_protobuf_SourceCodeInfo_msginit = {
   &google_protobuf_SourceCodeInfo_submsgs[0],
   &google_protobuf_SourceCodeInfo__fields[0],
-  UPB_SIZE(8, 8), 1, false, 1, 255,
+  UPB_SIZE(8, 8), 1, _UPB_MSGEXT_NONE, 1, 255,
 };
 
 static const upb_msglayout_field google_protobuf_SourceCodeInfo_Location__fields[5] = {
-  {1, UPB_SIZE(20, 40), 0, 0, 5, _UPB_MODE_ARRAY | _UPB_MODE_IS_PACKED},
-  {2, UPB_SIZE(24, 48), 0, 0, 5, _UPB_MODE_ARRAY | _UPB_MODE_IS_PACKED},
-  {3, UPB_SIZE(4, 8), 1, 0, 12, _UPB_MODE_SCALAR},
-  {4, UPB_SIZE(12, 24), 2, 0, 12, _UPB_MODE_SCALAR},
-  {6, UPB_SIZE(28, 56), 0, 0, 12, _UPB_MODE_ARRAY},
+  {1, UPB_SIZE(20, 40), 0, 0, 5, _UPB_MODE_ARRAY | _UPB_MODE_IS_PACKED | (_UPB_REP_PTR << 6)},
+  {2, UPB_SIZE(24, 48), 0, 0, 5, _UPB_MODE_ARRAY | _UPB_MODE_IS_PACKED | (_UPB_REP_PTR << 6)},
+  {3, UPB_SIZE(4, 8), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {4, UPB_SIZE(12, 24), 2, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {6, UPB_SIZE(28, 56), 0, 0, 12, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
 };
 
 const upb_msglayout google_protobuf_SourceCodeInfo_Location_msginit = {
   NULL,
   &google_protobuf_SourceCodeInfo_Location__fields[0],
-  UPB_SIZE(32, 64), 5, false, 4, 255,
+  UPB_SIZE(32, 64), 5, _UPB_MSGEXT_NONE, 4, 255,
 };
 
-static const upb_msglayout *const google_protobuf_GeneratedCodeInfo_submsgs[1] = {
-  &google_protobuf_GeneratedCodeInfo_Annotation_msginit,
+static const upb_msglayout_sub google_protobuf_GeneratedCodeInfo_submsgs[1] = {
+  {.submsg = &google_protobuf_GeneratedCodeInfo_Annotation_msginit},
 };
 
 static const upb_msglayout_field google_protobuf_GeneratedCodeInfo__fields[1] = {
-  {1, UPB_SIZE(0, 0), 0, 0, 11, _UPB_MODE_ARRAY},
+  {1, UPB_SIZE(0, 0), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
 };
 
 const upb_msglayout google_protobuf_GeneratedCodeInfo_msginit = {
   &google_protobuf_GeneratedCodeInfo_submsgs[0],
   &google_protobuf_GeneratedCodeInfo__fields[0],
-  UPB_SIZE(8, 8), 1, false, 1, 255,
+  UPB_SIZE(8, 8), 1, _UPB_MSGEXT_NONE, 1, 255,
 };
 
 static const upb_msglayout_field google_protobuf_GeneratedCodeInfo_Annotation__fields[4] = {
-  {1, UPB_SIZE(20, 32), 0, 0, 5, _UPB_MODE_ARRAY | _UPB_MODE_IS_PACKED},
-  {2, UPB_SIZE(12, 16), 1, 0, 12, _UPB_MODE_SCALAR},
-  {3, UPB_SIZE(4, 4), 2, 0, 5, _UPB_MODE_SCALAR},
-  {4, UPB_SIZE(8, 8), 3, 0, 5, _UPB_MODE_SCALAR},
+  {1, UPB_SIZE(20, 32), 0, 0, 5, _UPB_MODE_ARRAY | _UPB_MODE_IS_PACKED | (_UPB_REP_PTR << 6)},
+  {2, UPB_SIZE(12, 16), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {3, UPB_SIZE(4, 4), 2, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
+  {4, UPB_SIZE(8, 8), 3, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
 };
 
 const upb_msglayout google_protobuf_GeneratedCodeInfo_Annotation_msginit = {
   NULL,
   &google_protobuf_GeneratedCodeInfo_Annotation__fields[0],
-  UPB_SIZE(24, 48), 4, false, 4, 255,
+  UPB_SIZE(24, 48), 4, _UPB_MSGEXT_NONE, 4, 255,
+};
+
+static const upb_msglayout *messages_layout[27] = {
+  &google_protobuf_FileDescriptorSet_msginit,
+  &google_protobuf_FileDescriptorProto_msginit,
+  &google_protobuf_DescriptorProto_msginit,
+  &google_protobuf_DescriptorProto_ExtensionRange_msginit,
+  &google_protobuf_DescriptorProto_ReservedRange_msginit,
+  &google_protobuf_ExtensionRangeOptions_msginit,
+  &google_protobuf_FieldDescriptorProto_msginit,
+  &google_protobuf_OneofDescriptorProto_msginit,
+  &google_protobuf_EnumDescriptorProto_msginit,
+  &google_protobuf_EnumDescriptorProto_EnumReservedRange_msginit,
+  &google_protobuf_EnumValueDescriptorProto_msginit,
+  &google_protobuf_ServiceDescriptorProto_msginit,
+  &google_protobuf_MethodDescriptorProto_msginit,
+  &google_protobuf_FileOptions_msginit,
+  &google_protobuf_MessageOptions_msginit,
+  &google_protobuf_FieldOptions_msginit,
+  &google_protobuf_OneofOptions_msginit,
+  &google_protobuf_EnumOptions_msginit,
+  &google_protobuf_EnumValueOptions_msginit,
+  &google_protobuf_ServiceOptions_msginit,
+  &google_protobuf_MethodOptions_msginit,
+  &google_protobuf_UninterpretedOption_msginit,
+  &google_protobuf_UninterpretedOption_NamePart_msginit,
+  &google_protobuf_SourceCodeInfo_msginit,
+  &google_protobuf_SourceCodeInfo_Location_msginit,
+  &google_protobuf_GeneratedCodeInfo_msginit,
+  &google_protobuf_GeneratedCodeInfo_Annotation_msginit,
+};
+
+const upb_msglayout_file google_protobuf_descriptor_proto_upb_file_layout = {
+  messages_layout,
+  NULL,
+  27,
+  0,
 };
 
 #include "upb/port_undef.inc"

--- a/cmake/google/protobuf/descriptor.upb.c
+++ b/cmake/google/protobuf/descriptor.upb.c
@@ -17,7 +17,7 @@ static const upb_msglayout_sub google_protobuf_FileDescriptorSet_submsgs[1] = {
 };
 
 static const upb_msglayout_field google_protobuf_FileDescriptorSet__fields[1] = {
-  {1, UPB_SIZE(0, 0), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {1, UPB_SIZE(0, 0), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
 };
 
 const upb_msglayout google_protobuf_FileDescriptorSet_msginit = {
@@ -36,18 +36,18 @@ static const upb_msglayout_sub google_protobuf_FileDescriptorProto_submsgs[6] = 
 };
 
 static const upb_msglayout_field google_protobuf_FileDescriptorProto__fields[12] = {
-  {1, UPB_SIZE(4, 8), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
-  {2, UPB_SIZE(12, 24), 2, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
-  {3, UPB_SIZE(36, 72), 0, 0, 12, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
-  {4, UPB_SIZE(40, 80), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
-  {5, UPB_SIZE(44, 88), 0, 1, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
-  {6, UPB_SIZE(48, 96), 0, 4, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
-  {7, UPB_SIZE(52, 104), 0, 2, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
-  {8, UPB_SIZE(28, 56), 3, 3, 11, _UPB_MODE_SCALAR | (_UPB_REP_PTR << 6)},
-  {9, UPB_SIZE(32, 64), 4, 5, 11, _UPB_MODE_SCALAR | (_UPB_REP_PTR << 6)},
-  {10, UPB_SIZE(56, 112), 0, 0, 5, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
-  {11, UPB_SIZE(60, 120), 0, 0, 5, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
-  {12, UPB_SIZE(20, 40), 5, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {1, UPB_SIZE(4, 8), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
+  {2, UPB_SIZE(12, 24), 2, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
+  {3, UPB_SIZE(36, 72), 0, 0, 12, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
+  {4, UPB_SIZE(40, 80), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
+  {5, UPB_SIZE(44, 88), 0, 1, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
+  {6, UPB_SIZE(48, 96), 0, 4, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
+  {7, UPB_SIZE(52, 104), 0, 2, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
+  {8, UPB_SIZE(28, 56), 3, 3, 11, _UPB_MODE_SCALAR | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
+  {9, UPB_SIZE(32, 64), 4, 5, 11, _UPB_MODE_SCALAR | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
+  {10, UPB_SIZE(56, 112), 0, 0, 5, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
+  {11, UPB_SIZE(60, 120), 0, 0, 5, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
+  {12, UPB_SIZE(20, 40), 5, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
 };
 
 const upb_msglayout google_protobuf_FileDescriptorProto_msginit = {
@@ -67,16 +67,16 @@ static const upb_msglayout_sub google_protobuf_DescriptorProto_submsgs[7] = {
 };
 
 static const upb_msglayout_field google_protobuf_DescriptorProto__fields[10] = {
-  {1, UPB_SIZE(4, 8), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
-  {2, UPB_SIZE(16, 32), 0, 4, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
-  {3, UPB_SIZE(20, 40), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
-  {4, UPB_SIZE(24, 48), 0, 3, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
-  {5, UPB_SIZE(28, 56), 0, 1, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
-  {6, UPB_SIZE(32, 64), 0, 4, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
-  {7, UPB_SIZE(12, 24), 2, 5, 11, _UPB_MODE_SCALAR | (_UPB_REP_PTR << 6)},
-  {8, UPB_SIZE(36, 72), 0, 6, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
-  {9, UPB_SIZE(40, 80), 0, 2, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
-  {10, UPB_SIZE(44, 88), 0, 0, 12, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {1, UPB_SIZE(4, 8), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
+  {2, UPB_SIZE(16, 32), 0, 4, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
+  {3, UPB_SIZE(20, 40), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
+  {4, UPB_SIZE(24, 48), 0, 3, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
+  {5, UPB_SIZE(28, 56), 0, 1, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
+  {6, UPB_SIZE(32, 64), 0, 4, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
+  {7, UPB_SIZE(12, 24), 2, 5, 11, _UPB_MODE_SCALAR | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
+  {8, UPB_SIZE(36, 72), 0, 6, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
+  {9, UPB_SIZE(40, 80), 0, 2, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
+  {10, UPB_SIZE(44, 88), 0, 0, 12, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
 };
 
 const upb_msglayout google_protobuf_DescriptorProto_msginit = {
@@ -90,9 +90,9 @@ static const upb_msglayout_sub google_protobuf_DescriptorProto_ExtensionRange_su
 };
 
 static const upb_msglayout_field google_protobuf_DescriptorProto_ExtensionRange__fields[3] = {
-  {1, UPB_SIZE(4, 4), 1, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
-  {2, UPB_SIZE(8, 8), 2, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
-  {3, UPB_SIZE(12, 16), 3, 0, 11, _UPB_MODE_SCALAR | (_UPB_REP_PTR << 6)},
+  {1, UPB_SIZE(4, 4), 1, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << _UPB_REP_SHIFT)},
+  {2, UPB_SIZE(8, 8), 2, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << _UPB_REP_SHIFT)},
+  {3, UPB_SIZE(12, 16), 3, 0, 11, _UPB_MODE_SCALAR | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
 };
 
 const upb_msglayout google_protobuf_DescriptorProto_ExtensionRange_msginit = {
@@ -102,8 +102,8 @@ const upb_msglayout google_protobuf_DescriptorProto_ExtensionRange_msginit = {
 };
 
 static const upb_msglayout_field google_protobuf_DescriptorProto_ReservedRange__fields[2] = {
-  {1, UPB_SIZE(4, 4), 1, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
-  {2, UPB_SIZE(8, 8), 2, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
+  {1, UPB_SIZE(4, 4), 1, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << _UPB_REP_SHIFT)},
+  {2, UPB_SIZE(8, 8), 2, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << _UPB_REP_SHIFT)},
 };
 
 const upb_msglayout google_protobuf_DescriptorProto_ReservedRange_msginit = {
@@ -117,7 +117,7 @@ static const upb_msglayout_sub google_protobuf_ExtensionRangeOptions_submsgs[1] 
 };
 
 static const upb_msglayout_field google_protobuf_ExtensionRangeOptions__fields[1] = {
-  {999, UPB_SIZE(0, 0), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {999, UPB_SIZE(0, 0), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
 };
 
 const upb_msglayout google_protobuf_ExtensionRangeOptions_msginit = {
@@ -131,17 +131,17 @@ static const upb_msglayout_sub google_protobuf_FieldDescriptorProto_submsgs[1] =
 };
 
 static const upb_msglayout_field google_protobuf_FieldDescriptorProto__fields[11] = {
-  {1, UPB_SIZE(24, 24), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
-  {2, UPB_SIZE(32, 40), 2, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
-  {3, UPB_SIZE(12, 12), 3, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
-  {4, UPB_SIZE(4, 4), 4, 0, 14, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
-  {5, UPB_SIZE(8, 8), 5, 0, 14, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
-  {6, UPB_SIZE(40, 56), 6, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
-  {7, UPB_SIZE(48, 72), 7, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
-  {8, UPB_SIZE(64, 104), 8, 0, 11, _UPB_MODE_SCALAR | (_UPB_REP_PTR << 6)},
-  {9, UPB_SIZE(16, 16), 9, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
-  {10, UPB_SIZE(56, 88), 10, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
-  {17, UPB_SIZE(20, 20), 11, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
+  {1, UPB_SIZE(24, 24), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
+  {2, UPB_SIZE(32, 40), 2, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
+  {3, UPB_SIZE(12, 12), 3, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << _UPB_REP_SHIFT)},
+  {4, UPB_SIZE(4, 4), 4, 0, 14, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << _UPB_REP_SHIFT)},
+  {5, UPB_SIZE(8, 8), 5, 0, 14, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << _UPB_REP_SHIFT)},
+  {6, UPB_SIZE(40, 56), 6, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
+  {7, UPB_SIZE(48, 72), 7, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
+  {8, UPB_SIZE(64, 104), 8, 0, 11, _UPB_MODE_SCALAR | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
+  {9, UPB_SIZE(16, 16), 9, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << _UPB_REP_SHIFT)},
+  {10, UPB_SIZE(56, 88), 10, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
+  {17, UPB_SIZE(20, 20), 11, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
 };
 
 const upb_msglayout google_protobuf_FieldDescriptorProto_msginit = {
@@ -155,8 +155,8 @@ static const upb_msglayout_sub google_protobuf_OneofDescriptorProto_submsgs[1] =
 };
 
 static const upb_msglayout_field google_protobuf_OneofDescriptorProto__fields[2] = {
-  {1, UPB_SIZE(4, 8), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
-  {2, UPB_SIZE(12, 24), 2, 0, 11, _UPB_MODE_SCALAR | (_UPB_REP_PTR << 6)},
+  {1, UPB_SIZE(4, 8), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
+  {2, UPB_SIZE(12, 24), 2, 0, 11, _UPB_MODE_SCALAR | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
 };
 
 const upb_msglayout google_protobuf_OneofDescriptorProto_msginit = {
@@ -172,11 +172,11 @@ static const upb_msglayout_sub google_protobuf_EnumDescriptorProto_submsgs[3] = 
 };
 
 static const upb_msglayout_field google_protobuf_EnumDescriptorProto__fields[5] = {
-  {1, UPB_SIZE(4, 8), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
-  {2, UPB_SIZE(16, 32), 0, 2, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
-  {3, UPB_SIZE(12, 24), 2, 1, 11, _UPB_MODE_SCALAR | (_UPB_REP_PTR << 6)},
-  {4, UPB_SIZE(20, 40), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
-  {5, UPB_SIZE(24, 48), 0, 0, 12, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {1, UPB_SIZE(4, 8), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
+  {2, UPB_SIZE(16, 32), 0, 2, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
+  {3, UPB_SIZE(12, 24), 2, 1, 11, _UPB_MODE_SCALAR | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
+  {4, UPB_SIZE(20, 40), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
+  {5, UPB_SIZE(24, 48), 0, 0, 12, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
 };
 
 const upb_msglayout google_protobuf_EnumDescriptorProto_msginit = {
@@ -186,8 +186,8 @@ const upb_msglayout google_protobuf_EnumDescriptorProto_msginit = {
 };
 
 static const upb_msglayout_field google_protobuf_EnumDescriptorProto_EnumReservedRange__fields[2] = {
-  {1, UPB_SIZE(4, 4), 1, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
-  {2, UPB_SIZE(8, 8), 2, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
+  {1, UPB_SIZE(4, 4), 1, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << _UPB_REP_SHIFT)},
+  {2, UPB_SIZE(8, 8), 2, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << _UPB_REP_SHIFT)},
 };
 
 const upb_msglayout google_protobuf_EnumDescriptorProto_EnumReservedRange_msginit = {
@@ -201,9 +201,9 @@ static const upb_msglayout_sub google_protobuf_EnumValueDescriptorProto_submsgs[
 };
 
 static const upb_msglayout_field google_protobuf_EnumValueDescriptorProto__fields[3] = {
-  {1, UPB_SIZE(8, 8), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
-  {2, UPB_SIZE(4, 4), 2, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
-  {3, UPB_SIZE(16, 24), 3, 0, 11, _UPB_MODE_SCALAR | (_UPB_REP_PTR << 6)},
+  {1, UPB_SIZE(8, 8), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
+  {2, UPB_SIZE(4, 4), 2, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << _UPB_REP_SHIFT)},
+  {3, UPB_SIZE(16, 24), 3, 0, 11, _UPB_MODE_SCALAR | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
 };
 
 const upb_msglayout google_protobuf_EnumValueDescriptorProto_msginit = {
@@ -218,9 +218,9 @@ static const upb_msglayout_sub google_protobuf_ServiceDescriptorProto_submsgs[2]
 };
 
 static const upb_msglayout_field google_protobuf_ServiceDescriptorProto__fields[3] = {
-  {1, UPB_SIZE(4, 8), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
-  {2, UPB_SIZE(16, 32), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
-  {3, UPB_SIZE(12, 24), 2, 1, 11, _UPB_MODE_SCALAR | (_UPB_REP_PTR << 6)},
+  {1, UPB_SIZE(4, 8), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
+  {2, UPB_SIZE(16, 32), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
+  {3, UPB_SIZE(12, 24), 2, 1, 11, _UPB_MODE_SCALAR | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
 };
 
 const upb_msglayout google_protobuf_ServiceDescriptorProto_msginit = {
@@ -234,12 +234,12 @@ static const upb_msglayout_sub google_protobuf_MethodDescriptorProto_submsgs[1] 
 };
 
 static const upb_msglayout_field google_protobuf_MethodDescriptorProto__fields[6] = {
-  {1, UPB_SIZE(4, 8), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
-  {2, UPB_SIZE(12, 24), 2, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
-  {3, UPB_SIZE(20, 40), 3, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
-  {4, UPB_SIZE(28, 56), 4, 0, 11, _UPB_MODE_SCALAR | (_UPB_REP_PTR << 6)},
-  {5, UPB_SIZE(1, 1), 5, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
-  {6, UPB_SIZE(2, 2), 6, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
+  {1, UPB_SIZE(4, 8), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
+  {2, UPB_SIZE(12, 24), 2, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
+  {3, UPB_SIZE(20, 40), 3, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
+  {4, UPB_SIZE(28, 56), 4, 0, 11, _UPB_MODE_SCALAR | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
+  {5, UPB_SIZE(1, 1), 5, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
+  {6, UPB_SIZE(2, 2), 6, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
 };
 
 const upb_msglayout google_protobuf_MethodDescriptorProto_msginit = {
@@ -253,27 +253,27 @@ static const upb_msglayout_sub google_protobuf_FileOptions_submsgs[1] = {
 };
 
 static const upb_msglayout_field google_protobuf_FileOptions__fields[21] = {
-  {1, UPB_SIZE(20, 24), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
-  {8, UPB_SIZE(28, 40), 2, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
-  {9, UPB_SIZE(4, 4), 3, 0, 14, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
-  {10, UPB_SIZE(8, 8), 4, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
-  {11, UPB_SIZE(36, 56), 5, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
-  {16, UPB_SIZE(9, 9), 6, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
-  {17, UPB_SIZE(10, 10), 7, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
-  {18, UPB_SIZE(11, 11), 8, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
-  {20, UPB_SIZE(12, 12), 9, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
-  {23, UPB_SIZE(13, 13), 10, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
-  {27, UPB_SIZE(14, 14), 11, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
-  {31, UPB_SIZE(15, 15), 12, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
-  {36, UPB_SIZE(44, 72), 13, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
-  {37, UPB_SIZE(52, 88), 14, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
-  {39, UPB_SIZE(60, 104), 15, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
-  {40, UPB_SIZE(68, 120), 16, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
-  {41, UPB_SIZE(76, 136), 17, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
-  {42, UPB_SIZE(16, 16), 18, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
-  {44, UPB_SIZE(84, 152), 19, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
-  {45, UPB_SIZE(92, 168), 20, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
-  {999, UPB_SIZE(100, 184), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {1, UPB_SIZE(20, 24), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
+  {8, UPB_SIZE(28, 40), 2, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
+  {9, UPB_SIZE(4, 4), 3, 0, 14, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << _UPB_REP_SHIFT)},
+  {10, UPB_SIZE(8, 8), 4, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
+  {11, UPB_SIZE(36, 56), 5, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
+  {16, UPB_SIZE(9, 9), 6, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
+  {17, UPB_SIZE(10, 10), 7, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
+  {18, UPB_SIZE(11, 11), 8, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
+  {20, UPB_SIZE(12, 12), 9, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
+  {23, UPB_SIZE(13, 13), 10, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
+  {27, UPB_SIZE(14, 14), 11, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
+  {31, UPB_SIZE(15, 15), 12, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
+  {36, UPB_SIZE(44, 72), 13, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
+  {37, UPB_SIZE(52, 88), 14, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
+  {39, UPB_SIZE(60, 104), 15, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
+  {40, UPB_SIZE(68, 120), 16, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
+  {41, UPB_SIZE(76, 136), 17, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
+  {42, UPB_SIZE(16, 16), 18, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
+  {44, UPB_SIZE(84, 152), 19, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
+  {45, UPB_SIZE(92, 168), 20, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
+  {999, UPB_SIZE(100, 184), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
 };
 
 const upb_msglayout google_protobuf_FileOptions_msginit = {
@@ -287,11 +287,11 @@ static const upb_msglayout_sub google_protobuf_MessageOptions_submsgs[1] = {
 };
 
 static const upb_msglayout_field google_protobuf_MessageOptions__fields[5] = {
-  {1, UPB_SIZE(1, 1), 1, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
-  {2, UPB_SIZE(2, 2), 2, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
-  {3, UPB_SIZE(3, 3), 3, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
-  {7, UPB_SIZE(4, 4), 4, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
-  {999, UPB_SIZE(8, 8), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {1, UPB_SIZE(1, 1), 1, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
+  {2, UPB_SIZE(2, 2), 2, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
+  {3, UPB_SIZE(3, 3), 3, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
+  {7, UPB_SIZE(4, 4), 4, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
+  {999, UPB_SIZE(8, 8), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
 };
 
 const upb_msglayout google_protobuf_MessageOptions_msginit = {
@@ -305,13 +305,13 @@ static const upb_msglayout_sub google_protobuf_FieldOptions_submsgs[1] = {
 };
 
 static const upb_msglayout_field google_protobuf_FieldOptions__fields[7] = {
-  {1, UPB_SIZE(4, 4), 1, 0, 14, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
-  {2, UPB_SIZE(12, 12), 2, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
-  {3, UPB_SIZE(13, 13), 3, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
-  {5, UPB_SIZE(14, 14), 4, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
-  {6, UPB_SIZE(8, 8), 5, 0, 14, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
-  {10, UPB_SIZE(15, 15), 6, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
-  {999, UPB_SIZE(16, 16), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {1, UPB_SIZE(4, 4), 1, 0, 14, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << _UPB_REP_SHIFT)},
+  {2, UPB_SIZE(12, 12), 2, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
+  {3, UPB_SIZE(13, 13), 3, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
+  {5, UPB_SIZE(14, 14), 4, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
+  {6, UPB_SIZE(8, 8), 5, 0, 14, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << _UPB_REP_SHIFT)},
+  {10, UPB_SIZE(15, 15), 6, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
+  {999, UPB_SIZE(16, 16), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
 };
 
 const upb_msglayout google_protobuf_FieldOptions_msginit = {
@@ -325,7 +325,7 @@ static const upb_msglayout_sub google_protobuf_OneofOptions_submsgs[1] = {
 };
 
 static const upb_msglayout_field google_protobuf_OneofOptions__fields[1] = {
-  {999, UPB_SIZE(0, 0), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {999, UPB_SIZE(0, 0), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
 };
 
 const upb_msglayout google_protobuf_OneofOptions_msginit = {
@@ -339,9 +339,9 @@ static const upb_msglayout_sub google_protobuf_EnumOptions_submsgs[1] = {
 };
 
 static const upb_msglayout_field google_protobuf_EnumOptions__fields[3] = {
-  {2, UPB_SIZE(1, 1), 1, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
-  {3, UPB_SIZE(2, 2), 2, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
-  {999, UPB_SIZE(4, 8), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {2, UPB_SIZE(1, 1), 1, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
+  {3, UPB_SIZE(2, 2), 2, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
+  {999, UPB_SIZE(4, 8), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
 };
 
 const upb_msglayout google_protobuf_EnumOptions_msginit = {
@@ -355,8 +355,8 @@ static const upb_msglayout_sub google_protobuf_EnumValueOptions_submsgs[1] = {
 };
 
 static const upb_msglayout_field google_protobuf_EnumValueOptions__fields[2] = {
-  {1, UPB_SIZE(1, 1), 1, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
-  {999, UPB_SIZE(4, 8), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {1, UPB_SIZE(1, 1), 1, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
+  {999, UPB_SIZE(4, 8), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
 };
 
 const upb_msglayout google_protobuf_EnumValueOptions_msginit = {
@@ -370,8 +370,8 @@ static const upb_msglayout_sub google_protobuf_ServiceOptions_submsgs[1] = {
 };
 
 static const upb_msglayout_field google_protobuf_ServiceOptions__fields[2] = {
-  {33, UPB_SIZE(1, 1), 1, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
-  {999, UPB_SIZE(4, 8), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {33, UPB_SIZE(1, 1), 1, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
+  {999, UPB_SIZE(4, 8), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
 };
 
 const upb_msglayout google_protobuf_ServiceOptions_msginit = {
@@ -385,9 +385,9 @@ static const upb_msglayout_sub google_protobuf_MethodOptions_submsgs[1] = {
 };
 
 static const upb_msglayout_field google_protobuf_MethodOptions__fields[3] = {
-  {33, UPB_SIZE(8, 8), 1, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
-  {34, UPB_SIZE(4, 4), 2, 0, 14, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
-  {999, UPB_SIZE(12, 16), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {33, UPB_SIZE(8, 8), 1, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
+  {34, UPB_SIZE(4, 4), 2, 0, 14, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << _UPB_REP_SHIFT)},
+  {999, UPB_SIZE(12, 16), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
 };
 
 const upb_msglayout google_protobuf_MethodOptions_msginit = {
@@ -401,13 +401,13 @@ static const upb_msglayout_sub google_protobuf_UninterpretedOption_submsgs[1] = 
 };
 
 static const upb_msglayout_field google_protobuf_UninterpretedOption__fields[7] = {
-  {2, UPB_SIZE(56, 80), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
-  {3, UPB_SIZE(32, 32), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
-  {4, UPB_SIZE(8, 8), 2, 0, 4, _UPB_MODE_SCALAR | (_UPB_REP_8BYTE << 6)},
-  {5, UPB_SIZE(16, 16), 3, 0, 3, _UPB_MODE_SCALAR | (_UPB_REP_8BYTE << 6)},
-  {6, UPB_SIZE(24, 24), 4, 0, 1, _UPB_MODE_SCALAR | (_UPB_REP_8BYTE << 6)},
-  {7, UPB_SIZE(40, 48), 5, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
-  {8, UPB_SIZE(48, 64), 6, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
+  {2, UPB_SIZE(56, 80), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
+  {3, UPB_SIZE(32, 32), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
+  {4, UPB_SIZE(8, 8), 2, 0, 4, _UPB_MODE_SCALAR | (_UPB_REP_8BYTE << _UPB_REP_SHIFT)},
+  {5, UPB_SIZE(16, 16), 3, 0, 3, _UPB_MODE_SCALAR | (_UPB_REP_8BYTE << _UPB_REP_SHIFT)},
+  {6, UPB_SIZE(24, 24), 4, 0, 1, _UPB_MODE_SCALAR | (_UPB_REP_8BYTE << _UPB_REP_SHIFT)},
+  {7, UPB_SIZE(40, 48), 5, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
+  {8, UPB_SIZE(48, 64), 6, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
 };
 
 const upb_msglayout google_protobuf_UninterpretedOption_msginit = {
@@ -417,8 +417,8 @@ const upb_msglayout google_protobuf_UninterpretedOption_msginit = {
 };
 
 static const upb_msglayout_field google_protobuf_UninterpretedOption_NamePart__fields[2] = {
-  {1, UPB_SIZE(4, 8), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
-  {2, UPB_SIZE(1, 1), 2, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << 6)},
+  {1, UPB_SIZE(4, 8), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
+  {2, UPB_SIZE(1, 1), 2, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
 };
 
 const upb_msglayout google_protobuf_UninterpretedOption_NamePart_msginit = {
@@ -432,7 +432,7 @@ static const upb_msglayout_sub google_protobuf_SourceCodeInfo_submsgs[1] = {
 };
 
 static const upb_msglayout_field google_protobuf_SourceCodeInfo__fields[1] = {
-  {1, UPB_SIZE(0, 0), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {1, UPB_SIZE(0, 0), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
 };
 
 const upb_msglayout google_protobuf_SourceCodeInfo_msginit = {
@@ -442,11 +442,11 @@ const upb_msglayout google_protobuf_SourceCodeInfo_msginit = {
 };
 
 static const upb_msglayout_field google_protobuf_SourceCodeInfo_Location__fields[5] = {
-  {1, UPB_SIZE(20, 40), 0, 0, 5, _UPB_MODE_ARRAY | _UPB_MODE_IS_PACKED | (_UPB_REP_PTR << 6)},
-  {2, UPB_SIZE(24, 48), 0, 0, 5, _UPB_MODE_ARRAY | _UPB_MODE_IS_PACKED | (_UPB_REP_PTR << 6)},
-  {3, UPB_SIZE(4, 8), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
-  {4, UPB_SIZE(12, 24), 2, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
-  {6, UPB_SIZE(28, 56), 0, 0, 12, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {1, UPB_SIZE(20, 40), 0, 0, 5, _UPB_MODE_ARRAY | _UPB_MODE_IS_PACKED | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
+  {2, UPB_SIZE(24, 48), 0, 0, 5, _UPB_MODE_ARRAY | _UPB_MODE_IS_PACKED | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
+  {3, UPB_SIZE(4, 8), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
+  {4, UPB_SIZE(12, 24), 2, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
+  {6, UPB_SIZE(28, 56), 0, 0, 12, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
 };
 
 const upb_msglayout google_protobuf_SourceCodeInfo_Location_msginit = {
@@ -460,7 +460,7 @@ static const upb_msglayout_sub google_protobuf_GeneratedCodeInfo_submsgs[1] = {
 };
 
 static const upb_msglayout_field google_protobuf_GeneratedCodeInfo__fields[1] = {
-  {1, UPB_SIZE(0, 0), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6)},
+  {1, UPB_SIZE(0, 0), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
 };
 
 const upb_msglayout google_protobuf_GeneratedCodeInfo_msginit = {
@@ -470,10 +470,10 @@ const upb_msglayout google_protobuf_GeneratedCodeInfo_msginit = {
 };
 
 static const upb_msglayout_field google_protobuf_GeneratedCodeInfo_Annotation__fields[4] = {
-  {1, UPB_SIZE(20, 32), 0, 0, 5, _UPB_MODE_ARRAY | _UPB_MODE_IS_PACKED | (_UPB_REP_PTR << 6)},
-  {2, UPB_SIZE(12, 16), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << 6)},
-  {3, UPB_SIZE(4, 4), 2, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
-  {4, UPB_SIZE(8, 8), 3, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << 6)},
+  {1, UPB_SIZE(20, 32), 0, 0, 5, _UPB_MODE_ARRAY | _UPB_MODE_IS_PACKED | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
+  {2, UPB_SIZE(12, 16), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
+  {3, UPB_SIZE(4, 4), 2, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << _UPB_REP_SHIFT)},
+  {4, UPB_SIZE(8, 8), 3, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << _UPB_REP_SHIFT)},
 };
 
 const upb_msglayout google_protobuf_GeneratedCodeInfo_Annotation_msginit = {

--- a/cmake/google/protobuf/descriptor.upb.h
+++ b/cmake/google/protobuf/descriptor.upb.h
@@ -2038,6 +2038,8 @@ UPB_INLINE void google_protobuf_GeneratedCodeInfo_Annotation_set_end(google_prot
   *UPB_PTR_AT(msg, UPB_SIZE(8, 8), int32_t) = value;
 }
 
+extern const upb_msglayout_file google_protobuf_descriptor_proto_upb_file_layout;
+
 #ifdef __cplusplus
 }  /* extern "C" */
 #endif

--- a/tests/conformance_upb_failures.txt
+++ b/tests/conformance_upb_failures.txt
@@ -1,1 +1,0 @@
-Recommended.Proto2.JsonInput.FieldNameExtension.Validator

--- a/upb/decode.c
+++ b/upb/decode.c
@@ -688,7 +688,7 @@ static const char *decode_msg(upb_decstate *d, const char *ptr, upb_msg *msg,
       }
 
       /* Parse, using op for dispatch. */
-      switch (mode & 3) {
+      switch (mode & _UPB_MODE_MASK) {
         case _UPB_MODE_ARRAY:
           ptr = decode_toarray(d, ptr, field_msg, subs, field, &val, op);
           break;

--- a/upb/decode.c
+++ b/upb/decode.c
@@ -298,7 +298,8 @@ static void decode_munge(int type, wireval *val) {
   }
 }
 
-static const upb_msglayout_field *upb_find_field(const upb_msglayout *l,
+static const upb_msglayout_field *upb_find_field(upb_decstate *d,
+                                                 const upb_msglayout *l,
                                                  uint32_t field_number,
                                                  int *last_field_index) {
   static upb_msglayout_field none = {0, 0, 0, 0, 0, 0};
@@ -307,21 +308,30 @@ static const upb_msglayout_field *upb_find_field(const upb_msglayout *l,
 
   size_t idx = ((size_t)field_number) - 1;  // 0 wraps to SIZE_MAX
   if (idx < l->dense_below) {
+    /* Fastest case: index into dense fields. */
     goto found;
   }
 
-  /* Resume scanning from last_field_index since fields are usually in order. */
-  int last = *last_field_index;
-  for (idx = last; idx < l->field_count; idx++) {
-    if (l->fields[idx].number == field_number) {
-      goto found;
+  if (l->dense_below < l->field_count) {
+    /* Linear search non-dense fields. Resume scanning from last_field_index
+     * since fields are usually in order. */
+    int last = *last_field_index;
+    for (idx = last; idx < l->field_count; idx++) {
+      if (l->fields[idx].number == field_number) {
+        goto found;
+      }
+    }
+
+    for (idx = 0; idx < last; idx++) {
+      if (l->fields[idx].number == field_number) {
+        goto found;
+      }
     }
   }
 
-  for (idx = 0; idx < last; idx++) {
-    if (l->fields[idx].number == field_number) {
-      goto found;
-    }
+  if (l->ext == _UPB_MSGEXT_EXTENDABLE && d->extreg) {
+    const upb_msglayout_ext *ext = _upb_extreg_get(d->extreg, l, field_number);
+    if (ext) return &ext->field;
   }
 
   return &none; /* Unknown field. */
@@ -332,10 +342,9 @@ static const upb_msglayout_field *upb_find_field(const upb_msglayout *l,
   return &l->fields[idx];
 }
 
-static upb_msg *decode_newsubmsg(upb_decstate *d,
-                                 upb_msglayout const *const *submsgs,
+static upb_msg *decode_newsubmsg(upb_decstate *d, const upb_msglayout_sub *subs,
                                  const upb_msglayout_field *field) {
-  const upb_msglayout *subl = submsgs[field->submsg_index];
+  const upb_msglayout *subl = subs[field->submsg_index].submsg;
   return _upb_msg_new_inl(subl, &d->arena);
 }
 
@@ -365,10 +374,10 @@ static const char *decode_readstr(upb_decstate *d, const char *ptr, int size,
 
 UPB_FORCEINLINE
 static const char *decode_tosubmsg(upb_decstate *d, const char *ptr,
-                                   upb_msg *submsg, 
-                                   upb_msglayout const *const *submsgs,
+                                   upb_msg *submsg,
+                                   const upb_msglayout_sub *subs,
                                    const upb_msglayout_field *field, int size) {
-  const upb_msglayout *subl = submsgs[field->submsg_index];
+  const upb_msglayout *subl = subs[field->submsg_index].submsg;
   int saved_delta = decode_pushlimit(d, ptr, size);
   if (--d->depth < 0) decode_err(d);
   if (!decode_isdone(d, &ptr)) {
@@ -398,15 +407,15 @@ static const char *decode_group(upb_decstate *d, const char *ptr,
 UPB_FORCEINLINE
 static const char *decode_togroup(upb_decstate *d, const char *ptr,
                                   upb_msg *submsg,
-                                  upb_msglayout const *const *submsgs,
+                                  const upb_msglayout_sub *subs,
                                   const upb_msglayout_field *field) {
-  const upb_msglayout *subl = submsgs[field->submsg_index];
+  const upb_msglayout *subl = subs[field->submsg_index].submsg;
   return decode_group(d, ptr, submsg, subl, field->number);
 }
 
 static const char *decode_toarray(upb_decstate *d, const char *ptr,
                                   upb_msg *msg,
-                                  upb_msglayout const *const *submsgs,
+                                  const upb_msglayout_sub *subs,
                                   const upb_msglayout_field *field, wireval *val,
                                   int op) {
   upb_array **arrp = UPB_PTR_AT(msg, field->offset, void);
@@ -442,14 +451,14 @@ static const char *decode_toarray(upb_decstate *d, const char *ptr,
     }
     case OP_SUBMSG: {
       /* Append submessage / group. */
-      upb_msg *submsg = decode_newsubmsg(d, submsgs, field);
+      upb_msg *submsg = decode_newsubmsg(d, subs, field);
       *UPB_PTR_AT(_upb_array_ptr(arr), arr->len * sizeof(void *), upb_msg *) =
           submsg;
       arr->len++;
       if (UPB_UNLIKELY(field->descriptortype == UPB_DTYPE_GROUP)) {
-        return decode_togroup(d, ptr, submsg, submsgs, field);
+        return decode_togroup(d, ptr, submsg, subs, field);
       } else {
-        return decode_tosubmsg(d, ptr, submsg, submsgs, field, val->size);
+        return decode_tosubmsg(d, ptr, submsg, subs, field, val->size);
       }
     }
     case OP_FIXPCK_LG2(2):
@@ -495,12 +504,13 @@ static const char *decode_toarray(upb_decstate *d, const char *ptr,
 }
 
 static const char *decode_tomap(upb_decstate *d, const char *ptr, upb_msg *msg,
-                                upb_msglayout const *const *submsgs,
-                                const upb_msglayout_field *field, wireval *val) {
+                                const upb_msglayout_sub *subs,
+                                const upb_msglayout_field *field,
+                                wireval *val) {
   upb_map **map_p = UPB_PTR_AT(msg, field->offset, upb_map *);
   upb_map *map = *map_p;
   upb_map_entry ent;
-  const upb_msglayout *entry = submsgs[field->submsg_index];
+  const upb_msglayout *entry = subs[field->submsg_index].submsg;
 
   if (!map) {
     /* Lazily create map. */
@@ -520,16 +530,16 @@ static const char *decode_tomap(upb_decstate *d, const char *ptr, upb_msg *msg,
   if (entry->fields[1].descriptortype == UPB_DESCRIPTOR_TYPE_MESSAGE ||
       entry->fields[1].descriptortype == UPB_DESCRIPTOR_TYPE_GROUP) {
     /* Create proactively to handle the case where it doesn't appear. */
-    ent.v.val = upb_value_ptr(_upb_msg_new(entry->submsgs[0], &d->arena));
+    ent.v.val = upb_value_ptr(_upb_msg_new(entry->subs[0].submsg, &d->arena));
   }
 
-  ptr = decode_tosubmsg(d, ptr, &ent.k, submsgs, field, val->size);
+  ptr = decode_tosubmsg(d, ptr, &ent.k, subs, field, val->size);
   _upb_map_set(map, &ent.k, map->key_size, &ent.v, map->val_size, &d->arena);
   return ptr;
 }
 
 static const char *decode_tomsg(upb_decstate *d, const char *ptr, upb_msg *msg,
-                                upb_msglayout const *const *submsgs,
+                                const upb_msglayout_sub *subs,
                                 const upb_msglayout_field *field, wireval *val,
                                 int op) {
   void *mem = UPB_PTR_AT(msg, field->offset, void);
@@ -553,13 +563,13 @@ static const char *decode_tomsg(upb_decstate *d, const char *ptr, upb_msg *msg,
       upb_msg **submsgp = mem;
       upb_msg *submsg = *submsgp;
       if (!submsg) {
-        submsg = decode_newsubmsg(d, submsgs, field);
+        submsg = decode_newsubmsg(d, subs, field);
         *submsgp = submsg;
       }
       if (UPB_UNLIKELY(type == UPB_DTYPE_GROUP)) {
-        ptr = decode_togroup(d, ptr, submsg, submsgs, field);
+        ptr = decode_togroup(d, ptr, submsg, subs, field);
       } else {
-        ptr = decode_tosubmsg(d, ptr, submsg, submsgs, field, val->size);
+        ptr = decode_tosubmsg(d, ptr, submsg, subs, field, val->size);
       }
       break;
     }
@@ -616,7 +626,7 @@ static const char *decode_msg(upb_decstate *d, const char *ptr, upb_msg *msg,
     field_number = tag >> 3;
     wire_type = tag & 7;
 
-    field = upb_find_field(layout, field_number, &last_field_index);
+    field = upb_find_field(d, layout, field_number, &last_field_index);
 
     switch (wire_type) {
       case UPB_WIRE_TYPE_VARINT:
@@ -664,16 +674,29 @@ static const char *decode_msg(upb_decstate *d, const char *ptr, upb_msg *msg,
     }
 
     if (op >= 0) {
+      /* Known field, possibly an extension. */
+      upb_msg *field_msg = msg;
+      const upb_msglayout_sub *subs = layout->subs;
+      uint8_t mode = field->mode;
+
+      if (UPB_UNLIKELY(mode & _UPB_MODE_IS_EXTENSION)) {
+        const upb_msglayout_ext *ext_layout = (const upb_msglayout_ext*)field;
+        upb_msg_ext *ext = _upb_msg_getorcreateext(msg, ext_layout, &d->arena);
+        if (UPB_UNLIKELY(!ext)) decode_err(d);
+        field_msg = &ext->data;
+        subs = &ext->ext->sub;
+      }
+
       /* Parse, using op for dispatch. */
-      switch (_upb_getmode(field)) {
+      switch (mode & 3) {
         case _UPB_MODE_ARRAY:
-          ptr = decode_toarray(d, ptr, msg, layout->submsgs, field, &val, op);
+          ptr = decode_toarray(d, ptr, field_msg, subs, field, &val, op);
           break;
         case _UPB_MODE_MAP:
-          ptr = decode_tomap(d, ptr, msg, layout->submsgs, field, &val);
+          ptr = decode_tomap(d, ptr, field_msg, subs, field, &val);
           break;
         case _UPB_MODE_SCALAR:
-          ptr = decode_tomsg(d, ptr, msg, layout->submsgs, field, &val, op);
+          ptr = decode_tomsg(d, ptr, field_msg, subs, field, &val, op);
           break;
         default:
           UPB_UNREACHABLE();
@@ -743,6 +766,7 @@ bool _upb_decode(const char *buf, size_t size, void *msg,
     state.alias = options & UPB_DECODE_ALIAS;
   }
 
+  state.extreg = extreg;
   state.limit_ptr = state.end;
   state.unknown_msg = NULL;
   state.depth = depth ? depth : 64;

--- a/upb/decode_fast.c
+++ b/upb/decode_fast.c
@@ -969,7 +969,7 @@ static const char *fastdecode_tosubmsg(upb_decstate *d, const char *ptr,
   upb_msg **dst;                                                          \
   uint32_t submsg_idx = (data >> 16) & 0xff;                              \
   const upb_msglayout *tablep = decode_totablep(table);                   \
-  const upb_msglayout *subtablep = tablep->submsgs[submsg_idx];           \
+  const upb_msglayout *subtablep = tablep->subs[submsg_idx].submsg;       \
   fastdecode_submsgdata submsg = {decode_totable(subtablep)};             \
   fastdecode_arr farr;                                                    \
                                                                           \

--- a/upb/decode_internal.h
+++ b/upb/decode_internal.h
@@ -48,6 +48,7 @@ typedef struct upb_decstate {
   const char *limit_ptr;   /* = end + UPB_MIN(limit, 0) */
   upb_msg *unknown_msg;    /* If non-NULL, add unknown data at buffer flip. */
   const char *unknown;     /* Start of unknown data. */
+  const upb_extreg *extreg;  /* For looking up extensions during the parse. */
   int limit;               /* Submessage limit relative to end. */
   int depth;
   uint32_t end_group;   /* field number of END_GROUP tag, else DECODE_NOGROUP */

--- a/upb/def.c
+++ b/upb/def.c
@@ -1139,9 +1139,9 @@ static void fill_fieldlayout(upb_msglayout_field *field, const upb_fielddef *f) 
   }
 
   if (upb_fielddef_ismap(f)) {
-    field->mode = _UPB_MODE_MAP | (_UPB_REP_PTR << 6);
+    field->mode = _UPB_MODE_MAP | (_UPB_REP_PTR << _UPB_REP_SHIFT);
   } else if (upb_fielddef_isseq(f)) {
-    field->mode = _UPB_MODE_ARRAY | (_UPB_REP_PTR << 6);
+    field->mode = _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT);
   } else {
     /* Maps descriptor type -> elem_size_lg2.  */
     static const uint8_t sizes[] = {
@@ -1165,7 +1165,8 @@ static void fill_fieldlayout(upb_msglayout_field *field, const upb_fielddef *f) 
         _UPB_REP_4BYTE,   /* SINT32 */
         _UPB_REP_8BYTE,   /* SINT64 */
     };
-    field->mode = _UPB_MODE_SCALAR | (sizes[field->descriptortype] << 6);
+    field->mode =
+        _UPB_MODE_SCALAR | (sizes[field->descriptortype] << _UPB_REP_SHIFT);
   }
 
   if (upb_fielddef_packed(f)) {

--- a/upb/def.h
+++ b/upb/def.h
@@ -56,6 +56,8 @@ struct upb_enumdef;
 typedef struct upb_enumdef upb_enumdef;
 struct upb_enumvaldef;
 typedef struct upb_enumvaldef upb_enumvaldef;
+struct upb_extrange;
+typedef struct upb_extrange upb_extrange;
 struct upb_fielddef;
 typedef struct upb_fielddef upb_fielddef;
 struct upb_filedef;
@@ -137,6 +139,7 @@ bool upb_fielddef_haspresence(const upb_fielddef *f);
 const upb_msgdef *upb_fielddef_msgsubdef(const upb_fielddef *f);
 const upb_enumdef *upb_fielddef_enumsubdef(const upb_fielddef *f);
 const upb_msglayout_field *upb_fielddef_layout(const upb_fielddef *f);
+const upb_msglayout_ext *_upb_fielddef_extlayout(const upb_fielddef *f);
 
 /* upb_oneofdef ***************************************************************/
 
@@ -201,8 +204,10 @@ bool upb_msgdef_mapentry(const upb_msgdef *m);
 upb_wellknowntype_t upb_msgdef_wellknowntype(const upb_msgdef *m);
 bool upb_msgdef_iswrapper(const upb_msgdef *m);
 bool upb_msgdef_isnumberwrapper(const upb_msgdef *m);
+int upb_msgdef_extrangecount(const upb_msgdef *m);
 int upb_msgdef_fieldcount(const upb_msgdef *m);
 int upb_msgdef_oneofcount(const upb_msgdef *m);
+const upb_extrange *upb_msgdef_extrange(const upb_msgdef *m, int i);
 const upb_fielddef *upb_msgdef_field(const upb_msgdef *m, int i);
 const upb_oneofdef *upb_msgdef_oneof(const upb_msgdef *m, int i);
 const upb_fielddef *upb_msgdef_itof(const upb_msgdef *m, uint32_t i);
@@ -257,6 +262,14 @@ void upb_msg_oneof_iter_setdone(upb_msg_oneof_iter * iter);
 bool upb_msg_oneof_iter_isequal(const upb_msg_oneof_iter *iter1,
                                 const upb_msg_oneof_iter *iter2);
 /* END DEPRECATED */
+
+/* upb_extrange ***************************************************************/
+
+const google_protobuf_ExtensionRangeOptions *upb_extrange_options(
+    const upb_extrange *r);
+bool upb_extrange_hasoptions(const upb_extrange *r);
+int32_t upb_extrange_start(const upb_extrange *r);
+int32_t upb_extrange_end(const upb_extrange *r);
 
 /* upb_enumdef ****************************************************************/
 
@@ -321,6 +334,8 @@ const upb_enumdef *upb_symtab_lookupenum(const upb_symtab *s, const char *sym);
 const upb_enumvaldef *upb_symtab_lookupenumval(const upb_symtab *s,
                                                const char *sym);
 const upb_fielddef *upb_symtab_lookupext(const upb_symtab *s, const char *sym);
+const upb_fielddef *upb_symtab_lookupext2(const upb_symtab *s, const char *sym,
+                                         size_t len);
 const upb_filedef *upb_symtab_lookupfile(const upb_symtab *s, const char *name);
 const upb_filedef *upb_symtab_lookupfile2(
     const upb_symtab *s, const char *name, size_t len);
@@ -330,11 +345,14 @@ const upb_filedef *upb_symtab_addfile(
     upb_status *status);
 size_t _upb_symtab_bytesloaded(const upb_symtab *s);
 upb_arena *_upb_symtab_arena(const upb_symtab *s);
+const upb_fielddef *_upb_symtab_lookupextfield(const upb_symtab *s,
+                                               const upb_msglayout_ext *ext);
+const upb_extreg *upb_symtab_extreg(const upb_symtab *s);
 
 /* For generated code only: loads a generated descriptor. */
 typedef struct upb_def_init {
   struct upb_def_init **deps;     /* Dependencies of this file. */
-  const upb_msglayout **layouts;  /* Pre-order layouts of all messages. */
+  const upb_msglayout_file *layout;
   const char *filename;
   upb_strview descriptor;         /* Serialized descriptor. */
 } upb_def_init;

--- a/upb/encode.c
+++ b/upb/encode.c
@@ -187,17 +187,14 @@ static void encode_message(upb_encstate *e, const upb_msg *msg,
                            const upb_msglayout *m, size_t *size);
 
 static void encode_scalar(upb_encstate *e, const void *_field_mem,
-                          const upb_msglayout *m, const upb_msglayout_field *f,
-                          bool skip_zero_value) {
+                          const upb_msglayout_sub *subs,
+                          const upb_msglayout_field *f) {
   const char *field_mem = _field_mem;
   int wire_type;
 
 #define CASE(ctype, type, wtype, encodeval) \
   {                                         \
     ctype val = *(ctype *)field_mem;        \
-    if (skip_zero_value && val == 0) {      \
-      return;                               \
-    }                                       \
     encode_##type(e, encodeval);            \
     wire_type = wtype;                      \
     break;                                  \
@@ -231,9 +228,6 @@ static void encode_scalar(upb_encstate *e, const void *_field_mem,
     case UPB_DESCRIPTOR_TYPE_STRING:
     case UPB_DESCRIPTOR_TYPE_BYTES: {
       upb_strview view = *(upb_strview*)field_mem;
-      if (skip_zero_value && view.size == 0) {
-        return;
-      }
       encode_bytes(e, view.data, view.size);
       encode_varint(e, view.size);
       wire_type = UPB_WIRE_TYPE_DELIMITED;
@@ -242,7 +236,7 @@ static void encode_scalar(upb_encstate *e, const void *_field_mem,
     case UPB_DESCRIPTOR_TYPE_GROUP: {
       size_t size;
       void *submsg = *(void **)field_mem;
-      const upb_msglayout *subm = m->submsgs[f->submsg_index];
+      const upb_msglayout *subm = subs[f->submsg_index].submsg;
       if (submsg == NULL) {
         return;
       }
@@ -256,7 +250,7 @@ static void encode_scalar(upb_encstate *e, const void *_field_mem,
     case UPB_DESCRIPTOR_TYPE_MESSAGE: {
       size_t size;
       void *submsg = *(void **)field_mem;
-      const upb_msglayout *subm = m->submsgs[f->submsg_index];
+      const upb_msglayout *subm = subs[f->submsg_index].submsg;
       if (submsg == NULL) {
         return;
       }
@@ -276,7 +270,8 @@ static void encode_scalar(upb_encstate *e, const void *_field_mem,
 }
 
 static void encode_array(upb_encstate *e, const upb_msg *msg,
-                         const upb_msglayout *m, const upb_msglayout_field *f) {
+                         const upb_msglayout_sub *subs,
+                         const upb_msglayout_field *f) {
   const upb_array *arr = *UPB_PTR_AT(msg, f->offset, upb_array*);
   bool packed = f->mode & _UPB_MODE_IS_PACKED;
   size_t pre_len = e->limit - e->ptr;
@@ -344,7 +339,7 @@ static void encode_array(upb_encstate *e, const upb_msg *msg,
     case UPB_DESCRIPTOR_TYPE_GROUP: {
       const void *const*start = _upb_array_constptr(arr);
       const void *const*ptr = start + arr->len;
-      const upb_msglayout *subm = m->submsgs[f->submsg_index];
+      const upb_msglayout *subm = subs[f->submsg_index].submsg;
       if (--e->depth == 0) encode_err(e);
       do {
         size_t size;
@@ -359,7 +354,7 @@ static void encode_array(upb_encstate *e, const upb_msg *msg,
     case UPB_DESCRIPTOR_TYPE_MESSAGE: {
       const void *const*start = _upb_array_constptr(arr);
       const void *const*ptr = start + arr->len;
-      const upb_msglayout *subm = m->submsgs[f->submsg_index];
+      const upb_msglayout *subm = subs[f->submsg_index].submsg;
       if (--e->depth == 0) encode_err(e);
       do {
         size_t size;
@@ -387,17 +382,18 @@ static void encode_mapentry(upb_encstate *e, uint32_t number,
   const upb_msglayout_field *val_field = &layout->fields[1];
   size_t pre_len = e->limit - e->ptr;
   size_t size;
-  encode_scalar(e, &ent->v, layout, val_field, false);
-  encode_scalar(e, &ent->k, layout, key_field, false);
+  encode_scalar(e, &ent->v, layout->subs, val_field);
+  encode_scalar(e, &ent->k, layout->subs, key_field);
   size = (e->limit - e->ptr) - pre_len;
   encode_varint(e, size);
   encode_tag(e, number, UPB_WIRE_TYPE_DELIMITED);
 }
 
 static void encode_map(upb_encstate *e, const upb_msg *msg,
-                       const upb_msglayout *m, const upb_msglayout_field *f) {
+                       const upb_msglayout_sub *subs,
+                       const upb_msglayout_field *f) {
   const upb_map *map = *UPB_PTR_AT(msg, f->offset, const upb_map*);
-  const upb_msglayout *layout = m->submsgs[f->submsg_index];
+  const upb_msglayout *layout = subs[f->submsg_index].submsg;
   UPB_ASSERT(layout->field_count == 2);
 
   if (map == NULL) return;
@@ -425,28 +421,65 @@ static void encode_map(upb_encstate *e, const upb_msg *msg,
   }
 }
 
-static void encode_scalarfield(upb_encstate *e, const char *msg,
-                               const upb_msglayout *m,
-                               const upb_msglayout_field *f) {
-  bool skip_empty = false;
+static bool encode_shouldencode(upb_encstate *e, const upb_msg *msg,
+                                const upb_msglayout_sub *subs,
+                                const upb_msglayout_field *f) {
   if (f->presence == 0) {
-    /* Proto3 presence. */
-    skip_empty = true;
+    /* Proto3 presence or map/array. */
+    const void *mem = UPB_PTR_AT(msg, f->offset, void);
+    switch (f->mode >> 6) {
+      case _UPB_REP_1BYTE: {
+        char ch;
+        memcpy(&ch, mem, 1);
+        return ch != 0;
+      }
+      case _UPB_REP_4BYTE: {
+        uint32_t u32;
+        memcpy(&u32, mem, 4);
+        return u32 != 0;
+      }
+      case _UPB_REP_8BYTE: {
+        uint64_t u64;
+        memcpy(&u64, mem, 8);
+        return u64 != 0;
+      }
+      case _UPB_REP_STRVIEW: {
+        const upb_strview *str = (const upb_strview*)mem;
+        return str->size != 0;
+      }
+      default:
+        UPB_UNREACHABLE();
+    }
   } else if (f->presence > 0) {
     /* Proto2 presence: hasbit. */
-    if (!_upb_hasbit_field(msg, f)) return;
+    return _upb_hasbit_field(msg, f);
   } else {
     /* Field is in a oneof. */
-    if (_upb_getoneofcase_field(msg, f) != f->number) return;
+    return _upb_getoneofcase_field(msg, f) == f->number;
   }
-  encode_scalar(e, msg + f->offset, m, f, skip_empty);
+}
+
+static void encode_field(upb_encstate *e, const upb_msg *msg,
+                         const upb_msglayout_sub *subs,
+                         const upb_msglayout_field *field) {
+  switch (_upb_getmode(field)) {
+    case _UPB_MODE_ARRAY:
+      encode_array(e, msg, subs, field);
+      break;
+    case _UPB_MODE_MAP:
+      encode_map(e, msg, subs, field);
+      break;
+    case _UPB_MODE_SCALAR:
+      encode_scalar(e, UPB_PTR_AT(msg, field->offset, void), subs, field);
+      break;
+    default:
+      UPB_UNREACHABLE();
+  }
 }
 
 static void encode_message(upb_encstate *e, const upb_msg *msg,
                            const upb_msglayout *m, size_t *size) {
   size_t pre_len = e->limit - e->ptr;
-  const upb_msglayout_field *f = &m->fields[m->field_count];
-  const upb_msglayout_field *first = &m->fields[0];
 
   if ((e->options & UPB_ENCODE_SKIPUNKNOWN) == 0) {
     size_t unknown_size;
@@ -457,20 +490,26 @@ static void encode_message(upb_encstate *e, const upb_msg *msg,
     }
   }
 
+  if (m->ext != _UPB_MSGEXT_NONE) {
+    /* Encode all extensions together. Unlike C++, we do not attempt to keep
+     * these in field number order relative to normal fields or even to each
+     * other. */
+    size_t ext_count;
+    const upb_msg_ext *ext = _upb_msg_getexts(msg, &ext_count);
+    const upb_msg_ext *end = ext + ext_count;
+    if (ext_count) {
+      for (; ext != end; ext++) {
+        encode_field(e, &ext->data, &ext->ext->sub, &ext->ext->field);
+      }
+    }
+  }
+
+  const upb_msglayout_field *f = &m->fields[m->field_count];
+  const upb_msglayout_field *first = &m->fields[0];
   while (f != first) {
     f--;
-    switch (_upb_getmode(f)) {
-      case _UPB_MODE_ARRAY:
-        encode_array(e, msg, m, f);
-        break;
-      case _UPB_MODE_MAP:
-        encode_map(e, msg, m, f);
-        break;
-      case _UPB_MODE_SCALAR:
-        encode_scalarfield(e, msg, m, f);
-        break;
-      default:
-        UPB_UNREACHABLE();
+    if (encode_shouldencode(e, msg, m->subs, f)) {
+      encode_field(e, msg, m->subs, f);
     }
   }
 

--- a/upb/encode.c
+++ b/upb/encode.c
@@ -427,7 +427,7 @@ static bool encode_shouldencode(upb_encstate *e, const upb_msg *msg,
   if (f->presence == 0) {
     /* Proto3 presence or map/array. */
     const void *mem = UPB_PTR_AT(msg, f->offset, void);
-    switch (f->mode >> 6) {
+    switch (f->mode >> _UPB_REP_SHIFT) {
       case _UPB_REP_1BYTE: {
         char ch;
         memcpy(&ch, mem, 1);

--- a/upb/json_decode.h
+++ b/upb/json_decode.h
@@ -39,7 +39,7 @@ enum {
 };
 
 bool upb_json_decode(const char *buf, size_t size, upb_msg *msg,
-                     const upb_msgdef *m, const upb_symtab *any_pool,
+                     const upb_msgdef *m, const upb_symtab *symtab,
                      int options, upb_arena *arena, upb_status *status);
 
 #ifdef __cplusplus

--- a/upb/json_encode.c
+++ b/upb/json_encode.c
@@ -670,14 +670,18 @@ static void jsonenc_fieldval(jsonenc *e, const upb_fielddef *f,
                              upb_msgval val, bool *first) {
   const char *name;
 
-  if (e->options & UPB_JSONENC_PROTONAMES) {
-    name = upb_fielddef_name(f);
-  } else {
-    name = upb_fielddef_jsonname(f);
-  }
-
   jsonenc_putsep(e, ",", first);
-  jsonenc_printf(e, "\"%s\":", name);
+
+  if (upb_fielddef_isextension(f)) {
+    jsonenc_printf(e, "\"[%s]\":", upb_fielddef_fullname(f));
+  } else {
+    if (e->options & UPB_JSONENC_PROTONAMES) {
+      name = upb_fielddef_name(f);
+    } else {
+      name = upb_fielddef_jsonname(f);
+    }
+    jsonenc_printf(e, "\"%s\":", name);
+  }
 
   if (upb_fielddef_ismap(f)) {
     jsonenc_map(e, val.map_val, f);

--- a/upb/msg.c
+++ b/upb/msg.c
@@ -137,6 +137,18 @@ const upb_msg_ext *_upb_msg_getext(const upb_msg *msg,
   return NULL;
 }
 
+void _upb_msg_clearext(upb_msg *msg, const upb_msglayout_ext *ext_l) {
+  upb_msg_internal *in = upb_msg_getinternal(msg);
+  if (!in->internal) return;
+  const upb_msg_ext *base =
+      UPB_PTR_AT(in->internal, in->internal->ext_begin, void);
+  upb_msg_ext *ext = (void*)_upb_msg_getext(msg, ext_l);
+  if (ext) {
+    *ext = *base;
+    in->internal->ext_begin += sizeof(upb_msg_ext);
+  }
+}
+
 upb_msg_ext *_upb_msg_getorcreateext(upb_msg *msg, const upb_msglayout_ext *e,
                                      upb_arena *arena) {
   upb_msg_ext *ext = (upb_msg_ext*)_upb_msg_getext(msg, e);
@@ -361,14 +373,15 @@ upb_extreg *upb_extreg_new(upb_arena *arena) {
   return r;
 }
 
-bool _upb_extreg_add(upb_extreg *r, const upb_msglayout_ext *e, size_t count) {
+bool _upb_extreg_add(upb_extreg *r, const upb_msglayout_ext **e, size_t count) {
   char buf[EXTREG_KEY_SIZE];
-  const upb_msglayout_ext *start = e;
-  const upb_msglayout_ext *end = e + count;
+  const upb_msglayout_ext **start = e;
+  const upb_msglayout_ext **end = e + count;
   for (; e < end; e++) {
-    extreg_key(buf, e->extendee, e->field.number);
+    const upb_msglayout_ext *ext = *e;
+    extreg_key(buf, ext->extendee, ext->field.number);
     if (!upb_strtable_insert(&r->exts, buf, EXTREG_KEY_SIZE,
-                             upb_value_constptr(e), r->arena)) {
+                             upb_value_constptr(ext), r->arena)) {
       goto failure;
     }
   }
@@ -377,15 +390,15 @@ bool _upb_extreg_add(upb_extreg *r, const upb_msglayout_ext *e, size_t count) {
 failure:
   /* Back out the entries previously added. */
   for (end = e, e = start; e < end; e++) {
-    extreg_key(buf, e->extendee, e->field.number);
+    const upb_msglayout_ext *ext = *e;
+    extreg_key(buf, ext->extendee, ext->field.number);
     upb_strtable_remove(&r->exts, buf, EXTREG_KEY_SIZE, NULL);
   }
   return false;
 }
 
-const upb_msglayout_field *_upb_extreg_get(const upb_extreg *r,
-                                           const upb_msglayout *l,
-                                           uint32_t num) {
+const upb_msglayout_ext *_upb_extreg_get(const upb_extreg *r,
+                                         const upb_msglayout *l, uint32_t num) {
   char buf[EXTREG_KEY_SIZE];
   upb_value v;
   extreg_key(buf, l, num);

--- a/upb/msg.c
+++ b/upb/msg.c
@@ -142,7 +142,7 @@ void _upb_msg_clearext(upb_msg *msg, const upb_msglayout_ext *ext_l) {
   if (!in->internal) return;
   const upb_msg_ext *base =
       UPB_PTR_AT(in->internal, in->internal->ext_begin, void);
-  upb_msg_ext *ext = (void*)_upb_msg_getext(msg, ext_l);
+  upb_msg_ext *ext = (upb_msg_ext*)_upb_msg_getext(msg, ext_l);
   if (ext) {
     *ext = *base;
     in->internal->ext_begin += sizeof(upb_msg_ext);

--- a/upb/msg_internal.h
+++ b/upb/msg_internal.h
@@ -69,13 +69,16 @@ typedef struct {
   int16_t presence;       /* If >0, hasbit_index.  If <0, ~oneof_index. */
   uint16_t submsg_index;  /* undefined if descriptortype != MESSAGE or GROUP. */
   uint8_t descriptortype;
-  uint8_t mode;            /* upb_fieldmode | upb_labelflags | (upb_rep << 6) */
+  uint8_t mode; /* upb_fieldmode | upb_labelflags |
+                   (upb_rep << _UPB_REP_SHIFT) */
 } upb_msglayout_field;
 
 typedef enum {
   _UPB_MODE_MAP = 0,
   _UPB_MODE_ARRAY = 1,
   _UPB_MODE_SCALAR = 2,
+
+  _UPB_MODE_MASK = 3,  /* Mask to isolate the mode from upb_rep. */
 } upb_fieldmode;
 
 /* Extra flags on the mode field. */
@@ -97,6 +100,8 @@ enum upb_rep {
 #else
   _UPB_REP_PTR = _UPB_REP_8BYTE,
 #endif
+
+  _UPB_REP_SHIFT = 6,  /* Bit offset of the rep in upb_msglayout_field.mode */
 };
 
 UPB_INLINE upb_fieldmode _upb_getmode(const upb_msglayout_field *field) {

--- a/upb/msg_test.cc
+++ b/upb/msg_test.cc
@@ -60,13 +60,13 @@ TEST(MessageTest, Extensions) {
   upb::MessageDefPtr m(upb_test_TestExtensions_getmsgdef(symtab.ptr()));
   EXPECT_TRUE(m.ptr() != nullptr);
 
-  std::string json = R"(
+  std::string json = R"json(
   {
       "[upb_test.TestExtensions.optional_int32_ext]": 123,
       "[upb_test.TestExtensions.Nested.repeated_int32_ext]": [2, 4, 6],
       "[upb_test.optional_msg_ext]": {"optional_int32": 456}
   }
-  )";
+  )json";
   upb::Status status;
   EXPECT_TRUE(upb_json_decode(json.data(), json.size(), ext_msg, m.ptr(),
                               symtab.ptr(), 0, arena.ptr(), status.ptr()))
@@ -98,4 +98,3 @@ TEST(MessageTest, Extensions) {
       << status.error_message();
   VerifyMessage(ext_msg3);
 }
-

--- a/upb/msg_test.cc
+++ b/upb/msg_test.cc
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2009-2021, Google LLC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Google LLC nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL Google LLC BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "gtest/gtest.h"
+#include "src/google/protobuf/test_messages_proto3.upb.h"
+#include "upb/def.hpp"
+#include "upb/json_decode.h"
+#include "upb/json_encode.h"
+#include "upb/msg_test.upb.h"
+#include "upb/msg_test.upbdefs.h"
+#include "upb/upb.hpp"
+
+void VerifyMessage(const upb_test_TestExtensions *ext_msg) {
+  EXPECT_TRUE(upb_test_TestExtensions_has_optional_int32_ext(ext_msg));
+  // EXPECT_FALSE(upb_test_TestExtensions_Nested_has_optional_int32_ext(ext_msg));
+  EXPECT_TRUE(upb_test_has_optional_msg_ext(ext_msg));
+
+  EXPECT_EQ(123, upb_test_TestExtensions_optional_int32_ext(ext_msg));
+  const protobuf_test_messages_proto3_TestAllTypesProto3 *ext_submsg =
+      upb_test_optional_msg_ext(ext_msg);
+  EXPECT_TRUE(ext_submsg != nullptr);
+  EXPECT_EQ(456,
+            protobuf_test_messages_proto3_TestAllTypesProto3_optional_int32(
+                ext_submsg));
+}
+
+TEST(MessageTest, Extensions) {
+  upb::Arena arena;
+  upb_test_TestExtensions *ext_msg = upb_test_TestExtensions_new(arena.ptr());
+
+  EXPECT_FALSE(upb_test_TestExtensions_has_optional_int32_ext(ext_msg));
+  // EXPECT_FALSE(upb_test_TestExtensions_Nested_has_optional_int32_ext(ext_msg));
+  EXPECT_FALSE(upb_test_has_optional_msg_ext(ext_msg));
+
+  upb::SymbolTable symtab;
+  upb::MessageDefPtr m(upb_test_TestExtensions_getmsgdef(symtab.ptr()));
+  EXPECT_TRUE(m.ptr() != nullptr);
+
+  std::string json = R"(
+  {
+      "[upb_test.TestExtensions.optional_int32_ext]": 123,
+      "[upb_test.TestExtensions.Nested.repeated_int32_ext]": [2, 4, 6],
+      "[upb_test.optional_msg_ext]": {"optional_int32": 456}
+  }
+  )";
+  upb::Status status;
+  EXPECT_TRUE(upb_json_decode(json.data(), json.size(), ext_msg, m.ptr(),
+                              symtab.ptr(), 0, arena.ptr(), status.ptr()))
+      << status.error_message();
+
+  VerifyMessage(ext_msg);
+
+  // Test round-trip through binary format.
+  size_t size;
+  char *serialized = upb_test_TestExtensions_serialize(ext_msg, arena.ptr(), &size);
+  ASSERT_TRUE(serialized != nullptr);
+  ASSERT_GE(size, 0);
+
+  upb_test_TestExtensions *ext_msg2 = upb_test_TestExtensions_parse_ex(
+      serialized, size, upb_symtab_extreg(symtab.ptr()), 0, arena.ptr());
+  VerifyMessage(ext_msg2);
+
+  // Test round-trip through JSON format.
+  size_t json_size =
+      upb_json_encode(ext_msg, m.ptr(), symtab.ptr(), 0, NULL, 0, status.ptr());
+  char *json_buf =
+      static_cast<char *>(upb_arena_malloc(arena.ptr(), json_size + 1));
+  upb_json_encode(ext_msg, m.ptr(), symtab.ptr(), 0, json_buf, json_size + 1,
+                  status.ptr());
+  upb_test_TestExtensions *ext_msg3 = upb_test_TestExtensions_new(arena.ptr());
+  fprintf(stderr, "%.*s\n", (int)json_size, json_buf);
+  EXPECT_TRUE(upb_json_decode(json_buf, json_size, ext_msg3, m.ptr(),
+                              symtab.ptr(), 0, arena.ptr(), status.ptr()))
+      << status.error_message();
+  VerifyMessage(ext_msg3);
+}
+

--- a/upb/msg_test.proto
+++ b/upb/msg_test.proto
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2009-2021, Google LLC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Google LLC nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL Google LLC BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+syntax = "proto2";
+
+import "src/google/protobuf/test_messages_proto3.proto";
+
+package upb_test;
+
+message TestExtensions {
+  extensions 1000 to max;
+  extend TestExtensions {
+    optional int32 optional_int32_ext = 1000;
+  }
+  message Nested {
+    extend TestExtensions {
+      repeated int32 repeated_int32_ext = 1001;
+    }
+  }
+}
+
+extend TestExtensions {
+  optional protobuf_test_messages.proto3.TestAllTypesProto3 optional_msg_ext = 1002;
+}

--- a/upb/reflection.c
+++ b/upb/reflection.c
@@ -108,15 +108,20 @@ static upb_msgval _upb_msg_getraw(const upb_msg *msg, const upb_fielddef *f) {
 }
 
 bool upb_msg_has(const upb_msg *msg, const upb_fielddef *f) {
-  const upb_msglayout_field *field = upb_fielddef_layout(f);
-  if (in_oneof(field)) {
-    return _upb_getoneofcase_field(msg, field) == field->number;
-  } else if (field->presence > 0) {
-    return _upb_hasbit_field(msg, field);
+  if (upb_fielddef_isextension(f)) {
+    const upb_msglayout_ext *ext = _upb_fielddef_extlayout(f);
+    return _upb_msg_getext(msg, ext) != NULL;
   } else {
-    UPB_ASSERT(field->descriptortype == UPB_DESCRIPTOR_TYPE_MESSAGE ||
-               field->descriptortype == UPB_DESCRIPTOR_TYPE_GROUP);
-    return _upb_msg_getraw(msg, f).msg_val != NULL;
+    const upb_msglayout_field *field = upb_fielddef_layout(f);
+    if (in_oneof(field)) {
+      return _upb_getoneofcase_field(msg, field) == field->number;
+    } else if (field->presence > 0) {
+      return _upb_hasbit_field(msg, field);
+    } else {
+      UPB_ASSERT(field->descriptortype == UPB_DESCRIPTOR_TYPE_MESSAGE ||
+                 field->descriptortype == UPB_DESCRIPTOR_TYPE_GROUP);
+      return _upb_msg_getraw(msg, f).msg_val != NULL;
+    }
   }
 }
 
@@ -136,73 +141,92 @@ const upb_fielddef *upb_msg_whichoneof(const upb_msg *msg,
 }
 
 upb_msgval upb_msg_get(const upb_msg *msg, const upb_fielddef *f) {
-  if (!upb_fielddef_haspresence(f) || upb_msg_has(msg, f)) {
+  if (upb_fielddef_isextension(f)) {
+    const upb_msg_ext *ext = _upb_msg_getext(msg, _upb_fielddef_extlayout(f));
+    if (ext) {
+      upb_msgval val;
+      memcpy(&val, &ext->data, sizeof(val));
+      return val;
+    } else if (upb_fielddef_isseq(f)) {
+      return (upb_msgval){.array_val = NULL};
+    }
+  } else if (!upb_fielddef_haspresence(f) || upb_msg_has(msg, f)) {
     return _upb_msg_getraw(msg, f);
-  } else {
-    return upb_fielddef_default(f);
   }
+  return upb_fielddef_default(f);
 }
 
 upb_mutmsgval upb_msg_mutable(upb_msg *msg, const upb_fielddef *f,
                               upb_arena *a) {
-  const upb_msglayout_field *field = upb_fielddef_layout(f);
-  upb_mutmsgval ret;
-  char *mem = UPB_PTR_AT(msg, field->offset, char);
-  bool wrong_oneof =
-      in_oneof(field) && _upb_getoneofcase_field(msg, field) != field->number;
-
-  memcpy(&ret, mem, sizeof(void*));
-
-  if (a && (!ret.msg || wrong_oneof)) {
-    if (upb_fielddef_ismap(f)) {
-      const upb_msgdef *entry = upb_fielddef_msgsubdef(f);
-      const upb_fielddef *key = upb_msgdef_itof(entry, UPB_MAPENTRY_KEY);
-      const upb_fielddef *value = upb_msgdef_itof(entry, UPB_MAPENTRY_VALUE);
-      ret.map = upb_map_new(a, upb_fielddef_type(key), upb_fielddef_type(value));
-    } else if (upb_fielddef_isseq(f)) {
-      ret.array = upb_array_new(a, upb_fielddef_type(f));
-    } else {
-      UPB_ASSERT(upb_fielddef_issubmsg(f));
-      ret.msg = upb_msg_new(upb_fielddef_msgsubdef(f), a);
-    }
-
-    memcpy(mem, &ret, sizeof(void*));
-
-    if (wrong_oneof) {
-      *_upb_oneofcase_field(msg, field) = field->number;
-    } else if (field->presence > 0) {
-      _upb_sethas_field(msg, field);
-    }
+  assert(upb_fielddef_issubmsg(f) || upb_fielddef_isseq(f));
+  if (upb_fielddef_haspresence(f) && !upb_msg_has(msg, f)) {
+    // We need to skip the upb_msg_get() call in this case.
+    goto make;
   }
+
+  upb_msgval val = upb_msg_get(msg, f);
+  if (val.array_val) {
+    return (upb_mutmsgval){.array = (upb_array*)val.array_val};
+  }
+
+  upb_mutmsgval ret;
+make:
+  if (!a) return (upb_mutmsgval){.array = NULL};
+  if (upb_fielddef_ismap(f)) {
+    const upb_msgdef *entry = upb_fielddef_msgsubdef(f);
+    const upb_fielddef *key = upb_msgdef_itof(entry, UPB_MAPENTRY_KEY);
+    const upb_fielddef *value = upb_msgdef_itof(entry, UPB_MAPENTRY_VALUE);
+    ret.map = upb_map_new(a, upb_fielddef_type(key), upb_fielddef_type(value));
+  } else if (upb_fielddef_isseq(f)) {
+    ret.array = upb_array_new(a, upb_fielddef_type(f));
+  } else {
+    UPB_ASSERT(upb_fielddef_issubmsg(f));
+    ret.msg = upb_msg_new(upb_fielddef_msgsubdef(f), a);
+  }
+
+  val.array_val = ret.array;
+  upb_msg_set(msg, f, val, a);
+
   return ret;
 }
 
-void upb_msg_set(upb_msg *msg, const upb_fielddef *f, upb_msgval val,
+bool upb_msg_set(upb_msg *msg, const upb_fielddef *f, upb_msgval val,
                  upb_arena *a) {
-  const upb_msglayout_field *field = upb_fielddef_layout(f);
-  char *mem = UPB_PTR_AT(msg, field->offset, char);
-  UPB_UNUSED(a);  /* We reserve the right to make set insert into a map. */
-  memcpy(mem, &val, get_field_size(field));
-  if (field->presence > 0) {
-    _upb_sethas_field(msg, field);
-  } else if (in_oneof(field)) {
-    *_upb_oneofcase_field(msg, field) = field->number;
+  if (upb_fielddef_isextension(f)) {
+    upb_msg_ext *ext =
+        _upb_msg_getorcreateext(msg, _upb_fielddef_extlayout(f), a);
+    if (!ext) return false;
+    memcpy(&ext->data, &val, sizeof(val));
+  } else {
+    const upb_msglayout_field *field = upb_fielddef_layout(f);
+    char *mem = UPB_PTR_AT(msg, field->offset, char);
+    memcpy(mem, &val, get_field_size(field));
+    if (field->presence > 0) {
+      _upb_sethas_field(msg, field);
+    } else if (in_oneof(field)) {
+      *_upb_oneofcase_field(msg, field) = field->number;
+    }
   }
+  return true;
 }
 
 void upb_msg_clearfield(upb_msg *msg, const upb_fielddef *f) {
-  const upb_msglayout_field *field = upb_fielddef_layout(f);
-  char *mem = UPB_PTR_AT(msg, field->offset, char);
+  if (upb_fielddef_isextension(f)) {
+    _upb_msg_clearext(msg, _upb_fielddef_extlayout(f));
+  } else {
+    const upb_msglayout_field *field = upb_fielddef_layout(f);
+    char *mem = UPB_PTR_AT(msg, field->offset, char);
 
-  if (field->presence > 0) {
-    _upb_clearhas_field(msg, field);
-  } else if (in_oneof(field)) {
-    uint32_t *oneof_case = _upb_oneofcase_field(msg, field);
-    if (*oneof_case != field->number) return;
-    *oneof_case = 0;
+    if (field->presence > 0) {
+      _upb_clearhas_field(msg, field);
+    } else if (in_oneof(field)) {
+      uint32_t *oneof_case = _upb_oneofcase_field(msg, field);
+      if (*oneof_case != field->number) return;
+      *oneof_case = 0;
+    }
+
+    memset(mem, 0, get_field_size(field));
   }
-
-  memset(mem, 0, get_field_size(field));
 }
 
 void upb_msg_clear(upb_msg *msg, const upb_msgdef *m) {
@@ -212,10 +236,12 @@ void upb_msg_clear(upb_msg *msg, const upb_msgdef *m) {
 bool upb_msg_next(const upb_msg *msg, const upb_msgdef *m,
                   const upb_symtab *ext_pool, const upb_fielddef **out_f,
                   upb_msgval *out_val, size_t *iter) {
-  int i = *iter;
-  int n = upb_msgdef_fieldcount(m);
+  size_t i = *iter;
+  size_t n = upb_msgdef_fieldcount(m);
   const upb_msgval zero = {0};
   UPB_UNUSED(ext_pool);
+
+  /* Iterate over normal fields, returning the first one that is set. */
   while (++i < n) {
     const upb_fielddef *f = upb_msgdef_field(m, i);
     upb_msgval val = _upb_msg_getraw(msg, f);
@@ -245,6 +271,20 @@ bool upb_msg_next(const upb_msg *msg, const upb_msgdef *m,
     *iter = i;
     return true;
   }
+
+  if (ext_pool) {
+    /* Return any extensions that are set. */
+    size_t count;
+    const upb_msg_ext *ext = _upb_msg_getexts(msg, &count);
+    if (i - n < count) {
+      ext += count - 1 - (i - n);
+      memcpy(out_val, &ext->data, sizeof(*out_val));
+      *out_f = _upb_symtab_lookupextfield(ext_pool, ext->ext);
+      *iter = i;
+      return true;
+    }
+  }
+
   *iter = i;
   return false;
 }

--- a/upb/reflection.c
+++ b/upb/reflection.c
@@ -158,7 +158,7 @@ upb_msgval upb_msg_get(const upb_msg *msg, const upb_fielddef *f) {
 
 upb_mutmsgval upb_msg_mutable(upb_msg *msg, const upb_fielddef *f,
                               upb_arena *a) {
-  assert(upb_fielddef_issubmsg(f) || upb_fielddef_isseq(f));
+  UPB_ASSERT(upb_fielddef_issubmsg(f) || upb_fielddef_isseq(f));
   if (upb_fielddef_haspresence(f) && !upb_msg_has(msg, f)) {
     // We need to skip the upb_msg_get() call in this case.
     goto make;

--- a/upb/reflection.h
+++ b/upb/reflection.h
@@ -82,8 +82,9 @@ const upb_fielddef *upb_msg_whichoneof(const upb_msg *msg,
 
 /* Sets the given field to the given value.  For a msg/array/map/string, the
  * value must be in the same arena.  */
-void upb_msg_set(upb_msg *msg, const upb_fielddef *f, upb_msgval val,
+bool upb_msg_set(upb_msg *msg, const upb_fielddef *f, upb_msgval val,
                  upb_arena *a);
+
 
 /* Clears any field presence and sets the value back to its default. */
 void upb_msg_clearfield(upb_msg *msg, const upb_fielddef *f);

--- a/upb/reflection.h
+++ b/upb/reflection.h
@@ -81,7 +81,10 @@ const upb_fielddef *upb_msg_whichoneof(const upb_msg *msg,
                                        const upb_oneofdef *o);
 
 /* Sets the given field to the given value.  For a msg/array/map/string, the
- * value must be in the same arena.  */
+ * caller must ensure that the target data outlives |msg| (by living either in
+ * the same arena or a different arena that outlives it).
+ *
+ * Returns false if allocation fails. */
 bool upb_msg_set(upb_msg *msg, const upb_fielddef *f, upb_msgval val,
                  upb_arena *a);
 

--- a/upbc/BUILD
+++ b/upbc/BUILD
@@ -54,6 +54,7 @@ cc_binary(
         ":common",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/strings",
         "@com_google_protobuf//:protobuf",
         "@com_google_protobuf//:protoc_lib",

--- a/upbc/common.cc
+++ b/upbc/common.cc
@@ -31,14 +31,6 @@ namespace {
 
 namespace protobuf = ::google::protobuf;
 
-void AddMessages(const protobuf::Descriptor* message,
-                 std::vector<const protobuf::Descriptor*>* messages) {
-  messages->push_back(message);
-  for (int i = 0; i < message->nested_type_count(); i++) {
-    AddMessages(message->nested_type(i), messages);
-  }
-}
-
 }  // namespace
 
 std::string StripExtension(absl::string_view fname) {
@@ -69,21 +61,16 @@ void EmitFileWarning(const protobuf::FileDescriptor* file, Output& output) {
       file->name());
 }
 
-std::vector<const protobuf::Descriptor*> SortedMessages(
-    const protobuf::FileDescriptor* file) {
-  std::vector<const protobuf::Descriptor*> messages;
-  for (int i = 0; i < file->message_type_count(); i++) {
-    AddMessages(file->message_type(i), &messages);
-  }
-  return messages;
-}
-
 std::string MessageName(const protobuf::Descriptor* descriptor) {
   return ToCIdent(descriptor->full_name());
 }
 
-std::string MessageInit(const protobuf::Descriptor* descriptor) {
-  return MessageName(descriptor) + "_msginit";
+std::string FileLayoutName(const google::protobuf::FileDescriptor* file) {
+  return ToCIdent(file->name()) + "_upb_file_layout";
+}
+
+std::string HeaderFilename(const google::protobuf::FileDescriptor* file) {
+  return StripExtension(file->name()) + ".upb.h";
 }
 
 }  // namespace upbc

--- a/upbc/common.h
+++ b/upbc/common.h
@@ -82,10 +82,9 @@ std::string ToCIdent(absl::string_view str);
 std::string ToPreproc(absl::string_view str);
 void EmitFileWarning(const google::protobuf::FileDescriptor* file,
                      Output& output);
-std::vector<const google::protobuf::Descriptor*> SortedMessages(
-    const google::protobuf::FileDescriptor* file);
-std::string MessageInit(const google::protobuf::Descriptor* descriptor);
 std::string MessageName(const google::protobuf::Descriptor* descriptor);
+std::string FileLayoutName(const google::protobuf::FileDescriptor* file);
+std::string HeaderFilename(const google::protobuf::FileDescriptor* file);
 
 }  // namespace upbc
 

--- a/upbc/protoc-gen-upb.cc
+++ b/upbc/protoc-gen-upb.cc
@@ -1172,18 +1172,16 @@ int WriteExtensions(const protobuf::FileDescriptor* file, Output& output) {
 
   // Order by full name for consistent ordering.
   std::map<std::string, const protobuf::Descriptor*> forward_messages;
-  auto add_forward_decl = [&](const protobuf::Descriptor* d) {
-    forward_messages[d->full_name()] = d;
-  };
 
   for (auto ext : exts) {
-    add_forward_decl(ext->containing_type());
+    forward_messages[ext->containing_type()->full_name()] =
+        ext->containing_type();
     if (ext->message_type()) {
-      add_forward_decl(ext->message_type());
+      forward_messages[ext->message_type()->full_name()] = ext->message_type();
     }
   }
 
-  for (auto decl : forward_messages) {
+  for (const auto& decl : forward_messages) {
     output("extern const upb_msglayout $0;\n", MessageInit(decl.second));
   }
 

--- a/upbc/protoc-gen-upb.cc
+++ b/upbc/protoc-gen-upb.cc
@@ -26,6 +26,7 @@
 #include <memory>
 
 #include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
 #include "absl/strings/ascii.h"
 #include "absl/strings/substitute.h"
 #include "google/protobuf/compiler/code_generator.h"
@@ -42,13 +43,30 @@ namespace {
 namespace protoc = ::google::protobuf::compiler;
 namespace protobuf = ::google::protobuf;
 
-std::string HeaderFilename(std::string proto_filename) {
-  return StripExtension(proto_filename) + ".upb.h";
+std::string SourceFilename(const google::protobuf::FileDescriptor* file) {
+  return StripExtension(file->name()) + ".upb.c";
 }
 
-std::string SourceFilename(std::string proto_filename) {
-  return StripExtension(proto_filename) + ".upb.c";
+std::string MessageInit(const protobuf::Descriptor* descriptor) {
+  return MessageName(descriptor) + "_msginit";
 }
+
+std::string ExtensionIdentBase(const protobuf::FieldDescriptor* ext) {
+  assert(ext->is_extension());
+  std::string ext_scope;
+  if (ext->extension_scope()) {
+    return MessageName(ext->extension_scope());
+  } else {
+    return ToCIdent(ext->file()->package());
+  }
+}
+
+std::string ExtensionLayout(const google::protobuf::FieldDescriptor* ext) {
+  return absl::StrCat(ExtensionIdentBase(ext), "_", ext->name(), "_ext");
+}
+
+const char *kMessagesInit = "messages_layout";
+const char *kExtensionsInit = "extensions_layout";
 
 void AddEnums(const protobuf::Descriptor* message,
               std::vector<const protobuf::EnumDescriptor*>* enums) {
@@ -77,6 +95,56 @@ std::vector<const protobuf::EnumDescriptor*> SortedEnums(
   }
   SortDefs(&enums);
   return enums;
+}
+
+void AddMessages(const protobuf::Descriptor* message,
+                 std::vector<const protobuf::Descriptor*>* messages) {
+  messages->push_back(message);
+  for (int i = 0; i < message->nested_type_count(); i++) {
+    AddMessages(message->nested_type(i), messages);
+  }
+}
+
+// Ordering must match upb/def.c!
+//
+// The ordering is significant because each upb_msgdef* will point at the
+// corresponding upb_msglayout and we just iterate through the list without
+// any search or lookup.
+std::vector<const protobuf::Descriptor*> SortedMessages(
+    const protobuf::FileDescriptor* file) {
+  std::vector<const protobuf::Descriptor*> messages;
+  for (int i = 0; i < file->message_type_count(); i++) {
+    AddMessages(file->message_type(i), &messages);
+  }
+  return messages;
+}
+
+void AddExtensionsFromMessage(
+    const protobuf::Descriptor* message,
+    std::vector<const protobuf::FieldDescriptor*>* exts) {
+  for (int i = 0; i < message->extension_count(); i++) {
+    exts->push_back(message->extension(i));
+  }
+  for (int i = 0; i < message->nested_type_count(); i++) {
+    AddExtensionsFromMessage(message->nested_type(i), exts);
+  }
+}
+
+// Ordering must match upb/def.c!
+//
+// The ordering is significant because each upb_fielddef* will point at the
+// corresponding upb_msglayout_ext and we just iterate through the list without
+// any search or lookup.
+std::vector<const protobuf::FieldDescriptor*> SortedExtensions(
+    const protobuf::FileDescriptor* file) {
+  std::vector<const protobuf::FieldDescriptor*> ret;
+  for (int i = 0; i < file->message_type_count(); i++) {
+    AddExtensionsFromMessage(file->message_type(i), &ret);
+  }
+  for (int i = 0; i < file->extension_count(); i++) {
+    ret.push_back(file->extension(i));
+  }
+  return ret;
 }
 
 std::vector<const protobuf::FieldDescriptor*> FieldNumberOrder(
@@ -180,6 +248,29 @@ std::string SizeLg2(const protobuf::FieldDescriptor* field) {
   }
 }
 
+std::string SizeRep(const protobuf::FieldDescriptor* field) {
+  switch (field->cpp_type()) {
+    case protobuf::FieldDescriptor::CPPTYPE_MESSAGE:
+      return "_UPB_REP_PTR";
+    case protobuf::FieldDescriptor::CPPTYPE_ENUM:
+    case protobuf::FieldDescriptor::CPPTYPE_FLOAT:
+    case protobuf::FieldDescriptor::CPPTYPE_INT32:
+    case protobuf::FieldDescriptor::CPPTYPE_UINT32:
+      return "_UPB_REP_4BYTE";
+    case protobuf::FieldDescriptor::CPPTYPE_BOOL:
+      return "_UPB_REP_1BYTE";
+    case protobuf::FieldDescriptor::CPPTYPE_DOUBLE:
+    case protobuf::FieldDescriptor::CPPTYPE_INT64:
+    case protobuf::FieldDescriptor::CPPTYPE_UINT64:
+      return "_UPB_REP_8BYTE";
+    case protobuf::FieldDescriptor::CPPTYPE_STRING:
+      return "_UPB_REP_STRVIEW";
+    default:
+      fprintf(stderr, "Unexpected type");
+      abort();
+  }
+}
+
 std::string FieldDefault(const protobuf::FieldDescriptor* field) {
   switch (field->cpp_type()) {
     case protobuf::FieldDescriptor::CPPTYPE_MESSAGE:
@@ -236,6 +327,34 @@ void DumpEnumValues(const protobuf::EnumDescriptor* desc, Output& output) {
       output(",");
     }
     output("\n");
+  }
+}
+
+void GenerateExtensionInHeader(const protobuf::FieldDescriptor* ext,
+                               Output& output) {
+  output(
+      "UPB_INLINE bool $0_has_$1(const struct $2 *msg) { "
+      "return _upb_msg_getext(msg, &$3) != NULL; }\n",
+      ExtensionIdentBase(ext), ext->name(), MessageName(ext->containing_type()),
+      ExtensionLayout(ext));
+
+  if (ext->is_repeated()) {
+  } else if (ext->message_type()) {
+    output(
+        "UPB_INLINE $0 $1_$2(const struct $3 *msg) { "
+        "const upb_msg_ext *ext = _upb_msg_getext(msg, &$4); "
+        "UPB_ASSERT(ext); return *UPB_PTR_AT(&ext->data, 0, $0); }\n",
+        CTypeConst(ext), ExtensionIdentBase(ext), ext->name(),
+        MessageName(ext->containing_type()), ExtensionLayout(ext),
+        FieldDefault(ext));
+  } else {
+    output(
+        "UPB_INLINE $0 $1_$2(const struct $3 *msg) { "
+        "const upb_msg_ext *ext = _upb_msg_getext(msg, &$4); "
+        "return ext ? *UPB_PTR_AT(&ext->data, 0, $0) : $5; }\n",
+        CTypeConst(ext), ExtensionIdentBase(ext), ext->name(),
+        MessageName(ext->containing_type()), ExtensionLayout(ext),
+        FieldDefault(ext));
   }
 }
 
@@ -524,11 +643,10 @@ void WriteHeader(const protobuf::FileDescriptor* file, Output& output) {
       ToPreproc(file->name()));
 
   for (int i = 0; i < file->public_dependency_count(); i++) {
-    const auto& name = file->public_dependency(i)->name();
     if (i == 0) {
       output("/* Public Imports. */\n");
     }
-    output("#include \"$0\"\n", HeaderFilename(name));
+    output("#include \"$0\"\n", HeaderFilename(file));
     if (i == file->public_dependency_count() - 1) {
       output("\n");
     }
@@ -544,6 +662,8 @@ void WriteHeader(const protobuf::FileDescriptor* file, Output& output) {
 
   const std::vector<const protobuf::Descriptor*> this_file_messages =
       SortedMessages(file);
+  const std::vector<const protobuf::FieldDescriptor*> this_file_exts =
+      SortedExtensions(file);
 
   // Forward-declare types defined in this file.
   for (auto message : this_file_messages) {
@@ -554,6 +674,9 @@ void WriteHeader(const protobuf::FileDescriptor* file, Output& output) {
   }
   for (auto message : this_file_messages) {
     output("extern const upb_msglayout $0;\n", MessageInit(message));
+  }
+  for (auto ext : this_file_exts) {
+    output("extern const upb_msglayout_ext $0;\n", ExtensionLayout(ext));
   }
 
   // Forward-declare types not in this file, but used as submessages.
@@ -568,6 +691,12 @@ void WriteHeader(const protobuf::FileDescriptor* file, Output& output) {
         forward_messages[field->message_type()->full_name()] =
             field->message_type();
       }
+    }
+  }
+  for (auto ext : this_file_exts) {
+    if (ext->file() != ext->containing_type()->file()) {
+      forward_messages[ext->containing_type()->full_name()] =
+          ext->containing_type();
     }
   }
   for (const auto& pair : forward_messages) {
@@ -595,6 +724,12 @@ void WriteHeader(const protobuf::FileDescriptor* file, Output& output) {
   for (auto message : this_file_messages) {
     GenerateMessageInHeader(message, output);
   }
+
+  for (auto ext : this_file_exts) {
+    GenerateExtensionInHeader(ext, output);
+  }
+
+  output("extern const upb_msglayout_file $0;\n\n", FileLayoutName(file));
 
   output(
       "#ifdef __cplusplus\n"
@@ -853,20 +988,28 @@ void WriteField(const protobuf::FieldDescriptor* field,
                 absl::string_view offset, absl::string_view presence,
                 int submsg_index, Output& output) {
   std::string mode;
+  std::string rep;
   if (field->is_map()) {
     mode = "_UPB_MODE_MAP";
+    rep = "_UPB_REP_PTR";
   } else if (field->is_repeated()) {
     mode = "_UPB_MODE_ARRAY";
+    rep = "_UPB_REP_PTR";
   } else {
     mode = "_UPB_MODE_SCALAR";
+    rep = SizeRep(field);
   }
 
   if (field->is_packed()) {
     absl::StrAppend(&mode, " | _UPB_MODE_IS_PACKED");
   }
 
-  output("{$0, $1, $2, $3, $4, $5}", field->number(), offset, presence,
-         submsg_index, TableDescriptorType(field), mode);
+  if (field->is_extension()) {
+    absl::StrAppend(&mode, " | _UPB_MODE_IS_EXTENSION");
+  }
+
+  output("{$0, $1, $2, $3, $4, $5 | ($6 << 6)}", field->number(), offset,
+         presence, submsg_index, TableDescriptorType(field), mode, rep);
 }
 
 // Writes a single field into a .upb.c source file.
@@ -913,11 +1056,11 @@ void WriteMessage(const protobuf::Descriptor* message, Output& output,
     // "submsgs" array for every strongly-connected component.
     std::string submsgs_array_name = msg_name + "_submsgs";
     submsgs_array_ref = "&" + submsgs_array_name + "[0]";
-    output("static const upb_msglayout *const $0[$1] = {\n",
+    output("static const upb_msglayout_sub $0[$1] = {\n",
            submsgs_array_name, submsg_array.submsgs().size());
 
     for (auto submsg : submsg_array.submsgs()) {
-      output("  &$0,\n", MessageInit(submsg));
+      output("  {.submsg = &$0},\n", MessageInit(submsg));
     }
 
     output("};\n\n");
@@ -960,12 +1103,19 @@ void WriteMessage(const protobuf::Descriptor* message, Output& output,
     table_mask = (table.size() - 1) << 3;
   }
 
+  std::string msgext = "_UPB_MSGEXT_NONE";
+
+  if (message->extension_range_count()) {
+    msgext = "_UPB_MSGEXT_EXTENDABLE";
+  }
+
   output("const upb_msglayout $0 = {\n", MessageInit(message));
   output("  $0,\n", submsgs_array_ref);
   output("  $0,\n", fields_array_ref);
-  output("  $0, $1, $2, $3, $4,\n", GetSizeInit(layout.message_size()),
+  output("  $0, $1, $2, $3, $4,\n",
+         GetSizeInit(layout.message_size()),
          field_number_order.size(),
-         "false",  // TODO: extendable
+         msgext,
          dense_below,
          table_mask
   );
@@ -980,11 +1130,74 @@ void WriteMessage(const protobuf::Descriptor* message, Output& output,
   output("};\n\n");
 }
 
-void WriteMessages(const protobuf::FileDescriptor* file, Output& output,
+void WriteExtension(const protobuf::FieldDescriptor* ext, Output& output) {
+  output("const upb_msglayout_ext $0 = {\n  ", ExtensionLayout(ext));
+  WriteField(ext, "0", "0", 0, output);
+  output(",\n");
+  output("  &$0,\n", MessageInit(ext->containing_type()));
+  if (ext->message_type()) {
+    output("  {.submsg = &$0},\n", MessageInit(ext->message_type()));
+  } else {
+    output("  {.submsg = NULL},\n");
+  }
+  output("\n};\n");
+}
+
+int WriteMessages(const protobuf::FileDescriptor* file, Output& output,
                    bool fasttable_enabled) {
-  for (auto* message : SortedMessages(file)) {
+  std::vector<const protobuf::Descriptor*> file_messages =
+      SortedMessages(file);
+
+  if (file_messages.empty()) return 0;
+
+  for (auto message : file_messages) {
     WriteMessage(message, output, fasttable_enabled);
   }
+
+  output("static const upb_msglayout *$0[$1] = {\n", kMessagesInit,
+         file_messages.size());
+  for (auto message : file_messages) {
+    output("  &$0,\n", MessageInit(message));
+  }
+  output("};\n");
+  output("\n");
+  return file_messages.size();
+}
+
+int WriteExtensions(const protobuf::FileDescriptor* file, Output& output) {
+  auto exts = SortedExtensions(file);
+  absl::flat_hash_set<const protobuf::Descriptor*> forward_decls;
+
+  if (exts.empty()) return 0;
+
+  for (auto ext : exts) {
+    forward_decls.insert(ext->containing_type());
+    if (ext->message_type()) {
+      forward_decls.insert(ext->message_type());
+    }
+  }
+
+  for (auto ext : exts) {
+    WriteExtension(ext, output);
+  }
+
+  for (auto decl : forward_decls) {
+    output("extern const upb_msglayout $0;\n", MessageInit(decl));
+  }
+
+  output(
+      "\n"
+      "static const upb_msglayout_ext *$0[$1] = {\n",
+      kExtensionsInit, exts.size());
+
+  for (auto ext : exts) {
+    output("  &$0,\n", ExtensionLayout(ext));
+  }
+
+  output(
+      "};\n"
+      "\n");
+  return exts.size();
 }
 
 // Writes a .upb.c source file.
@@ -996,10 +1209,10 @@ void WriteSource(const protobuf::FileDescriptor* file, Output& output,
       "#include <stddef.h>\n"
       "#include \"upb/msg_internal.h\"\n"
       "#include \"$0\"\n",
-      HeaderFilename(file->name()));
+      HeaderFilename(file));
 
   for (int i = 0; i < file->dependency_count(); i++) {
-    output("#include \"$0\"\n", HeaderFilename(file->dependency(i)->name()));
+    output("#include \"$0\"\n", HeaderFilename(file->dependency(i)));
   }
 
   output(
@@ -1007,7 +1220,15 @@ void WriteSource(const protobuf::FileDescriptor* file, Output& output,
       "#include \"upb/port_def.inc\"\n"
       "\n");
 
-  WriteMessages(file, output, fasttable_enabled);
+  int msg_count = WriteMessages(file, output, fasttable_enabled);
+  int ext_count = WriteExtensions(file, output);
+
+  output("const upb_msglayout_file $0 = {\n", FileLayoutName(file));
+  output("  $0,\n", msg_count ? kMessagesInit : "NULL");
+  output("  $0,\n", ext_count ? kExtensionsInit : "NULL");
+  output("  $0,\n", msg_count);
+  output("  $0,\n", ext_count);
+  output("};\n\n");
 
   output("#include \"upb/port_undef.inc\"\n");
   output("\n");
@@ -1040,10 +1261,10 @@ bool Generator::Generate(const protobuf::FileDescriptor* file,
     }
   }
 
-  Output h_output(context->Open(HeaderFilename(file->name())));
+  Output h_output(context->Open(HeaderFilename(file)));
   WriteHeader(file, h_output);
 
-  Output c_output(context->Open(SourceFilename(file->name())));
+  Output c_output(context->Open(SourceFilename(file)));
   WriteSource(file, c_output, fasttable_enabled);
 
   return true;

--- a/upbc/protoc-gen-upbdefs.cc
+++ b/upbc/protoc-gen-upbdefs.cc
@@ -104,27 +104,11 @@ void WriteDefSource(const protobuf::FileDescriptor* file, Output& output) {
 
   output("#include \"upb/def.h\"\n");
   output("#include \"$0\"\n", DefHeaderFilename(file->name()));
+  output("#include \"$0\"\n", HeaderFilename(file));
   output("\n");
 
   for (int i = 0; i < file->dependency_count(); i++) {
     output("extern upb_def_init $0;\n", DefInitSymbol(file->dependency(i)));
-  }
-
-  std::vector<const protobuf::Descriptor*> file_messages =
-      SortedMessages(file);
-
-  for (auto message : file_messages) {
-    output("extern const upb_msglayout $0;\n", MessageInit(message));
-  }
-  output("\n");
-
-  if (!file_messages.empty()) {
-    output("static const upb_msglayout *layouts[$0] = {\n", file_messages.size());
-    for (auto message : file_messages) {
-      output("  &$0,\n", MessageInit(message));
-    }
-    output("};\n");
-    output("\n");
   }
 
   protobuf::FileDescriptorProto file_proto;
@@ -156,11 +140,7 @@ void WriteDefSource(const protobuf::FileDescriptor* file, Output& output) {
 
   output("upb_def_init $0 = {\n", DefInitSymbol(file));
   output("  deps,\n");
-  if (file_messages.empty()) {
-    output("  NULL,\n");
-  } else {
-    output("  layouts,\n");
-  }
+  output("  &$0,\n", FileLayoutName(file));
   output("  \"$0\",\n", file->name());
   output("  UPB_STRVIEW_INIT(descriptor, $0)\n", file_data.size());
   output("};\n");


### PR DESCRIPTION
This adds support for extensions across all of upb:
- binary parser
- binary serializer
- json parser
- json serializer
- generated API (in a few cases, more work is needed here)
- reflection

The core representation for extensions is an array. Arrays with linear search beat hash tables for small N, and most messages do not have a large number of extensions present.

As of this PR, upb is now passing all conformance tests!

The code size growth is very modest. The perf is neutral for parsing and a 10% improvement for serialization!

Fixes: https://github.com/protocolbuffers/upb/issues/238

```
name                                      old time/op  new time/op  delta
ArenaOneAlloc                             21.4ns ± 0%  21.0ns ± 1%   -2.15%  (p=0.000 n=12+12)
ArenaInitialBlockOneAlloc                 6.28ns ± 0%  6.29ns ± 0%   +0.09%  (p=0.000 n=12+12)
LoadDescriptor_Upb                        53.5µs ± 1%  53.5µs ± 0%     ~     (p=0.887 n=12+12)
LoadAdsDescriptor_Upb                     3.45ms ± 0%  3.54ms ± 4%   +2.63%  (p=0.000 n=12+12)
LoadDescriptor_Proto2                      239µs ± 0%   238µs ± 0%   -0.50%  (p=0.000 n=10+12)
LoadAdsDescriptor_Proto2                  14.5ms ± 0%  14.7ms ± 0%   +1.42%  (p=0.000 n=10+10)
Parse_Upb_FileDesc<UseArena,Copy>         11.0µs ± 0%  10.6µs ± 0%   -3.26%  (p=0.000 n=11+12)
Parse_Upb_FileDesc<UseArena,Alias>        9.35µs ± 0%  9.38µs ± 0%   +0.26%  (p=0.000 n=12+12)
Parse_Upb_FileDesc<InitBlock,Copy>        10.6µs ± 0%  10.1µs ± 1%   -4.02%  (p=0.000 n=12+12)
Parse_Upb_FileDesc<InitBlock,Alias>       8.93µs ± 0%  8.91µs ± 0%   -0.18%  (p=0.000 n=12+11)
Parse_Proto2<FileDesc,NoArena,Copy>       29.4µs ± 0%  29.2µs ± 0%   -0.80%  (p=0.000 n=12+10)
Parse_Proto2<FileDesc,UseArena,Copy>      20.8µs ± 2%  20.8µs ± 2%     ~     (p=0.671 n=12+12)
Parse_Proto2<FileDesc,InitBlock,Copy>     16.6µs ± 0%  17.2µs ±12%     ~     (p=0.219 n=12+12)
Parse_Proto2<FileDescSV,InitBlock,Alias>  16.7µs ± 0%  19.3µs ±14%  +15.36%  (p=0.000 n=12+12)
SerializeDescriptor_Proto2                5.36µs ± 1%  5.34µs ± 1%     ~     (p=0.211 n=11+12)
SerializeDescriptor_Upb                   12.5µs ± 0%  11.1µs ± 0%  -10.74%  (p=0.000 n=12+12)


    FILE SIZE        VM SIZE    
 --------------  -------------- 
   +11% +1.93Ki  +9.9% +1.58Ki    upb/def.c
     +14%    +400   +14%    +400    create_msgdef
    +8.3%    +384  +8.3%    +384    _upb_symtab_addfile
     +20%    +288   +21%    +288    resolve_fielddef
    [NEW]    +150  [NEW]    +104    upb_symtab_lookupext2
    [NEW]    +123  [NEW]     +72    _upb_symtab_lookupextfield
    [NEW]    +120  [NEW]     +72    _upb_fielddef_extlayout
    [NEW]    +105  [NEW]     +56    upb_fielddef_isextension
    [NEW]    +102  [NEW]     +56    upb_fielddef_fullname
    [NEW]    +100  [NEW]     +56    upb_msgdef_fullname
    [NEW]     +66  [NEW]     +19    fill_fieldlayout.sizes
     +13%     +64   +14%     +64    _upb_symtab_loaddefinit
     +13%     +32   +15%     +32    upb_symtab_new
    +0.8%     +16  +0.8%     +16    create_fielddef
    +5.5%      +8  [ = ]       0    upb_oneofdef_name
    +6.7%      +7  [ = ]       0    upb_oneofdef_issynthetic
    +5.4%      +7  [ = ]       0    upb_oneofdef_itof
   +47% +1.25Ki   +48%   +1024    upb/msg.c
    [NEW]    +320  [NEW]    +280    _upb_extreg_add
    [NEW]    +240  [NEW]    +192    _upb_msg_getorcreateext
    [NEW]    +199  [NEW]    +160    upb_extreg_new
    [NEW]    +184  [NEW]    +144    _upb_extreg_get
    [NEW]    +176  [NEW]    +136    _upb_msg_getext
    [NEW]    +153  [NEW]    +112    _upb_msg_getexts
    +4.7%     +10  [ = ]       0    _upb_map_new
  +9.5%    +849   +12%    +368    bazel-out/k8-opt/bin/external/com_google_protobuf/src/google/protobuf/test_messages_proto2.upb.c
    [NEW]    +248  [NEW]    +224    messages_layout
    [NEW]    +159  [NEW]     +32    protobuf_test_messages_proto2_TestAllTypesProto2_MessageSetCorrectExtension1_message_set_extension_ext
    [NEW]    +159  [NEW]     +32    protobuf_test_messages_proto2_TestAllTypesProto2_MessageSetCorrectExtension2_message_set_extension_ext
    [NEW]    +111  [NEW]     +24    src_google_protobuf_test_messages_proto2_proto_upb_file_layout
    [NEW]    +106  [NEW]     +32    protobuf_test_messages_proto2_extension_int32_ext
    [NEW]     +74  [NEW]     +32    extensions_layout
    -6.2%      -8 -25.0%      -8    protobuf_test_messages_proto2_UnknownToTestAllTypes_OptionalGroup_msginit
  +2.7%    +320  +3.0%    +332    upb/decode.c
    +3.3%    +320  +3.3%    +320    decode_msg
    +3.3%     +16  +3.5%     +16    _upb_decode
     +11%      +8   +20%      +8    delim_ops
   -35.3%     -24 -50.0%     -12    upb_find_field.none
  +3.8%    +303  +6.0%    +192    bazel-out/k8-opt/bin/external/com_google_protobuf/src/google/protobuf/test_messages_proto3.upb.c
    [NEW]    +200  [NEW]    +176    messages_layout
    [NEW]    +111  [NEW]     +24    src_google_protobuf_test_messages_proto3_proto_upb_file_layout
    -7.3%      -8 -25.0%      -8    protobuf_test_messages_proto3_ForeignMessage_msginit
  +9.6%    +252  [ = ]       0    [Unmapped]
  +6.6%    +240  +8.1%    +240    upb/reflection.c
     +23%    +112   +25%    +112    upb_msg_next
     +35%     +80   +42%     +80    upb_msg_get
     +30%     +64   +36%     +64    upb_msg_set
     +20%     +48   +23%     +48    upb_msg_has
   -11.4%     -64 -12.3%     -64    upb_msg_mutable
  +3.0%    +205  +3.0%    +205    [section .rodata]
    +3.0%    +202  +3.0%    +202    [section .rodata]
     +18%      +3   +18%      +3    parse_proto.msg
   +13%    +191   +27%     +96    bazel-out/k8-opt/bin/external/com_google_protobuf/google/protobuf/wrappers.upb.c
    [NEW]     +96  [NEW]     +72    messages_layout
    [NEW]     +95  [NEW]     +24    google_protobuf_wrappers_proto_upb_file_layout
   +19%    +174   +18%     +64    bazel-out/k8-opt/bin/external/com_google_protobuf/conformance/conformance.upb.c
    [NEW]    +102  [NEW]     +32    conformance_conformance_proto_upb_file_layout
    [NEW]     +72  [NEW]     +32    messages_layout
   +16%    +157   +24%     +64    bazel-out/k8-opt/bin/external/com_google_protobuf/google/protobuf/struct.upb.c
    [NEW]    +101  [NEW]     +32    google_protobuf_struct_proto_upb_file_layout
    [NEW]     +56  [NEW]     +32    messages_layout
   +88%    +137  +100%     +40    bazel-out/k8-opt/bin/external/com_google_protobuf/google/protobuf/field_mask.upb.c
    [NEW]     +97  [NEW]     +24    google_protobuf_field_mask_proto_upb_file_layout
    [NEW]     +40  [NEW]     +16    messages_layout
   +83%    +136   +83%     +40    bazel-out/k8-opt/bin/external/com_google_protobuf/google/protobuf/timestamp.upb.c
    [NEW]     +96  [NEW]     +24    google_protobuf_timestamp_proto_upb_file_layout
    [NEW]     +40  [NEW]     +16    messages_layout
   +86%    +130   +83%     +40    bazel-out/k8-opt/bin/external/com_google_protobuf/google/protobuf/any.upb.c
    [NEW]     +98  [NEW]     +32    google_protobuf_any_proto_upb_file_layout
    [NEW]     +32  [NEW]      +8    messages_layout
  +0.8%    +128  +0.8%    +128    upb/json_decode.c
    +7.6%    +128  +7.8%    +128    jsondec_field
   +78%    +127   +67%     +32    bazel-out/k8-opt/bin/external/com_google_protobuf/google/protobuf/duration.upb.c
    [NEW]     +95  [NEW]     +24    google_protobuf_duration_proto_upb_file_layout
    [NEW]     +32  [NEW]      +8    messages_layout
 -13.7%     -92  [ = ]       0    [section .strtab]
    +158%     +19  [ = ]       0    completed.0
   -18.5%      -5  [ = ]       0    _GLOBAL_OFFSET_TABLE_
    [DEL]      -7  [ = ]       0    _start
   -22.8%     -99  [ = ]       0    [section .strtab]
 -12.3%     -96 -11.1%     -72    bazel-out/k8-opt/bin/external/com_google_protobuf/google/protobuf/wrappers.upbdefs.c
    [DEL]     -96  [DEL]     -72    layouts
  -0.4%    -183  -0.5%    -164    [14 Others]
  -1.7%    -208  -1.5%    -184    bazel-out/k8-opt/bin/external/com_google_protobuf/src/google/protobuf/test_messages_proto3.upbdefs.c
    -9.1%      -8 -12.5%      -8    deps
    [DEL]    -200  [DEL]    -176    layouts
  -2.3%    -248  -2.1%    -224    bazel-out/k8-opt/bin/external/com_google_protobuf/src/google/protobuf/test_messages_proto2.upbdefs.c
    [DEL]    -248  [DEL]    -224    layouts
  +3.4% +5.64Ki  +2.9% +3.75Ki    TOTAL
```