### PR TITLE
Implemented proto2's unfortunate enum behavior

### DIFF
--- a/benchmarks/compare.py
+++ b/benchmarks/compare.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # Copyright (c) 2009-2021, Google LLC
 # All rights reserved.

--- a/cmake/google/protobuf/descriptor.upb.c
+++ b/cmake/google/protobuf/descriptor.upb.c
@@ -126,16 +126,18 @@ const upb_msglayout google_protobuf_ExtensionRangeOptions_msginit = {
   UPB_SIZE(8, 8), 1, _UPB_MSGEXT_EXTENDABLE, 0, 255,
 };
 
-static const upb_msglayout_sub google_protobuf_FieldDescriptorProto_submsgs[1] = {
+static const upb_msglayout_sub google_protobuf_FieldDescriptorProto_submsgs[3] = {
   {.submsg = &google_protobuf_FieldOptions_msginit},
+  {.subenum = &google_protobuf_FieldDescriptorProto_Label_enuminit},
+  {.subenum = &google_protobuf_FieldDescriptorProto_Type_enuminit},
 };
 
 static const upb_msglayout_field google_protobuf_FieldDescriptorProto__fields[11] = {
   {1, UPB_SIZE(24, 24), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
   {2, UPB_SIZE(32, 40), 2, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
   {3, UPB_SIZE(12, 12), 3, 0, 5, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << _UPB_REP_SHIFT)},
-  {4, UPB_SIZE(4, 4), 4, 0, 14, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << _UPB_REP_SHIFT)},
-  {5, UPB_SIZE(8, 8), 5, 0, 14, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << _UPB_REP_SHIFT)},
+  {4, UPB_SIZE(4, 4), 4, 1, 14, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << _UPB_REP_SHIFT)},
+  {5, UPB_SIZE(8, 8), 5, 2, 14, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << _UPB_REP_SHIFT)},
   {6, UPB_SIZE(40, 56), 6, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
   {7, UPB_SIZE(48, 72), 7, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
   {8, UPB_SIZE(64, 104), 8, 0, 11, _UPB_MODE_SCALAR | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
@@ -248,14 +250,15 @@ const upb_msglayout google_protobuf_MethodDescriptorProto_msginit = {
   UPB_SIZE(32, 64), 6, _UPB_MSGEXT_NONE, 6, 255,
 };
 
-static const upb_msglayout_sub google_protobuf_FileOptions_submsgs[1] = {
+static const upb_msglayout_sub google_protobuf_FileOptions_submsgs[2] = {
   {.submsg = &google_protobuf_UninterpretedOption_msginit},
+  {.subenum = &google_protobuf_FileOptions_OptimizeMode_enuminit},
 };
 
 static const upb_msglayout_field google_protobuf_FileOptions__fields[21] = {
   {1, UPB_SIZE(20, 24), 1, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
   {8, UPB_SIZE(28, 40), 2, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
-  {9, UPB_SIZE(4, 4), 3, 0, 14, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << _UPB_REP_SHIFT)},
+  {9, UPB_SIZE(4, 4), 3, 1, 14, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << _UPB_REP_SHIFT)},
   {10, UPB_SIZE(8, 8), 4, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
   {11, UPB_SIZE(36, 56), 5, 0, 12, _UPB_MODE_SCALAR | (_UPB_REP_STRVIEW << _UPB_REP_SHIFT)},
   {16, UPB_SIZE(9, 9), 6, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
@@ -300,16 +303,18 @@ const upb_msglayout google_protobuf_MessageOptions_msginit = {
   UPB_SIZE(16, 16), 5, _UPB_MSGEXT_EXTENDABLE, 3, 255,
 };
 
-static const upb_msglayout_sub google_protobuf_FieldOptions_submsgs[1] = {
+static const upb_msglayout_sub google_protobuf_FieldOptions_submsgs[3] = {
   {.submsg = &google_protobuf_UninterpretedOption_msginit},
+  {.subenum = &google_protobuf_FieldOptions_CType_enuminit},
+  {.subenum = &google_protobuf_FieldOptions_JSType_enuminit},
 };
 
 static const upb_msglayout_field google_protobuf_FieldOptions__fields[7] = {
-  {1, UPB_SIZE(4, 4), 1, 0, 14, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << _UPB_REP_SHIFT)},
+  {1, UPB_SIZE(4, 4), 1, 1, 14, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << _UPB_REP_SHIFT)},
   {2, UPB_SIZE(12, 12), 2, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
   {3, UPB_SIZE(13, 13), 3, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
   {5, UPB_SIZE(14, 14), 4, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
-  {6, UPB_SIZE(8, 8), 5, 0, 14, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << _UPB_REP_SHIFT)},
+  {6, UPB_SIZE(8, 8), 5, 2, 14, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << _UPB_REP_SHIFT)},
   {10, UPB_SIZE(15, 15), 6, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
   {999, UPB_SIZE(16, 16), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
 };
@@ -380,13 +385,14 @@ const upb_msglayout google_protobuf_ServiceOptions_msginit = {
   UPB_SIZE(8, 16), 2, _UPB_MSGEXT_EXTENDABLE, 0, 255,
 };
 
-static const upb_msglayout_sub google_protobuf_MethodOptions_submsgs[1] = {
+static const upb_msglayout_sub google_protobuf_MethodOptions_submsgs[2] = {
   {.submsg = &google_protobuf_UninterpretedOption_msginit},
+  {.subenum = &google_protobuf_MethodOptions_IdempotencyLevel_enuminit},
 };
 
 static const upb_msglayout_field google_protobuf_MethodOptions__fields[3] = {
   {33, UPB_SIZE(8, 8), 1, 0, 8, _UPB_MODE_SCALAR | (_UPB_REP_1BYTE << _UPB_REP_SHIFT)},
-  {34, UPB_SIZE(4, 4), 2, 0, 14, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << _UPB_REP_SHIFT)},
+  {34, UPB_SIZE(4, 4), 2, 1, 14, _UPB_MODE_SCALAR | (_UPB_REP_4BYTE << _UPB_REP_SHIFT)},
   {999, UPB_SIZE(12, 16), 0, 0, 11, _UPB_MODE_ARRAY | (_UPB_REP_PTR << _UPB_REP_SHIFT)},
 };
 
@@ -512,10 +518,57 @@ static const upb_msglayout *messages_layout[27] = {
   &google_protobuf_GeneratedCodeInfo_Annotation_msginit,
 };
 
+const upb_enumlayout google_protobuf_FieldDescriptorProto_Label_enuminit = {
+  NULL,
+  0xeULL,
+  0,
+};
+
+const upb_enumlayout google_protobuf_FieldDescriptorProto_Type_enuminit = {
+  NULL,
+  0x7fffeULL,
+  0,
+};
+
+const upb_enumlayout google_protobuf_FieldOptions_CType_enuminit = {
+  NULL,
+  0x7ULL,
+  0,
+};
+
+const upb_enumlayout google_protobuf_FieldOptions_JSType_enuminit = {
+  NULL,
+  0x7ULL,
+  0,
+};
+
+const upb_enumlayout google_protobuf_FileOptions_OptimizeMode_enuminit = {
+  NULL,
+  0xeULL,
+  0,
+};
+
+const upb_enumlayout google_protobuf_MethodOptions_IdempotencyLevel_enuminit = {
+  NULL,
+  0x7ULL,
+  0,
+};
+
+static const upb_enumlayout *enums_layout[6] = {
+  &google_protobuf_FieldDescriptorProto_Label_enuminit,
+  &google_protobuf_FieldDescriptorProto_Type_enuminit,
+  &google_protobuf_FieldOptions_CType_enuminit,
+  &google_protobuf_FieldOptions_JSType_enuminit,
+  &google_protobuf_FileOptions_OptimizeMode_enuminit,
+  &google_protobuf_MethodOptions_IdempotencyLevel_enuminit,
+};
+
 const upb_msglayout_file google_protobuf_descriptor_proto_upb_file_layout = {
   messages_layout,
+  enums_layout,
   NULL,
   27,
+  6,
   0,
 };
 

--- a/cmake/google/protobuf/descriptor.upb.h
+++ b/cmake/google/protobuf/descriptor.upb.h
@@ -154,6 +154,13 @@ typedef enum {
 } google_protobuf_MethodOptions_IdempotencyLevel;
 
 
+extern const upb_enumlayout google_protobuf_FieldDescriptorProto_Label_enuminit;
+extern const upb_enumlayout google_protobuf_FieldDescriptorProto_Type_enuminit;
+extern const upb_enumlayout google_protobuf_FieldOptions_CType_enuminit;
+extern const upb_enumlayout google_protobuf_FieldOptions_JSType_enuminit;
+extern const upb_enumlayout google_protobuf_FileOptions_OptimizeMode_enuminit;
+extern const upb_enumlayout google_protobuf_MethodOptions_IdempotencyLevel_enuminit;
+
 /* google.protobuf.FileDescriptorSet */
 
 UPB_INLINE google_protobuf_FileDescriptorSet *google_protobuf_FileDescriptorSet_new(upb_arena *arena) {

--- a/upb/decode.c
+++ b/upb/decode.c
@@ -101,12 +101,14 @@ static const unsigned FIXED64_OK_MASK = (1 << UPB_DTYPE_DOUBLE) |
 #define OP_MSGSET_ITEM -2
 #define OP_MSGSET_TYPEID -3
 #define OP_SCALAR_LG2(n) (n)      /* n in [0, 2, 3] => op in [0, 2, 3] */
+#define OP_ENUM 1
 #define OP_STRING 4
 #define OP_BYTES 5
 #define OP_SUBMSG 6
-/* Ops above are scalar-only. Repeated fields can use any op.  */
+/* Scalar fields use only ops above. Repeated fields can use any op.  */
 #define OP_FIXPCK_LG2(n) (n + 5)  /* n in [2, 3] => op in [7, 8] */
 #define OP_VARPCK_LG2(n) (n + 9)  /* n in [0, 2, 3] => op in [9, 11, 12] */
+#define OP_PACKED_ENUM 13
 
 static const int8_t varint_ops[] = {
     OP_UNKNOWN,       /* field not found */
@@ -123,7 +125,7 @@ static const int8_t varint_ops[] = {
     OP_UNKNOWN,       /* MESSAGE */
     OP_UNKNOWN,       /* BYTES */
     OP_SCALAR_LG2(2), /* UINT32 */
-    OP_SCALAR_LG2(2), /* ENUM */
+    OP_ENUM,          /* ENUM */
     OP_UNKNOWN,       /* SFIXED32 */
     OP_UNKNOWN,       /* SFIXED64 */
     OP_SCALAR_LG2(2), /* SINT32 */
@@ -169,7 +171,7 @@ static const int8_t delim_ops[] = {
     OP_SUBMSG,        /* REPEATED MESSAGE */
     OP_BYTES,         /* REPEATED BYTES */
     OP_VARPCK_LG2(2), /* REPEATED UINT32 */
-    OP_VARPCK_LG2(2), /* REPEATED ENUM */
+    OP_PACKED_ENUM,   /* REPEATED ENUM */
     OP_FIXPCK_LG2(2), /* REPEATED SFIXED32 */
     OP_FIXPCK_LG2(3), /* REPEATED SFIXED64 */
     OP_VARPCK_LG2(2), /* REPEATED SINT32 */
@@ -384,6 +386,134 @@ static const char *decode_togroup(upb_decstate *d, const char *ptr,
   return decode_group(d, ptr, submsg, subl, field->number);
 }
 
+static char *encode_varint32(uint32_t val, char *ptr) {
+  do {
+    uint8_t byte = val & 0x7fU;
+    val >>= 7;
+    if (val) byte |= 0x80U;
+    *(ptr++) = byte;
+  } while (val);
+  return ptr;
+}
+
+UPB_NOINLINE
+static bool decode_checkenum_slow(upb_decstate *d, const char *ptr, upb_msg *msg,
+                             const upb_enumlayout *e,
+                             const upb_msglayout_field *field, uint32_t v) {
+  // OPT: binary search long lists?
+  int n = e->value_count;
+  for (int i = 0; i < n; i++) {
+    if ((uint32_t)e->values[i] == v) return true;
+  }
+
+  // Unrecognized enum goes into unknown fields.
+  // For packed fields the tag could be arbitrarily far in the past, so we
+  // just re-encode the tag here.
+  char buf[20];
+  char *end = buf;
+  uint32_t tag = ((uint32_t)field->number << 3) | UPB_WIRE_TYPE_VARINT;
+  end = encode_varint32(tag, end);
+  end = encode_varint32(v, end);
+
+  if (!_upb_msg_addunknown(msg, buf, end - buf, &d->arena)) {
+    decode_err(d);
+  }
+
+  return false;
+}
+
+UPB_FORCEINLINE
+static bool decode_checkenum(upb_decstate *d, const char *ptr, upb_msg *msg,
+                             const upb_enumlayout *e,
+                             const upb_msglayout_field *field, wireval *val) {
+  uint32_t v = val->uint32_val;
+
+  if (UPB_LIKELY(v < 64) && UPB_LIKELY(((1ULL << v) & e->mask))) return true;
+
+  return decode_checkenum_slow(d, ptr, msg, e, field, v);
+}
+
+UPB_NOINLINE
+static const char *decode_enum_toarray(upb_decstate *d, const char *ptr,
+                                       upb_msg *msg, upb_array *arr,
+                                       const upb_msglayout_sub *subs,
+                                       const upb_msglayout_field *field,
+                                       wireval *val) {
+  const upb_enumlayout *e = subs[field->submsg_index].subenum;
+  if (!decode_checkenum(d, ptr, msg, e, field, val)) return ptr;
+  void *mem = UPB_PTR_AT(_upb_array_ptr(arr), arr->len * 4, void);
+  arr->len++;
+  memcpy(mem, val, 4);
+  return ptr;
+}
+
+#include <stdio.h>
+UPB_FORCEINLINE
+static const char *decode_fixed_packed(upb_decstate *d, const char *ptr,
+                                       upb_array *arr, wireval *val,
+                                       const upb_msglayout_field *field,
+                                       int lg2) {
+  int mask = (1 << lg2) - 1;
+  size_t count = val->size >> lg2;
+  if ((val->size & mask) != 0) {
+    return decode_err(d); /* Length isn't a round multiple of elem size. */
+  }
+  decode_reserve(d, arr, count);
+  void *mem = UPB_PTR_AT(_upb_array_ptr(arr), arr->len << lg2, void);
+  arr->len += count;
+  memcpy(mem, ptr, val->size);  /* XXX: ptr boundary. */
+  return ptr + val->size;
+}
+
+UPB_FORCEINLINE
+static const char *decode_varint_packed(upb_decstate *d, const char *ptr,
+                                        upb_array *arr, wireval *val,
+                                        const upb_msglayout_field *field,
+                                        int lg2) {
+  int scale = 1 << lg2;
+  int saved_limit = decode_pushlimit(d, ptr, val->size);
+  char *out = UPB_PTR_AT(_upb_array_ptr(arr), arr->len << lg2, void);
+  while (!decode_isdone(d, &ptr)) {
+    wireval elem;
+    ptr = decode_varint64(d, ptr, &elem.uint64_val);
+    decode_munge(field->descriptortype, &elem);
+    if (decode_reserve(d, arr, 1)) {
+      out = UPB_PTR_AT(_upb_array_ptr(arr), arr->len << lg2, void);
+    }
+    arr->len++;
+    memcpy(out, &elem, scale);
+    out += scale;
+  }
+  decode_poplimit(d, ptr, saved_limit);
+  return ptr;
+}
+
+UPB_NOINLINE
+static const char *decode_enum_packed(upb_decstate *d, const char *ptr,
+                                      upb_msg *msg, upb_array *arr,
+                                      const upb_msglayout_sub *subs,
+                                      const upb_msglayout_field *field,
+                                      wireval *val) {
+  const upb_enumlayout *e = subs[field->submsg_index].subenum;
+  int saved_limit = decode_pushlimit(d, ptr, val->size);
+  char *out = UPB_PTR_AT(_upb_array_ptr(arr), arr->len * 4, void);
+  while (!decode_isdone(d, &ptr)) {
+    wireval elem;
+    ptr = decode_varint64(d, ptr, &elem.uint64_val);
+    if (!decode_checkenum(d, ptr, msg, e, field, &elem)) {
+      continue;
+    }
+    if (decode_reserve(d, arr, 1)) {
+      out = UPB_PTR_AT(_upb_array_ptr(arr), arr->len * 4, void);
+    }
+    arr->len++;
+    memcpy(out, &elem, 4);
+    out += 4;
+  }
+  decode_poplimit(d, ptr, saved_limit);
+  return ptr;
+}
+
 static const char *decode_toarray(upb_decstate *d, const char *ptr,
                                   upb_msg *msg,
                                   const upb_msglayout_sub *subs,
@@ -433,42 +563,18 @@ static const char *decode_toarray(upb_decstate *d, const char *ptr,
       }
     }
     case OP_FIXPCK_LG2(2):
-    case OP_FIXPCK_LG2(3): {
-      /* Fixed packed. */
-      int lg2 = op - OP_FIXPCK_LG2(0);
-      int mask = (1 << lg2) - 1;
-      size_t count = val->size >> lg2;
-      if ((val->size & mask) != 0) {
-        return decode_err(d); /* Length isn't a round multiple of elem size. */
-      }
-      decode_reserve(d, arr, count);
-      mem = UPB_PTR_AT(_upb_array_ptr(arr), arr->len << lg2, void);
-      arr->len += count;
-      memcpy(mem, ptr, val->size);  /* XXX: ptr boundary. */
-      return ptr + val->size;
-    }
+    case OP_FIXPCK_LG2(3):
+      return decode_fixed_packed(d, ptr, arr, val, field,
+                                 op - OP_FIXPCK_LG2(0));
     case OP_VARPCK_LG2(0):
     case OP_VARPCK_LG2(2):
-    case OP_VARPCK_LG2(3): {
-      /* Varint packed. */
-      int lg2 = op - OP_VARPCK_LG2(0);
-      int scale = 1 << lg2;
-      int saved_limit = decode_pushlimit(d, ptr, val->size);
-      char *out = UPB_PTR_AT(_upb_array_ptr(arr), arr->len << lg2, void);
-      while (!decode_isdone(d, &ptr)) {
-        wireval elem;
-        ptr = decode_varint64(d, ptr, &elem.uint64_val);
-        decode_munge(field->descriptortype, &elem);
-        if (decode_reserve(d, arr, 1)) {
-          out = UPB_PTR_AT(_upb_array_ptr(arr), arr->len << lg2, void);
-        }
-        arr->len++;
-        memcpy(out, &elem, scale);
-        out += scale;
-      }
-      decode_poplimit(d, ptr, saved_limit);
-      return ptr;
-    }
+    case OP_VARPCK_LG2(3):
+      return decode_varint_packed(d, ptr, arr, val, field,
+                                  op - OP_VARPCK_LG2(0));
+    case OP_ENUM:
+      return decode_enum_toarray(d, ptr, msg, arr, subs, field, val);
+    case OP_PACKED_ENUM:
+      return decode_enum_packed(d, ptr, msg, arr, subs, field, val);
     default:
       UPB_UNREACHABLE();
   }
@@ -516,6 +622,12 @@ static const char *decode_tomsg(upb_decstate *d, const char *ptr, upb_msg *msg,
   void *mem = UPB_PTR_AT(msg, field->offset, void);
   int type = field->descriptortype;
 
+  if (UPB_UNLIKELY(op == OP_ENUM) &&
+      !decode_checkenum(d, ptr, msg, subs[field->submsg_index].subenum, field,
+                        val)) {
+    return ptr;
+  }
+
   /* Set presence if necessary. */
   if (field->presence > 0) {
     _upb_sethas_field(msg, field);
@@ -552,6 +664,7 @@ static const char *decode_tomsg(upb_decstate *d, const char *ptr, upb_msg *msg,
     case OP_SCALAR_LG2(3):
       memcpy(mem, val, 8);
       break;
+    case OP_ENUM:
     case OP_SCALAR_LG2(2):
       memcpy(mem, val, 4);
       break;
@@ -798,13 +911,12 @@ static const char *decode_msg(upb_decstate *d, const char *ptr, upb_msg *msg,
     field_number = tag >> 3;
     wire_type = tag & 7;
 
-    field = decode_findfield(d, layout, field_number, &last_field_index);
-
     if (wire_type == UPB_WIRE_TYPE_END_GROUP) {
       d->end_group = field_number;
       return ptr;
     }
 
+    field = decode_findfield(d, layout, field_number, &last_field_index);
     ptr = decode_wireval(d, ptr, field, wire_type, &val, &op);
 
     if (op >= 0) {

--- a/upb/def.c
+++ b/upb/def.c
@@ -2363,6 +2363,16 @@ static void create_service(
   }
 }
 
+static int popcount(uint64_t x) {
+  // For assertions only, speed does not matter.
+  int n = 0;
+  while (x) {
+    if (x & 1) n++;
+    x >>= 1;
+  }
+  return n;
+}
+
 upb_enumlayout *create_enumlayout(symtab_addctx *ctx, const upb_enumdef *e) {
   int n = 0;
   uint64_t mask = 0;
@@ -2387,7 +2397,7 @@ upb_enumlayout *create_enumlayout(symtab_addctx *ctx, const upb_enumdef *e) {
   }
 
   UPB_ASSERT(p == values + n);
-  UPB_ASSERT(upb_inttable_count(&e->iton) == n + __builtin_popcountll(mask));
+  UPB_ASSERT(upb_inttable_count(&e->iton) == n + popcount(mask));
 
   upb_enumlayout *layout = symtab_alloc(ctx, sizeof(*layout));
   layout->value_count = n;
@@ -2463,7 +2473,7 @@ static void create_enumdef(
     if (ctx->layout) {
       UPB_ASSERT(ctx->enum_count < ctx->layout->enum_count);
       e->layout = ctx->layout->enums[ctx->enum_count++];
-      UPB_ASSERT(n == e->layout->value_count + __builtin_popcountll(e->layout->mask));
+      UPB_ASSERT(n == e->layout->value_count + popcount(e->layout->mask));
     } else {
       e->layout = create_enumlayout(ctx, e);
     }

--- a/upb/msg_internal.h
+++ b/upb/msg_internal.h
@@ -66,8 +66,8 @@ enum {
 typedef struct {
   uint32_t number;
   uint16_t offset;
-  int16_t presence;       /* If >0, hasbit_index.  If <0, ~oneof_index. */
-  uint16_t submsg_index;  /* undefined if descriptortype != MESSAGE or GROUP. */
+  int16_t presence;       // If >0, hasbit_index.  If <0, ~oneof_index
+  uint16_t submsg_index;  // undefined if descriptortype != MESSAGE/GROUP/ENUM
   uint8_t descriptortype;
   uint8_t mode; /* upb_fieldmode | upb_labelflags |
                    (upb_rep << _UPB_REP_SHIFT) */
@@ -130,9 +130,15 @@ typedef struct {
   _upb_field_parser *field_parser;
 } _upb_fasttable_entry;
 
+typedef struct {
+  const int32_t *values;  // List of values <0 or >63
+  uint64_t mask;          // Bits are set for acceptable value 0 <= x < 64
+  int value_count;
+} upb_enumlayout;
+
 typedef union {
   const struct upb_msglayout *submsg;
-  // TODO: const upb_enumlayout *subenum;
+  const upb_enumlayout *subenum;
 } upb_msglayout_sub;
 
 typedef enum {
@@ -179,8 +185,10 @@ typedef struct {
 
 typedef struct {
   const upb_msglayout **msgs;
+  const upb_enumlayout **enums;
   const upb_msglayout_ext **exts;
   int msg_count;
+  int enum_count;
   int ext_count;
 } upb_msglayout_file;
 

--- a/upb/msg_test.proto
+++ b/upb/msg_test.proto
@@ -58,3 +58,24 @@ message MessageSetMember {
     optional MessageSetMember message_set_extension = 4;
   }
 }
+
+message Proto2EnumMessage {
+  enum Proto2TestEnum {
+    ZERO = 0;
+    NEGATIVE = -1;
+    SMALL = 15;
+    LARGE = 12345;
+  }
+
+  optional Proto2TestEnum optional_enum = 1;
+  repeated Proto2TestEnum repeated_enum = 2;
+  map<int32, Proto2TestEnum> int32_enum_map = 3;
+}
+
+// The same fields as Proto2EnumMessage, but with int32 fields so we can fake
+// wire format.
+message Proto2FakeEnumMessage {
+  optional int32 optional_enum = 1;
+  repeated int32 repeated_enum = 2;
+  map<int32, int32> int32_enum_map = 3;
+}

--- a/upb/msg_test.proto
+++ b/upb/msg_test.proto
@@ -69,7 +69,7 @@ message Proto2EnumMessage {
 
   optional Proto2TestEnum optional_enum = 1;
   repeated Proto2TestEnum repeated_enum = 2;
-  map<int32, Proto2TestEnum> int32_enum_map = 3;
+  repeated Proto2TestEnum packed_enum = 3 [packed = true];
 }
 
 // The same fields as Proto2EnumMessage, but with int32 fields so we can fake
@@ -77,5 +77,5 @@ message Proto2EnumMessage {
 message Proto2FakeEnumMessage {
   optional int32 optional_enum = 1;
   repeated int32 repeated_enum = 2;
-  map<int32, int32> int32_enum_map = 3;
+  repeated int32 packed_enum = 3 [packed = true];
 }


### PR DESCRIPTION
Proto2 puts enums into the unknown field set at parse time if the parsed value was not declared in the enum.

For singular fields, it is bad. For repeated fields, it is worse (the enum gets reordered, as illustrated in the test case).

This grows the code size and regresses performance a bit. (The performance regression would be worse, but I optimized it to use a bit test for the common case of enumerators between 0 and 63.)

It's unfortunate to have to spend code size and perf on this "feature", when history has shown it to be a mistake. It raises the question "can we just not do this?" At the moment I've implemented this because existing Python unit tests verify this behavior. But is there any chance we could break with the past here?

In particular, note that this does not really affect the wire. The data is preserved and reserialized either way (albeit in scrambled order for repeated fields), it's just a question of how it is presented through the message API to the application. So maybe there is hope here that a breaking change policy could make this behavior unnecessary.

```
name                                      old time/op  new time/op   delta
ArenaInitialBlockOneAlloc                 6.88ns ± 0%   6.37ns ± 1%   -7.34%  (p=0.000 n=12+12)
ArenaOneAlloc                             21.1ns ± 1%   20.8ns ± 1%   -1.34%  (p=0.000 n=12+11)
LoadAdsDescriptor_Proto2                  15.1ms ± 5%   15.1ms ± 3%     ~     (p=0.755 n=12+12)
LoadAdsDescriptor_Upb                     3.78ms ± 4%   3.78ms ± 3%     ~     (p=0.949 n=11+11)
LoadDescriptor_Proto2                      250µs ± 1%    245µs ± 3%   -1.63%  (p=0.000 n=12+12)
LoadDescriptor_Upb                        48.0µs ±17%   48.0µs ± 2%   -0.02%  (p=0.009 n=10+10)
Parse_Proto2<FileDesc,InitBlock,Copy>     17.0µs ± 1%   18.8µs ±13%  +10.96%  (p=0.000 n=10+12)
Parse_Proto2<FileDesc,NoArena,Copy>       31.7µs ±10%   29.7µs ± 9%   -6.48%  (p=0.003 n=12+10)
Parse_Proto2<FileDescSV,InitBlock,Alias>  17.1µs ±14%   17.3µs ± 3%   +1.18%  (p=0.002 n=10+10)
Parse_Proto2<FileDesc,UseArena,Copy>      20.2µs ± 3%   20.2µs ± 6%     ~     (p=0.766 n=9+11)
Parse_Upb_FileDesc<InitBlock,Alias>       8.54µs ± 0%   8.90µs ± 0%   +4.21%  (p=0.000 n=10+10)
Parse_Upb_FileDesc<InitBlock,Copy>        9.85µs ± 1%  10.68µs ± 0%   +8.43%  (p=0.000 n=11+11)
Parse_Upb_FileDesc<UseArena,Alias>        8.93µs ± 1%   9.36µs ± 1%   +4.73%  (p=0.000 n=12+11)
Parse_Upb_FileDesc<UseArena,Copy>         10.3µs ± 1%   11.1µs ± 1%   +7.86%  (p=0.000 n=10+12)
SerializeDescriptor_Proto2                6.43µs ±39%   5.56µs ± 6%     ~     (p=0.843 n=12+12)
SerializeDescriptor_Upb                   11.3µs ± 0%   11.6µs ± 0%   +2.92%  (p=0.000 n=11+11)


    FILE SIZE        VM SIZE    
 --------------  -------------- 
  +202% +1.71Ki  [ = ]       0    [Unmapped]
   +11% +1.35Ki   +11% +1.23Ki    upb/decode.c
    [NEW]    +531  [NEW]    +488    decode_enum_packed
    [NEW]    +326  [NEW]    +280    decode_checkenum_slow
    +3.2%    +320  +3.2%    +320    decode_msg
    [NEW]    +212  [NEW]    +168    decode_enum_toarray
    -2.1%      -5  [ = ]       0    decode_isdonefallback
  +2.6%    +676  +2.8%    +648    upb/def.c
    [NEW]    +610  [NEW]    +568    create_enumlayout
    +4.9%     +80  +5.0%     +80    create_enumdef
    +1.3%     +32  +1.3%     +32    resolve_msgdef
   -10.9%     -14  [ = ]       0    upb_oneofdef_field
    -0.3%     -16  -0.3%     -16    _upb_symtab_addfile
    -0.4%     -16  -0.4%     -16    create_msgdef
  +6.6%    +652  +3.8%    +128    bazel-out/k8-opt/bin/external/com_google_protobuf/src/google/protobuf/test_messages_proto2.upb.c
    [NEW]    +123  [NEW]     +16    protobuf_test_messages_proto2_TestAllTypesProto2_MapStringForeignEnumEntry_submsgs
    [NEW]    +117  [NEW]     +24    protobuf_test_messages_proto2_TestAllTypesProto2_NestedEnum_enuminit
    [NEW]    +114  [NEW]      +8    protobuf_test_messages_proto2_TestAllTypesProto2_MapStringNestedEnumEntry_submsgs
    [NEW]    +108  [NEW]      +8    protobuf_test_messages_proto2_TestAllTypesProto2_NestedEnum_enuminit_values
    [NEW]    +105  [NEW]     +24    protobuf_test_messages_proto2_ForeignEnumProto2_enuminit
    [NEW]     +53  [NEW]     +16    enums_layout
     +22%     +24  +100%     +24    src_google_protobuf_test_messages_proto2_proto_upb_file_layout
    +2.9%      +8  +4.2%      +8    protobuf_test_messages_proto2_TestAllTypesProto2_submsgs
  +9.1%    +647  +8.1%    +200    bazel-out/k8-opt/bin/external/com_google_protobuf/google/protobuf/descriptor.upb.c
    [NEW]    +118  [NEW]     +32    google_protobuf_MethodOptions_IdempotencyLevel_enuminit
    [NEW]    +100  [NEW]     +24    google_protobuf_FieldDescriptorProto_Label_enuminit
    [NEW]    +100  [NEW]     +24    google_protobuf_FieldOptions_JSType_enuminit
    [NEW]     +99  [NEW]     +24    google_protobuf_FieldDescriptorProto_Type_enuminit
    [NEW]     +98  [NEW]     +24    google_protobuf_FileOptions_OptimizeMode_enuminit
    [NEW]     +97  [NEW]     +24    google_protobuf_FieldOptions_CType_enuminit
     +35%     +24  +300%     +24    google_protobuf_FieldOptions_submsgs
     +19%     +16  +100%     +16    google_protobuf_FieldDescriptorProto_submsgs
    +9.2%      +8   +33%      +8    google_protobuf_MessageOptions_msginit
    +8.0%      +7  [ = ]       0    google_protobuf_DescriptorProto_msginit
    -5.9%      -6  [ = ]       0    google_protobuf_ServiceDescriptorProto_msginit
    -7.0%      -7  [ = ]       0    google_protobuf_FieldDescriptorProto_msginit
    -7.4%      -7  [ = ]       0    google_protobuf_SourceCodeInfo_msginit
  [ = ]       0   +43%     +24    [LOAD #3 [RW]]
  +1.5%     +16  +3.8%     +16    bazel-out/k8-opt/bin/external/com_google_protobuf/conformance/conformance.upb.c
     +16%     +16   +50%     +16    conformance_conformance_proto_upb_file_layout
  +5.7%     +16   +18%     +16    bazel-out/k8-opt/bin/external/com_google_protobuf/google/protobuf/any.upb.c
     +16%     +16   +50%     +16    google_protobuf_any_proto_upb_file_layout
  +5.5%     +16   +20%     +16    bazel-out/k8-opt/bin/external/com_google_protobuf/google/protobuf/duration.upb.c
     +17%     +16   +67%     +16    google_protobuf_duration_proto_upb_file_layout
  +5.5%     +16   +20%     +16    bazel-out/k8-opt/bin/external/com_google_protobuf/google/protobuf/field_mask.upb.c
     +16%     +16   +67%     +16    google_protobuf_field_mask_proto_upb_file_layout
  +1.4%     +16  +4.9%     +16    bazel-out/k8-opt/bin/external/com_google_protobuf/google/protobuf/struct.upb.c
     +16%     +16   +50%     +16    google_protobuf_struct_proto_upb_file_layout
  +5.3%     +16   +18%     +16    bazel-out/k8-opt/bin/external/com_google_protobuf/google/protobuf/timestamp.upb.c
     +17%     +16   +67%     +16    google_protobuf_timestamp_proto_upb_file_layout
  +1.0%     +16  +3.5%     +16    bazel-out/k8-opt/bin/external/com_google_protobuf/google/protobuf/wrappers.upb.c
     +17%     +16   +67%     +16    google_protobuf_wrappers_proto_upb_file_layout
  +0.2%     +16  +0.5%     +16    bazel-out/k8-opt/bin/external/com_google_protobuf/src/google/protobuf/test_messages_proto3.upb.c
     +14%     +16   +67%     +16    src_google_protobuf_test_messages_proto3_proto_upb_file_layout
  +0.4%     +13  [ = ]       0    tests/conformance_upb.c
    +6.3%     +13  [ = ]       0    main
  +0.1%     +10  [ = ]       0    upb/table.c
    +5.6%     +10  [ = ]       0    upb_inttable_done
  +0.1%      +8  +0.1%      +8    [section .rodata]
  [ = ]       0  [NEW]      +4    [section .bss]
    [ = ]       0  [NEW]      +4    completed.0
  -1.4%      -9  [ = ]       0    [section .strtab]
  [ = ]       0  -0.5%     -12    upb/upb.c
    [ = ]       0  [DEL]      -4    completed.0
    [ = ]       0 -50.0%      -8    upb_alloc_global
  +2.9% +5.13Ki  +1.7% +2.33Ki    TOTAL
```