### PR TITLE
Optimize varint encoding

### DIFF
--- a/upb/encode.c
+++ b/upb/encode.c
@@ -42,11 +42,11 @@
 
 static char *encode_varint64(uint64_t val, char *buf)
 {
-  do
+  while (val > 127)
   {
     *buf++ = val | 0x80;
     val >>= 7;
-  } while (val > 127);
+  }
   *buf++ = val;
   return buf;
 }
@@ -58,10 +58,16 @@ typedef struct
 {
   jmp_buf err;
   upb_alloc *alloc;
-  char *buf, *ptr, *limit;
+  char *buf, *limit;
   int options;
   int depth;
   _upb_mapsorter sorter;
+} upb_context;
+
+typedef struct
+{
+  char *ptr;
+  upb_context *ctx;
 } upb_encstate;
 
 static size_t upb_roundup_pow2(size_t bytes)
@@ -74,32 +80,35 @@ static size_t upb_roundup_pow2(size_t bytes)
   return ret;
 }
 
+UPB_FORCEINLINE
 UPB_NORETURN static void encode_err(upb_encstate *e)
 {
-  UPB_LONGJMP(e->err, 1);
+  UPB_LONGJMP(e->ctx->err, 1);
 }
 
 UPB_NOINLINE
-static void encode_growbuffer(upb_encstate *e, size_t bytes)
+static char *encode_growbuffer(upb_encstate e2, size_t bytes)
 {
-  size_t old_size = e->limit - e->buf;
-  size_t new_size = upb_roundup_pow2(bytes + (e->limit - e->ptr));
-  char *new_buf = upb_realloc(e->alloc, e->buf, old_size, new_size);
+  char *ptr = e2.ptr;
+  upb_context *e = e2.ctx;
+  size_t cur_size = e->limit - ptr;
+  size_t new_size = upb_roundup_pow2(bytes + cur_size);
+  char *new_buf = upb_malloc(e->alloc, new_size);
 
   if (!new_buf)
-    encode_err(e);
+    encode_err(&e2);
 
   /* We want previous data at the end, realloc() put it at the beginning. */
-  if (old_size > 0)
+  if (cur_size > 0)
   {
-    memmove(new_buf + new_size - old_size, e->buf, old_size);
+    memcpy(new_buf + new_size - cur_size, ptr, cur_size);
   }
 
-  e->ptr = new_buf + new_size - (e->limit - e->ptr);
+  ptr = new_buf + new_size - cur_size;
   e->limit = new_buf + new_size;
   e->buf = new_buf;
 
-  e->ptr -= bytes;
+  return ptr - bytes;
 }
 
 /* Call to ensure that at least "bytes" bytes are available for writing at
@@ -107,9 +116,9 @@ static void encode_growbuffer(upb_encstate *e, size_t bytes)
 UPB_FORCEINLINE
 static void encode_reserve(upb_encstate *e, size_t bytes)
 {
-  if ((size_t)(e->ptr - e->buf) < bytes)
+  if ((size_t)(e->ptr - e->ctx->buf) < bytes)
   {
-    encode_growbuffer(e, bytes);
+    e->ptr = encode_growbuffer(*e, bytes);
     return;
   }
 
@@ -117,6 +126,7 @@ static void encode_reserve(upb_encstate *e, size_t bytes)
 }
 
 /* Writes the given bytes to the buffer, handling reserve/advance. */
+UPB_FORCEINLINE
 static void encode_bytes(upb_encstate *e, const void *data, size_t len)
 {
   if (len == 0)
@@ -125,12 +135,14 @@ static void encode_bytes(upb_encstate *e, const void *data, size_t len)
   memcpy(e->ptr, data, len);
 }
 
+UPB_FORCEINLINE
 static void encode_fixed64(upb_encstate *e, uint64_t val)
 {
   val = _upb_be_swap64(val);
   encode_bytes(e, &val, sizeof(uint64_t));
 }
 
+UPB_FORCEINLINE
 static void encode_fixed32(upb_encstate *e, uint32_t val)
 {
   val = _upb_be_swap32(val);
@@ -138,32 +150,33 @@ static void encode_fixed32(upb_encstate *e, uint32_t val)
 }
 
 UPB_NOINLINE
-static void encode_longvarint(upb_encstate *e, uint64_t val)
+static char *encode_longvarint(upb_encstate e, uint64_t val)
 {
   char buffer[32];
 
   char *start = buffer + 16;
   char *end = encode_varint64(val, start);
 
-  encode_reserve(e, 16);
-  memcpy(e->ptr, end - 16, 16);
-  e->ptr += 16 - (end - start);
+  encode_reserve(&e, 16);
+  memcpy(e.ptr, end - 16, 16);
+  return e.ptr + 16 - (end - start);
 }
 
 UPB_FORCEINLINE
 static void encode_varint(upb_encstate *e, uint64_t val)
 {
-  if (val < 128 && e->ptr != e->buf)
+  if (val < 128 && e->ptr != e->ctx->buf)
   {
     --e->ptr;
     *e->ptr = val;
   }
   else
   {
-    encode_longvarint(e, val);
+    e->ptr = encode_longvarint(*e, val);
   }
 }
 
+UPB_FORCEINLINE
 static void encode_double(upb_encstate *e, double d)
 {
   uint64_t u64;
@@ -172,6 +185,7 @@ static void encode_double(upb_encstate *e, double d)
   encode_fixed64(e, u64);
 }
 
+UPB_FORCEINLINE
 static void encode_float(upb_encstate *e, float d)
 {
   uint32_t u32;
@@ -180,15 +194,17 @@ static void encode_float(upb_encstate *e, float d)
   encode_fixed32(e, u32);
 }
 
+UPB_FORCEINLINE
 static void encode_tag(upb_encstate *e, uint32_t field_number,
                        uint8_t wire_type)
 {
   encode_varint(e, (field_number << 3) | wire_type);
 }
 
-static void encode_fixedarray(upb_encstate *e, const upb_array *arr,
-                              size_t elem_size, uint32_t tag)
+static char *encode_fixedarray_impl(upb_encstate e, const upb_array *arr,
+                                    size_t elem_size, uint32_t tag)
 {
+  // ENDIAN??
   size_t bytes = arr->len * elem_size;
   const char *data = _upb_array_constptr(arr);
   const char *ptr = data + bytes - elem_size;
@@ -196,8 +212,8 @@ static void encode_fixedarray(upb_encstate *e, const upb_array *arr,
   {
     while (true)
     {
-      encode_bytes(e, ptr, elem_size);
-      encode_varint(e, tag);
+      encode_bytes(&e, ptr, elem_size);
+      encode_varint(&e, tag);
       if (ptr == data)
         break;
       ptr -= elem_size;
@@ -205,16 +221,31 @@ static void encode_fixedarray(upb_encstate *e, const upb_array *arr,
   }
   else
   {
-    encode_bytes(e, data, bytes);
+    encode_bytes(&e, data, bytes);
   }
+  return e.ptr;
 }
 
-static void encode_message(upb_encstate *e, const upb_msg *msg,
-                           const upb_msglayout *m, size_t *size);
+UPB_FORCEINLINE
+static void encode_fixedarray(upb_encstate *e, const upb_array *arr,
+                              size_t elem_size, uint32_t tag)
+{
+  e->ptr = encode_fixedarray_impl(*e, arr, elem_size, tag);
+}
 
-static void encode_scalar(upb_encstate *e, const void *_field_mem,
-                          const upb_msglayout_sub *subs,
-                          const upb_msglayout_field *f)
+static char *encode_message_impl(upb_encstate e, const upb_msg *msg,
+                                 const upb_msglayout *m, size_t *size);
+
+UPB_FORCEINLINE
+static void encode_message(upb_encstate *e, const upb_msg *msg,
+                           const upb_msglayout *m, size_t *size)
+{
+  e->ptr = encode_message_impl(*e, msg, m, size);
+}
+
+static char *encode_scalar_impl(upb_encstate e, const void *_field_mem,
+                                const upb_msglayout_sub *subs,
+                                const upb_msglayout_field *f)
 {
   const char *field_mem = _field_mem;
   int wire_type;
@@ -222,7 +253,7 @@ static void encode_scalar(upb_encstate *e, const void *_field_mem,
 #define CASE(ctype, type, wtype, encodeval) \
   {                                         \
     ctype val = *(ctype *)field_mem;        \
-    encode_##type(e, encodeval);            \
+    encode_##type(&e, encodeval);           \
     wire_type = wtype;                      \
     break;                                  \
   }
@@ -257,8 +288,8 @@ static void encode_scalar(upb_encstate *e, const void *_field_mem,
   case UPB_DESCRIPTOR_TYPE_BYTES:
   {
     upb_strview view = *(upb_strview *)field_mem;
-    encode_bytes(e, view.data, view.size);
-    encode_varint(e, view.size);
+    encode_bytes(&e, view.data, view.size);
+    encode_varint(&e, view.size);
     wire_type = UPB_WIRE_TYPE_DELIMITED;
     break;
   }
@@ -269,14 +300,14 @@ static void encode_scalar(upb_encstate *e, const void *_field_mem,
     const upb_msglayout *subm = subs[f->submsg_index].submsg;
     if (submsg == NULL)
     {
-      return;
+      return e.ptr;
     }
-    if (--e->depth == 0)
-      encode_err(e);
-    encode_tag(e, f->number, UPB_WIRE_TYPE_END_GROUP);
-    encode_message(e, submsg, subm, &size);
+    if (--e.ctx->depth == 0)
+      encode_err(&e);
+    encode_tag(&e, f->number, UPB_WIRE_TYPE_END_GROUP);
+    encode_message(&e, submsg, subm, &size);
     wire_type = UPB_WIRE_TYPE_START_GROUP;
-    e->depth++;
+    e.ctx->depth++;
     break;
   }
   case UPB_DESCRIPTOR_TYPE_MESSAGE:
@@ -286,14 +317,14 @@ static void encode_scalar(upb_encstate *e, const void *_field_mem,
     const upb_msglayout *subm = subs[f->submsg_index].submsg;
     if (submsg == NULL)
     {
-      return;
+      return e.ptr;
     }
-    if (--e->depth == 0)
-      encode_err(e);
-    encode_message(e, submsg, subm, &size);
-    encode_varint(e, size);
+    if (--e.ctx->depth == 0)
+      encode_err(&e);
+    encode_message(&e, submsg, subm, &size);
+    encode_varint(&e, size);
     wire_type = UPB_WIRE_TYPE_DELIMITED;
-    e->depth++;
+    e.ctx->depth++;
     break;
   }
   default:
@@ -301,20 +332,29 @@ static void encode_scalar(upb_encstate *e, const void *_field_mem,
   }
 #undef CASE
 
-  encode_tag(e, f->number, wire_type);
+  encode_tag(&e, f->number, wire_type);
+  return e.ptr;
 }
 
-static void encode_array(upb_encstate *e, const upb_msg *msg,
-                         const upb_msglayout_sub *subs,
-                         const upb_msglayout_field *f)
+UPB_FORCEINLINE
+static void encode_scalar(upb_encstate *e, const void *_field_mem,
+                          const upb_msglayout_sub *subs,
+                          const upb_msglayout_field *f)
+{
+  e->ptr = encode_scalar_impl(*e, _field_mem, subs, f);
+}
+
+static char *encode_array_impl(upb_encstate e, const upb_msg *msg,
+                               const upb_msglayout_sub *subs,
+                               const upb_msglayout_field *f)
 {
   const upb_array *arr = *UPB_PTR_AT(msg, f->offset, upb_array *);
   bool packed = f->mode & _UPB_MODE_IS_PACKED;
-  size_t pre_len = e->limit - e->ptr;
+  size_t pre_len = e.ctx->limit - e.ptr;
 
   if (arr == NULL || arr->len == 0)
   {
-    return;
+    return e.ptr;
   }
 
 #define VARINT_CASE(ctype, encode)                                       \
@@ -325,9 +365,9 @@ static void encode_array(upb_encstate *e, const upb_msg *msg,
     do                                                                   \
     {                                                                    \
       ptr--;                                                             \
-      encode_varint(e, encode);                                          \
+      encode_varint(&e, encode);                                         \
       if (tag)                                                           \
-        encode_varint(e, tag);                                           \
+        encode_varint(&e, tag);                                          \
     } while (ptr != start);                                              \
   }                                                                      \
   break;
@@ -337,18 +377,18 @@ static void encode_array(upb_encstate *e, const upb_msg *msg,
   switch (f->descriptortype)
   {
   case UPB_DESCRIPTOR_TYPE_DOUBLE:
-    encode_fixedarray(e, arr, sizeof(double), TAG(UPB_WIRE_TYPE_64BIT));
+    encode_fixedarray(&e, arr, sizeof(double), TAG(UPB_WIRE_TYPE_64BIT));
     break;
   case UPB_DESCRIPTOR_TYPE_FLOAT:
-    encode_fixedarray(e, arr, sizeof(float), TAG(UPB_WIRE_TYPE_32BIT));
+    encode_fixedarray(&e, arr, sizeof(float), TAG(UPB_WIRE_TYPE_32BIT));
     break;
   case UPB_DESCRIPTOR_TYPE_SFIXED64:
   case UPB_DESCRIPTOR_TYPE_FIXED64:
-    encode_fixedarray(e, arr, sizeof(uint64_t), TAG(UPB_WIRE_TYPE_64BIT));
+    encode_fixedarray(&e, arr, sizeof(uint64_t), TAG(UPB_WIRE_TYPE_64BIT));
     break;
   case UPB_DESCRIPTOR_TYPE_FIXED32:
   case UPB_DESCRIPTOR_TYPE_SFIXED32:
-    encode_fixedarray(e, arr, sizeof(uint32_t), TAG(UPB_WIRE_TYPE_32BIT));
+    encode_fixedarray(&e, arr, sizeof(uint32_t), TAG(UPB_WIRE_TYPE_32BIT));
     break;
   case UPB_DESCRIPTOR_TYPE_INT64:
   case UPB_DESCRIPTOR_TYPE_UINT64:
@@ -372,95 +412,113 @@ static void encode_array(upb_encstate *e, const upb_msg *msg,
     do
     {
       ptr--;
-      encode_bytes(e, ptr->data, ptr->size);
-      encode_varint(e, ptr->size);
-      encode_tag(e, f->number, UPB_WIRE_TYPE_DELIMITED);
+      encode_bytes(&e, ptr->data, ptr->size);
+      encode_varint(&e, ptr->size);
+      encode_tag(&e, f->number, UPB_WIRE_TYPE_DELIMITED);
     } while (ptr != start);
-    return;
+    return e.ptr;
   }
   case UPB_DESCRIPTOR_TYPE_GROUP:
   {
     const void *const *start = _upb_array_constptr(arr);
     const void *const *ptr = start + arr->len;
     const upb_msglayout *subm = subs[f->submsg_index].submsg;
-    if (--e->depth == 0)
-      encode_err(e);
+    if (--e.ctx->depth == 0)
+      encode_err(&e);
     do
     {
       size_t size;
       ptr--;
-      encode_tag(e, f->number, UPB_WIRE_TYPE_END_GROUP);
-      encode_message(e, *ptr, subm, &size);
-      encode_tag(e, f->number, UPB_WIRE_TYPE_START_GROUP);
+      encode_tag(&e, f->number, UPB_WIRE_TYPE_END_GROUP);
+      encode_message(&e, *ptr, subm, &size);
+      encode_tag(&e, f->number, UPB_WIRE_TYPE_START_GROUP);
     } while (ptr != start);
-    e->depth++;
-    return;
+    e.ctx->depth++;
+    return e.ptr;
   }
   case UPB_DESCRIPTOR_TYPE_MESSAGE:
   {
     const void *const *start = _upb_array_constptr(arr);
     const void *const *ptr = start + arr->len;
     const upb_msglayout *subm = subs[f->submsg_index].submsg;
-    if (--e->depth == 0)
-      encode_err(e);
+    if (--e.ctx->depth == 0)
+      encode_err(&e);
     do
     {
       size_t size;
       ptr--;
-      encode_message(e, *ptr, subm, &size);
-      encode_varint(e, size);
-      encode_tag(e, f->number, UPB_WIRE_TYPE_DELIMITED);
+      encode_message(&e, *ptr, subm, &size);
+      encode_varint(&e, size);
+      encode_tag(&e, f->number, UPB_WIRE_TYPE_DELIMITED);
     } while (ptr != start);
-    e->depth++;
-    return;
+    e.ctx->depth++;
+    return e.ptr;
   }
   }
 #undef VARINT_CASE
 
   if (packed)
   {
-    encode_varint(e, e->limit - e->ptr - pre_len);
-    encode_tag(e, f->number, UPB_WIRE_TYPE_DELIMITED);
+    encode_varint(&e, e.ctx->limit - e.ptr - pre_len);
+    encode_tag(&e, f->number, UPB_WIRE_TYPE_DELIMITED);
   }
+  return e.ptr;
 }
 
+UPB_FORCEINLINE
+static void encode_array(upb_encstate *e, const upb_msg *msg,
+                         const upb_msglayout_sub *subs,
+                         const upb_msglayout_field *f)
+{
+  e->ptr = encode_array_impl(*e, msg, subs, f);
+}
+
+static char *encode_mapentry_impl(upb_encstate e, uint32_t number,
+                                  const upb_msglayout *layout,
+                                  const upb_map_entry *ent)
+{
+  const upb_msglayout_field *key_field = &layout->fields[0];
+  const upb_msglayout_field *val_field = &layout->fields[1];
+  size_t pre_len = e.ctx->limit - e.ptr;
+  size_t size;
+  encode_scalar(&e, &ent->v, layout->subs, val_field);
+  encode_scalar(&e, &ent->k, layout->subs, key_field);
+  size = (e.ctx->limit - e.ptr) - pre_len;
+  encode_varint(&e, size);
+  encode_tag(&e, number, UPB_WIRE_TYPE_DELIMITED);
+  return e.ptr;
+}
+
+UPB_FORCEINLINE
 static void encode_mapentry(upb_encstate *e, uint32_t number,
                             const upb_msglayout *layout,
                             const upb_map_entry *ent)
 {
-  const upb_msglayout_field *key_field = &layout->fields[0];
-  const upb_msglayout_field *val_field = &layout->fields[1];
-  size_t pre_len = e->limit - e->ptr;
-  size_t size;
-  encode_scalar(e, &ent->v, layout->subs, val_field);
-  encode_scalar(e, &ent->k, layout->subs, key_field);
-  size = (e->limit - e->ptr) - pre_len;
-  encode_varint(e, size);
-  encode_tag(e, number, UPB_WIRE_TYPE_DELIMITED);
+  e->ptr = encode_mapentry_impl(*e, number, layout, ent);
 }
 
-static void encode_map(upb_encstate *e, const upb_msg *msg,
-                       const upb_msglayout_sub *subs,
-                       const upb_msglayout_field *f)
+static char *encode_map_impl(upb_encstate e, const upb_msg *msg,
+                             const upb_msglayout_sub *subs,
+                             const upb_msglayout_field *f)
 {
   const upb_map *map = *UPB_PTR_AT(msg, f->offset, const upb_map *);
   const upb_msglayout *layout = subs[f->submsg_index].submsg;
   UPB_ASSERT(layout->field_count == 2);
 
   if (map == NULL)
-    return;
+    return e.ptr;
 
-  if (e->options & UPB_ENCODE_DETERMINISTIC)
+  if (e.ctx->options & UPB_ENCODE_DETERMINISTIC)
   {
     _upb_sortedmap sorted;
-    _upb_mapsorter_pushmap(&e->sorter, layout->fields[0].descriptortype, map,
+    _upb_mapsorter_pushmap(&e.ctx->sorter, layout->fields[0].descriptortype, map,
                            &sorted);
     upb_map_entry ent;
-    while (_upb_sortedmap_next(&e->sorter, map, &sorted, &ent))
+    while (_upb_sortedmap_next(&e.ctx->sorter, map, &sorted, &ent))
     {
-      encode_mapentry(e, f->number, layout, &ent);
+      encode_mapentry(&e, f->number, layout, &ent);
     }
-    _upb_mapsorter_popmap(&e->sorter, &sorted);
+    _upb_mapsorter_popmap(&e.ctx->sorter, &sorted);
   }
   else
   {
@@ -473,12 +531,21 @@ static void encode_map(upb_encstate *e, const upb_msg *msg,
       upb_map_entry ent;
       _upb_map_fromkey(key, &ent.k, map->key_size);
       _upb_map_fromvalue(val, &ent.v, map->val_size);
-      encode_mapentry(e, f->number, layout, &ent);
+      encode_mapentry(&e, f->number, layout, &ent);
     }
   }
+  return e.ptr;
 }
 
-static bool encode_shouldencode(upb_encstate *e, const upb_msg *msg,
+UPB_FORCEINLINE
+static void encode_map(upb_encstate *e, const upb_msg *msg,
+                       const upb_msglayout_sub *subs,
+                       const upb_msglayout_field *f)
+{
+  e->ptr = encode_map_impl(*e, msg, subs, f);
+}
+
+static bool encode_shouldencode(const upb_msg *msg,
                                 const upb_msglayout_sub *subs,
                                 const upb_msglayout_field *f)
 {
@@ -527,24 +594,33 @@ static bool encode_shouldencode(upb_encstate *e, const upb_msg *msg,
   }
 }
 
-static void encode_field(upb_encstate *e, const upb_msg *msg,
-                         const upb_msglayout_sub *subs,
-                         const upb_msglayout_field *field)
+static char *encode_field_impl(upb_encstate e, const upb_msg *msg,
+                               const upb_msglayout_sub *subs,
+                               const upb_msglayout_field *field)
 {
   switch (_upb_getmode(field))
   {
   case _UPB_MODE_ARRAY:
-    encode_array(e, msg, subs, field);
+    encode_array(&e, msg, subs, field);
     break;
   case _UPB_MODE_MAP:
-    encode_map(e, msg, subs, field);
+    encode_map(&e, msg, subs, field);
     break;
   case _UPB_MODE_SCALAR:
-    encode_scalar(e, UPB_PTR_AT(msg, field->offset, void), subs, field);
+    encode_scalar(&e, UPB_PTR_AT(msg, field->offset, void), subs, field);
     break;
   default:
     UPB_UNREACHABLE();
   }
+  return e.ptr;
+}
+
+UPB_FORCEINLINE
+static void encode_field(upb_encstate *e, const upb_msg *msg,
+                         const upb_msglayout_sub *subs,
+                         const upb_msglayout_field *field)
+{
+  e->ptr = encode_field_impl(*e, msg, subs, field);
 }
 
 /* message MessageSet {
@@ -553,6 +629,7 @@ static void encode_field(upb_encstate *e, const upb_msg *msg,
  *     required string message = 3;
  *   }
  * } */
+UPB_FORCEINLINE
 static void encode_msgset_item(upb_encstate *e, const upb_msg_ext *ext)
 {
   size_t size;
@@ -565,19 +642,19 @@ static void encode_msgset_item(upb_encstate *e, const upb_msg_ext *ext)
   encode_tag(e, 1, UPB_WIRE_TYPE_START_GROUP);
 }
 
-static void encode_message(upb_encstate *e, const upb_msg *msg,
-                           const upb_msglayout *m, size_t *size)
+static char *encode_message_impl(upb_encstate e, const upb_msg *msg,
+                                 const upb_msglayout *m, size_t *size)
 {
-  size_t pre_len = e->limit - e->ptr;
+  size_t pre_len = e.ctx->limit - e.ptr;
 
-  if ((e->options & UPB_ENCODE_SKIPUNKNOWN) == 0)
+  if ((e.ctx->options & UPB_ENCODE_SKIPUNKNOWN) == 0)
   {
     size_t unknown_size;
     const char *unknown = upb_msg_getunknown(msg, &unknown_size);
 
     if (unknown)
     {
-      encode_bytes(e, unknown, unknown_size);
+      encode_bytes(&e, unknown, unknown_size);
     }
   }
 
@@ -595,11 +672,11 @@ static void encode_message(upb_encstate *e, const upb_msg *msg,
       {
         if (UPB_UNLIKELY(m->ext == _UPB_MSGEXT_MSGSET))
         {
-          encode_msgset_item(e, ext);
+          encode_msgset_item(&e, ext);
         }
         else
         {
-          encode_field(e, &ext->data, &ext->ext->sub, &ext->ext->field);
+          encode_field(&e, &ext->data, &ext->ext->sub, &ext->ext->field);
         }
       }
     }
@@ -610,31 +687,32 @@ static void encode_message(upb_encstate *e, const upb_msg *msg,
   while (f != first)
   {
     f--;
-    if (encode_shouldencode(e, msg, m->subs, f))
+    if (encode_shouldencode(msg, m->subs, f))
     {
-      encode_field(e, msg, m->subs, f);
+      encode_field(&e, msg, m->subs, f);
     }
   }
 
-  *size = (e->limit - e->ptr) - pre_len;
+  *size = (e.ctx->limit - e.ptr) - pre_len;
+  return e.ptr;
 }
 
 char *upb_encode_ex(const void *msg, const upb_msglayout *l, int options,
                     upb_arena *arena, size_t *size)
 {
-  upb_encstate e;
+  upb_context ctx;
   unsigned depth = (unsigned)options >> 16;
 
-  e.alloc = upb_arena_alloc(arena);
-  e.buf = NULL;
-  e.limit = NULL;
-  e.ptr = NULL;
-  e.depth = depth ? depth : 64;
-  e.options = options;
-  _upb_mapsorter_init(&e.sorter);
+  ctx.alloc = upb_arena_alloc(arena);
+  ctx.buf = NULL;
+  ctx.limit = NULL;
+  ctx.depth = depth ? depth : 64;
+  ctx.options = options;
+  _upb_mapsorter_init(&ctx.sorter);
   char *ret = NULL;
 
-  if (UPB_SETJMP(e.err))
+  upb_encstate e = {NULL, &ctx};
+  if (UPB_SETJMP(ctx.err))
   {
     *size = 0;
     ret = NULL;
@@ -642,7 +720,7 @@ char *upb_encode_ex(const void *msg, const upb_msglayout *l, int options,
   else
   {
     encode_message(&e, msg, l, size);
-    *size = e.limit - e.ptr;
+    *size = ctx.limit - e.ptr;
     if (*size == 0)
     {
       static char ch;
@@ -655,6 +733,6 @@ char *upb_encode_ex(const void *msg, const upb_msglayout *l, int options,
     }
   }
 
-  _upb_mapsorter_destroy(&e.sorter);
+  _upb_mapsorter_destroy(&ctx.sorter);
   return ret;
 }

--- a/upb/encode.c
+++ b/upb/encode.c
@@ -40,22 +40,22 @@
 
 #define UPB_PB_VARINT_MAX_LEN 10
 
-UPB_NOINLINE
-static size_t encode_varint64(uint64_t val, char *buf) {
-  size_t i = 0;
-  do {
-    uint8_t byte = val & 0x7fU;
+static char *encode_varint64(uint64_t val, char *buf)
+{
+  do
+  {
+    *buf++ = val | 0x80;
     val >>= 7;
-    if (val) byte |= 0x80U;
-    buf[i++] = byte;
-  } while (val);
-  return i;
+  } while (val > 127);
+  *buf++ = val;
+  return buf;
 }
 
 static uint32_t encode_zz32(int32_t n) { return ((uint32_t)n << 1) ^ (n >> 31); }
 static uint64_t encode_zz64(int64_t n) { return ((uint64_t)n << 1) ^ (n >> 63); }
 
-typedef struct {
+typedef struct
+{
   jmp_buf err;
   upb_alloc *alloc;
   char *buf, *ptr, *limit;
@@ -64,28 +64,34 @@ typedef struct {
   _upb_mapsorter sorter;
 } upb_encstate;
 
-static size_t upb_roundup_pow2(size_t bytes) {
+static size_t upb_roundup_pow2(size_t bytes)
+{
   size_t ret = 128;
-  while (ret < bytes) {
+  while (ret < bytes)
+  {
     ret *= 2;
   }
   return ret;
 }
 
-UPB_NORETURN static void encode_err(upb_encstate *e) {
+UPB_NORETURN static void encode_err(upb_encstate *e)
+{
   UPB_LONGJMP(e->err, 1);
 }
 
 UPB_NOINLINE
-static void encode_growbuffer(upb_encstate *e, size_t bytes) {
+static void encode_growbuffer(upb_encstate *e, size_t bytes)
+{
   size_t old_size = e->limit - e->buf;
   size_t new_size = upb_roundup_pow2(bytes + (e->limit - e->ptr));
   char *new_buf = upb_realloc(e->alloc, e->buf, old_size, new_size);
 
-  if (!new_buf) encode_err(e);
+  if (!new_buf)
+    encode_err(e);
 
   /* We want previous data at the end, realloc() put it at the beginning. */
-  if (old_size > 0) {
+  if (old_size > 0)
+  {
     memmove(new_buf + new_size - old_size, e->buf, old_size);
   }
 
@@ -99,8 +105,10 @@ static void encode_growbuffer(upb_encstate *e, size_t bytes) {
 /* Call to ensure that at least "bytes" bytes are available for writing at
  * e->ptr.  Returns false if the bytes could not be allocated. */
 UPB_FORCEINLINE
-static void encode_reserve(upb_encstate *e, size_t bytes) {
-  if ((size_t)(e->ptr - e->buf) < bytes) {
+static void encode_reserve(upb_encstate *e, size_t bytes)
+{
+  if ((size_t)(e->ptr - e->buf) < bytes)
+  {
     encode_growbuffer(e, bytes);
     return;
   }
@@ -109,52 +117,63 @@ static void encode_reserve(upb_encstate *e, size_t bytes) {
 }
 
 /* Writes the given bytes to the buffer, handling reserve/advance. */
-static void encode_bytes(upb_encstate *e, const void *data, size_t len) {
-  if (len == 0) return;  /* memcpy() with zero size is UB */
+static void encode_bytes(upb_encstate *e, const void *data, size_t len)
+{
+  if (len == 0)
+    return; /* memcpy() with zero size is UB */
   encode_reserve(e, len);
   memcpy(e->ptr, data, len);
 }
 
-static void encode_fixed64(upb_encstate *e, uint64_t val) {
+static void encode_fixed64(upb_encstate *e, uint64_t val)
+{
   val = _upb_be_swap64(val);
   encode_bytes(e, &val, sizeof(uint64_t));
 }
 
-static void encode_fixed32(upb_encstate *e, uint32_t val) {
+static void encode_fixed32(upb_encstate *e, uint32_t val)
+{
   val = _upb_be_swap32(val);
   encode_bytes(e, &val, sizeof(uint32_t));
 }
 
 UPB_NOINLINE
-static void encode_longvarint(upb_encstate *e, uint64_t val) {
-  size_t len;
-  char *start;
+static void encode_longvarint(upb_encstate *e, uint64_t val)
+{
+  char buffer[32];
 
-  encode_reserve(e, UPB_PB_VARINT_MAX_LEN);
-  len = encode_varint64(val, e->ptr);
-  start = e->ptr + UPB_PB_VARINT_MAX_LEN - len;
-  memmove(start, e->ptr, len);
-  e->ptr = start;
+  char *start = buffer + 16;
+  char *end = encode_varint64(val, start);
+
+  encode_reserve(e, 16);
+  memcpy(e->ptr, end - 16, 16);
+  e->ptr += 16 - (end - start);
 }
 
 UPB_FORCEINLINE
-static void encode_varint(upb_encstate *e, uint64_t val) {
-  if (val < 128 && e->ptr != e->buf) {
+static void encode_varint(upb_encstate *e, uint64_t val)
+{
+  if (val < 128 && e->ptr != e->buf)
+  {
     --e->ptr;
     *e->ptr = val;
-  } else {
+  }
+  else
+  {
     encode_longvarint(e, val);
   }
 }
 
-static void encode_double(upb_encstate *e, double d) {
+static void encode_double(upb_encstate *e, double d)
+{
   uint64_t u64;
   UPB_ASSERT(sizeof(double) == sizeof(uint64_t));
   memcpy(&u64, &d, sizeof(uint64_t));
   encode_fixed64(e, u64);
 }
 
-static void encode_float(upb_encstate *e, float d) {
+static void encode_float(upb_encstate *e, float d)
+{
   uint32_t u32;
   UPB_ASSERT(sizeof(float) == sizeof(uint32_t));
   memcpy(&u32, &d, sizeof(uint32_t));
@@ -162,23 +181,30 @@ static void encode_float(upb_encstate *e, float d) {
 }
 
 static void encode_tag(upb_encstate *e, uint32_t field_number,
-                       uint8_t wire_type) {
+                       uint8_t wire_type)
+{
   encode_varint(e, (field_number << 3) | wire_type);
 }
 
 static void encode_fixedarray(upb_encstate *e, const upb_array *arr,
-                               size_t elem_size, uint32_t tag) {
+                              size_t elem_size, uint32_t tag)
+{
   size_t bytes = arr->len * elem_size;
-  const char* data = _upb_array_constptr(arr);
-  const char* ptr = data + bytes - elem_size;
-  if (tag) {
-    while (true) {
+  const char *data = _upb_array_constptr(arr);
+  const char *ptr = data + bytes - elem_size;
+  if (tag)
+  {
+    while (true)
+    {
       encode_bytes(e, ptr, elem_size);
       encode_varint(e, tag);
-      if (ptr == data) break;
+      if (ptr == data)
+        break;
       ptr -= elem_size;
     }
-  } else {
+  }
+  else
+  {
     encode_bytes(e, data, bytes);
   }
 }
@@ -188,7 +214,8 @@ static void encode_message(upb_encstate *e, const upb_msg *msg,
 
 static void encode_scalar(upb_encstate *e, const void *_field_mem,
                           const upb_msglayout_sub *subs,
-                          const upb_msglayout_field *f) {
+                          const upb_msglayout_field *f)
+{
   const char *field_mem = _field_mem;
   int wire_type;
 
@@ -200,69 +227,77 @@ static void encode_scalar(upb_encstate *e, const void *_field_mem,
     break;                                  \
   }
 
-  switch (f->descriptortype) {
-    case UPB_DESCRIPTOR_TYPE_DOUBLE:
-      CASE(double, double, UPB_WIRE_TYPE_64BIT, val);
-    case UPB_DESCRIPTOR_TYPE_FLOAT:
-      CASE(float, float, UPB_WIRE_TYPE_32BIT, val);
-    case UPB_DESCRIPTOR_TYPE_INT64:
-    case UPB_DESCRIPTOR_TYPE_UINT64:
-      CASE(uint64_t, varint, UPB_WIRE_TYPE_VARINT, val);
-    case UPB_DESCRIPTOR_TYPE_UINT32:
-      CASE(uint32_t, varint, UPB_WIRE_TYPE_VARINT, val);
-    case UPB_DESCRIPTOR_TYPE_INT32:
-    case UPB_DESCRIPTOR_TYPE_ENUM:
-      CASE(int32_t, varint, UPB_WIRE_TYPE_VARINT, (int64_t)val);
-    case UPB_DESCRIPTOR_TYPE_SFIXED64:
-    case UPB_DESCRIPTOR_TYPE_FIXED64:
-      CASE(uint64_t, fixed64, UPB_WIRE_TYPE_64BIT, val);
-    case UPB_DESCRIPTOR_TYPE_FIXED32:
-    case UPB_DESCRIPTOR_TYPE_SFIXED32:
-      CASE(uint32_t, fixed32, UPB_WIRE_TYPE_32BIT, val);
-    case UPB_DESCRIPTOR_TYPE_BOOL:
-      CASE(bool, varint, UPB_WIRE_TYPE_VARINT, val);
-    case UPB_DESCRIPTOR_TYPE_SINT32:
-      CASE(int32_t, varint, UPB_WIRE_TYPE_VARINT, encode_zz32(val));
-    case UPB_DESCRIPTOR_TYPE_SINT64:
-      CASE(int64_t, varint, UPB_WIRE_TYPE_VARINT, encode_zz64(val));
-    case UPB_DESCRIPTOR_TYPE_STRING:
-    case UPB_DESCRIPTOR_TYPE_BYTES: {
-      upb_strview view = *(upb_strview*)field_mem;
-      encode_bytes(e, view.data, view.size);
-      encode_varint(e, view.size);
-      wire_type = UPB_WIRE_TYPE_DELIMITED;
-      break;
+  switch (f->descriptortype)
+  {
+  case UPB_DESCRIPTOR_TYPE_DOUBLE:
+    CASE(double, double, UPB_WIRE_TYPE_64BIT, val);
+  case UPB_DESCRIPTOR_TYPE_FLOAT:
+    CASE(float, float, UPB_WIRE_TYPE_32BIT, val);
+  case UPB_DESCRIPTOR_TYPE_INT64:
+  case UPB_DESCRIPTOR_TYPE_UINT64:
+    CASE(uint64_t, varint, UPB_WIRE_TYPE_VARINT, val);
+  case UPB_DESCRIPTOR_TYPE_UINT32:
+    CASE(uint32_t, varint, UPB_WIRE_TYPE_VARINT, val);
+  case UPB_DESCRIPTOR_TYPE_INT32:
+  case UPB_DESCRIPTOR_TYPE_ENUM:
+    CASE(int32_t, varint, UPB_WIRE_TYPE_VARINT, (int64_t)val);
+  case UPB_DESCRIPTOR_TYPE_SFIXED64:
+  case UPB_DESCRIPTOR_TYPE_FIXED64:
+    CASE(uint64_t, fixed64, UPB_WIRE_TYPE_64BIT, val);
+  case UPB_DESCRIPTOR_TYPE_FIXED32:
+  case UPB_DESCRIPTOR_TYPE_SFIXED32:
+    CASE(uint32_t, fixed32, UPB_WIRE_TYPE_32BIT, val);
+  case UPB_DESCRIPTOR_TYPE_BOOL:
+    CASE(bool, varint, UPB_WIRE_TYPE_VARINT, val);
+  case UPB_DESCRIPTOR_TYPE_SINT32:
+    CASE(int32_t, varint, UPB_WIRE_TYPE_VARINT, encode_zz32(val));
+  case UPB_DESCRIPTOR_TYPE_SINT64:
+    CASE(int64_t, varint, UPB_WIRE_TYPE_VARINT, encode_zz64(val));
+  case UPB_DESCRIPTOR_TYPE_STRING:
+  case UPB_DESCRIPTOR_TYPE_BYTES:
+  {
+    upb_strview view = *(upb_strview *)field_mem;
+    encode_bytes(e, view.data, view.size);
+    encode_varint(e, view.size);
+    wire_type = UPB_WIRE_TYPE_DELIMITED;
+    break;
+  }
+  case UPB_DESCRIPTOR_TYPE_GROUP:
+  {
+    size_t size;
+    void *submsg = *(void **)field_mem;
+    const upb_msglayout *subm = subs[f->submsg_index].submsg;
+    if (submsg == NULL)
+    {
+      return;
     }
-    case UPB_DESCRIPTOR_TYPE_GROUP: {
-      size_t size;
-      void *submsg = *(void **)field_mem;
-      const upb_msglayout *subm = subs[f->submsg_index].submsg;
-      if (submsg == NULL) {
-        return;
-      }
-      if (--e->depth == 0) encode_err(e);
-      encode_tag(e, f->number, UPB_WIRE_TYPE_END_GROUP);
-      encode_message(e, submsg, subm, &size);
-      wire_type = UPB_WIRE_TYPE_START_GROUP;
-      e->depth++;
-      break;
+    if (--e->depth == 0)
+      encode_err(e);
+    encode_tag(e, f->number, UPB_WIRE_TYPE_END_GROUP);
+    encode_message(e, submsg, subm, &size);
+    wire_type = UPB_WIRE_TYPE_START_GROUP;
+    e->depth++;
+    break;
+  }
+  case UPB_DESCRIPTOR_TYPE_MESSAGE:
+  {
+    size_t size;
+    void *submsg = *(void **)field_mem;
+    const upb_msglayout *subm = subs[f->submsg_index].submsg;
+    if (submsg == NULL)
+    {
+      return;
     }
-    case UPB_DESCRIPTOR_TYPE_MESSAGE: {
-      size_t size;
-      void *submsg = *(void **)field_mem;
-      const upb_msglayout *subm = subs[f->submsg_index].submsg;
-      if (submsg == NULL) {
-        return;
-      }
-      if (--e->depth == 0) encode_err(e);
-      encode_message(e, submsg, subm, &size);
-      encode_varint(e, size);
-      wire_type = UPB_WIRE_TYPE_DELIMITED;
-      e->depth++;
-      break;
-    }
-    default:
-      UPB_UNREACHABLE();
+    if (--e->depth == 0)
+      encode_err(e);
+    encode_message(e, submsg, subm, &size);
+    encode_varint(e, size);
+    wire_type = UPB_WIRE_TYPE_DELIMITED;
+    e->depth++;
+    break;
+  }
+  default:
+    UPB_UNREACHABLE();
   }
 #undef CASE
 
@@ -271,12 +306,14 @@ static void encode_scalar(upb_encstate *e, const void *_field_mem,
 
 static void encode_array(upb_encstate *e, const upb_msg *msg,
                          const upb_msglayout_sub *subs,
-                         const upb_msglayout_field *f) {
-  const upb_array *arr = *UPB_PTR_AT(msg, f->offset, upb_array*);
+                         const upb_msglayout_field *f)
+{
+  const upb_array *arr = *UPB_PTR_AT(msg, f->offset, upb_array *);
   bool packed = f->mode & _UPB_MODE_IS_PACKED;
   size_t pre_len = e->limit - e->ptr;
 
-  if (arr == NULL || arr->len == 0) {
+  if (arr == NULL || arr->len == 0)
+  {
     return;
   }
 
@@ -285,91 +322,103 @@ static void encode_array(upb_encstate *e, const upb_msg *msg,
     const ctype *start = _upb_array_constptr(arr);                       \
     const ctype *ptr = start + arr->len;                                 \
     uint32_t tag = packed ? 0 : (f->number << 3) | UPB_WIRE_TYPE_VARINT; \
-    do {                                                                 \
+    do                                                                   \
+    {                                                                    \
       ptr--;                                                             \
       encode_varint(e, encode);                                          \
-      if (tag) encode_varint(e, tag);                                    \
+      if (tag)                                                           \
+        encode_varint(e, tag);                                           \
     } while (ptr != start);                                              \
   }                                                                      \
   break;
 
 #define TAG(wire_type) (packed ? 0 : (f->number << 3 | wire_type))
 
-  switch (f->descriptortype) {
-    case UPB_DESCRIPTOR_TYPE_DOUBLE:
-      encode_fixedarray(e, arr, sizeof(double), TAG(UPB_WIRE_TYPE_64BIT));
-      break;
-    case UPB_DESCRIPTOR_TYPE_FLOAT:
-      encode_fixedarray(e, arr, sizeof(float), TAG(UPB_WIRE_TYPE_32BIT));
-      break;
-    case UPB_DESCRIPTOR_TYPE_SFIXED64:
-    case UPB_DESCRIPTOR_TYPE_FIXED64:
-      encode_fixedarray(e, arr, sizeof(uint64_t), TAG(UPB_WIRE_TYPE_64BIT));
-      break;
-    case UPB_DESCRIPTOR_TYPE_FIXED32:
-    case UPB_DESCRIPTOR_TYPE_SFIXED32:
-      encode_fixedarray(e, arr, sizeof(uint32_t), TAG(UPB_WIRE_TYPE_32BIT));
-      break;
-    case UPB_DESCRIPTOR_TYPE_INT64:
-    case UPB_DESCRIPTOR_TYPE_UINT64:
-      VARINT_CASE(uint64_t, *ptr);
-    case UPB_DESCRIPTOR_TYPE_UINT32:
-      VARINT_CASE(uint32_t, *ptr);
-    case UPB_DESCRIPTOR_TYPE_INT32:
-    case UPB_DESCRIPTOR_TYPE_ENUM:
-      VARINT_CASE(int32_t, (int64_t)*ptr);
-    case UPB_DESCRIPTOR_TYPE_BOOL:
-      VARINT_CASE(bool, *ptr);
-    case UPB_DESCRIPTOR_TYPE_SINT32:
-      VARINT_CASE(int32_t, encode_zz32(*ptr));
-    case UPB_DESCRIPTOR_TYPE_SINT64:
-      VARINT_CASE(int64_t, encode_zz64(*ptr));
-    case UPB_DESCRIPTOR_TYPE_STRING:
-    case UPB_DESCRIPTOR_TYPE_BYTES: {
-      const upb_strview *start = _upb_array_constptr(arr);
-      const upb_strview *ptr = start + arr->len;
-      do {
-        ptr--;
-        encode_bytes(e, ptr->data, ptr->size);
-        encode_varint(e, ptr->size);
-        encode_tag(e, f->number, UPB_WIRE_TYPE_DELIMITED);
-      } while (ptr != start);
-      return;
-    }
-    case UPB_DESCRIPTOR_TYPE_GROUP: {
-      const void *const*start = _upb_array_constptr(arr);
-      const void *const*ptr = start + arr->len;
-      const upb_msglayout *subm = subs[f->submsg_index].submsg;
-      if (--e->depth == 0) encode_err(e);
-      do {
-        size_t size;
-        ptr--;
-        encode_tag(e, f->number, UPB_WIRE_TYPE_END_GROUP);
-        encode_message(e, *ptr, subm, &size);
-        encode_tag(e, f->number, UPB_WIRE_TYPE_START_GROUP);
-      } while (ptr != start);
-      e->depth++;
-      return;
-    }
-    case UPB_DESCRIPTOR_TYPE_MESSAGE: {
-      const void *const*start = _upb_array_constptr(arr);
-      const void *const*ptr = start + arr->len;
-      const upb_msglayout *subm = subs[f->submsg_index].submsg;
-      if (--e->depth == 0) encode_err(e);
-      do {
-        size_t size;
-        ptr--;
-        encode_message(e, *ptr, subm, &size);
-        encode_varint(e, size);
-        encode_tag(e, f->number, UPB_WIRE_TYPE_DELIMITED);
-      } while (ptr != start);
-      e->depth++;
-      return;
-    }
+  switch (f->descriptortype)
+  {
+  case UPB_DESCRIPTOR_TYPE_DOUBLE:
+    encode_fixedarray(e, arr, sizeof(double), TAG(UPB_WIRE_TYPE_64BIT));
+    break;
+  case UPB_DESCRIPTOR_TYPE_FLOAT:
+    encode_fixedarray(e, arr, sizeof(float), TAG(UPB_WIRE_TYPE_32BIT));
+    break;
+  case UPB_DESCRIPTOR_TYPE_SFIXED64:
+  case UPB_DESCRIPTOR_TYPE_FIXED64:
+    encode_fixedarray(e, arr, sizeof(uint64_t), TAG(UPB_WIRE_TYPE_64BIT));
+    break;
+  case UPB_DESCRIPTOR_TYPE_FIXED32:
+  case UPB_DESCRIPTOR_TYPE_SFIXED32:
+    encode_fixedarray(e, arr, sizeof(uint32_t), TAG(UPB_WIRE_TYPE_32BIT));
+    break;
+  case UPB_DESCRIPTOR_TYPE_INT64:
+  case UPB_DESCRIPTOR_TYPE_UINT64:
+    VARINT_CASE(uint64_t, *ptr);
+  case UPB_DESCRIPTOR_TYPE_UINT32:
+    VARINT_CASE(uint32_t, *ptr);
+  case UPB_DESCRIPTOR_TYPE_INT32:
+  case UPB_DESCRIPTOR_TYPE_ENUM:
+    VARINT_CASE(int32_t, (int64_t)*ptr);
+  case UPB_DESCRIPTOR_TYPE_BOOL:
+    VARINT_CASE(bool, *ptr);
+  case UPB_DESCRIPTOR_TYPE_SINT32:
+    VARINT_CASE(int32_t, encode_zz32(*ptr));
+  case UPB_DESCRIPTOR_TYPE_SINT64:
+    VARINT_CASE(int64_t, encode_zz64(*ptr));
+  case UPB_DESCRIPTOR_TYPE_STRING:
+  case UPB_DESCRIPTOR_TYPE_BYTES:
+  {
+    const upb_strview *start = _upb_array_constptr(arr);
+    const upb_strview *ptr = start + arr->len;
+    do
+    {
+      ptr--;
+      encode_bytes(e, ptr->data, ptr->size);
+      encode_varint(e, ptr->size);
+      encode_tag(e, f->number, UPB_WIRE_TYPE_DELIMITED);
+    } while (ptr != start);
+    return;
+  }
+  case UPB_DESCRIPTOR_TYPE_GROUP:
+  {
+    const void *const *start = _upb_array_constptr(arr);
+    const void *const *ptr = start + arr->len;
+    const upb_msglayout *subm = subs[f->submsg_index].submsg;
+    if (--e->depth == 0)
+      encode_err(e);
+    do
+    {
+      size_t size;
+      ptr--;
+      encode_tag(e, f->number, UPB_WIRE_TYPE_END_GROUP);
+      encode_message(e, *ptr, subm, &size);
+      encode_tag(e, f->number, UPB_WIRE_TYPE_START_GROUP);
+    } while (ptr != start);
+    e->depth++;
+    return;
+  }
+  case UPB_DESCRIPTOR_TYPE_MESSAGE:
+  {
+    const void *const *start = _upb_array_constptr(arr);
+    const void *const *ptr = start + arr->len;
+    const upb_msglayout *subm = subs[f->submsg_index].submsg;
+    if (--e->depth == 0)
+      encode_err(e);
+    do
+    {
+      size_t size;
+      ptr--;
+      encode_message(e, *ptr, subm, &size);
+      encode_varint(e, size);
+      encode_tag(e, f->number, UPB_WIRE_TYPE_DELIMITED);
+    } while (ptr != start);
+    e->depth++;
+    return;
+  }
   }
 #undef VARINT_CASE
 
-  if (packed) {
+  if (packed)
+  {
     encode_varint(e, e->limit - e->ptr - pre_len);
     encode_tag(e, f->number, UPB_WIRE_TYPE_DELIMITED);
   }
@@ -377,7 +426,8 @@ static void encode_array(upb_encstate *e, const upb_msg *msg,
 
 static void encode_mapentry(upb_encstate *e, uint32_t number,
                             const upb_msglayout *layout,
-                            const upb_map_entry *ent) {
+                            const upb_map_entry *ent)
+{
   const upb_msglayout_field *key_field = &layout->fields[0];
   const upb_msglayout_field *val_field = &layout->fields[1];
   size_t pre_len = e->limit - e->ptr;
@@ -391,26 +441,33 @@ static void encode_mapentry(upb_encstate *e, uint32_t number,
 
 static void encode_map(upb_encstate *e, const upb_msg *msg,
                        const upb_msglayout_sub *subs,
-                       const upb_msglayout_field *f) {
-  const upb_map *map = *UPB_PTR_AT(msg, f->offset, const upb_map*);
+                       const upb_msglayout_field *f)
+{
+  const upb_map *map = *UPB_PTR_AT(msg, f->offset, const upb_map *);
   const upb_msglayout *layout = subs[f->submsg_index].submsg;
   UPB_ASSERT(layout->field_count == 2);
 
-  if (map == NULL) return;
+  if (map == NULL)
+    return;
 
-  if (e->options & UPB_ENCODE_DETERMINISTIC) {
+  if (e->options & UPB_ENCODE_DETERMINISTIC)
+  {
     _upb_sortedmap sorted;
     _upb_mapsorter_pushmap(&e->sorter, layout->fields[0].descriptortype, map,
                            &sorted);
     upb_map_entry ent;
-    while (_upb_sortedmap_next(&e->sorter, map, &sorted, &ent)) {
+    while (_upb_sortedmap_next(&e->sorter, map, &sorted, &ent))
+    {
       encode_mapentry(e, f->number, layout, &ent);
     }
     _upb_mapsorter_popmap(&e->sorter, &sorted);
-  } else {
+  }
+  else
+  {
     upb_strtable_iter i;
     upb_strtable_begin(&i, &map->table);
-    for(; !upb_strtable_done(&i); upb_strtable_next(&i)) {
+    for (; !upb_strtable_done(&i); upb_strtable_next(&i))
+    {
       upb_strview key = upb_strtable_iter_key(&i);
       const upb_value val = upb_strtable_iter_value(&i);
       upb_map_entry ent;
@@ -423,37 +480,48 @@ static void encode_map(upb_encstate *e, const upb_msg *msg,
 
 static bool encode_shouldencode(upb_encstate *e, const upb_msg *msg,
                                 const upb_msglayout_sub *subs,
-                                const upb_msglayout_field *f) {
-  if (f->presence == 0) {
+                                const upb_msglayout_field *f)
+{
+  if (f->presence == 0)
+  {
     /* Proto3 presence or map/array. */
     const void *mem = UPB_PTR_AT(msg, f->offset, void);
-    switch (f->mode >> _UPB_REP_SHIFT) {
-      case _UPB_REP_1BYTE: {
-        char ch;
-        memcpy(&ch, mem, 1);
-        return ch != 0;
-      }
-      case _UPB_REP_4BYTE: {
-        uint32_t u32;
-        memcpy(&u32, mem, 4);
-        return u32 != 0;
-      }
-      case _UPB_REP_8BYTE: {
-        uint64_t u64;
-        memcpy(&u64, mem, 8);
-        return u64 != 0;
-      }
-      case _UPB_REP_STRVIEW: {
-        const upb_strview *str = (const upb_strview*)mem;
-        return str->size != 0;
-      }
-      default:
-        UPB_UNREACHABLE();
+    switch (f->mode >> _UPB_REP_SHIFT)
+    {
+    case _UPB_REP_1BYTE:
+    {
+      char ch;
+      memcpy(&ch, mem, 1);
+      return ch != 0;
     }
-  } else if (f->presence > 0) {
+    case _UPB_REP_4BYTE:
+    {
+      uint32_t u32;
+      memcpy(&u32, mem, 4);
+      return u32 != 0;
+    }
+    case _UPB_REP_8BYTE:
+    {
+      uint64_t u64;
+      memcpy(&u64, mem, 8);
+      return u64 != 0;
+    }
+    case _UPB_REP_STRVIEW:
+    {
+      const upb_strview *str = (const upb_strview *)mem;
+      return str->size != 0;
+    }
+    default:
+      UPB_UNREACHABLE();
+    }
+  }
+  else if (f->presence > 0)
+  {
     /* Proto2 presence: hasbit. */
     return _upb_hasbit_field(msg, f);
-  } else {
+  }
+  else
+  {
     /* Field is in a oneof. */
     return _upb_getoneofcase_field(msg, f) == f->number;
   }
@@ -461,19 +529,21 @@ static bool encode_shouldencode(upb_encstate *e, const upb_msg *msg,
 
 static void encode_field(upb_encstate *e, const upb_msg *msg,
                          const upb_msglayout_sub *subs,
-                         const upb_msglayout_field *field) {
-  switch (_upb_getmode(field)) {
-    case _UPB_MODE_ARRAY:
-      encode_array(e, msg, subs, field);
-      break;
-    case _UPB_MODE_MAP:
-      encode_map(e, msg, subs, field);
-      break;
-    case _UPB_MODE_SCALAR:
-      encode_scalar(e, UPB_PTR_AT(msg, field->offset, void), subs, field);
-      break;
-    default:
-      UPB_UNREACHABLE();
+                         const upb_msglayout_field *field)
+{
+  switch (_upb_getmode(field))
+  {
+  case _UPB_MODE_ARRAY:
+    encode_array(e, msg, subs, field);
+    break;
+  case _UPB_MODE_MAP:
+    encode_map(e, msg, subs, field);
+    break;
+  case _UPB_MODE_SCALAR:
+    encode_scalar(e, UPB_PTR_AT(msg, field->offset, void), subs, field);
+    break;
+  default:
+    UPB_UNREACHABLE();
   }
 }
 
@@ -483,7 +553,8 @@ static void encode_field(upb_encstate *e, const upb_msg *msg,
  *     required string message = 3;
  *   }
  * } */
-static void encode_msgset_item(upb_encstate *e, const upb_msg_ext *ext) {
+static void encode_msgset_item(upb_encstate *e, const upb_msg_ext *ext)
+{
   size_t size;
   encode_tag(e, 1, UPB_WIRE_TYPE_END_GROUP);
   encode_message(e, ext->data.ptr, ext->ext->sub.submsg, &size);
@@ -495,30 +566,39 @@ static void encode_msgset_item(upb_encstate *e, const upb_msg_ext *ext) {
 }
 
 static void encode_message(upb_encstate *e, const upb_msg *msg,
-                           const upb_msglayout *m, size_t *size) {
+                           const upb_msglayout *m, size_t *size)
+{
   size_t pre_len = e->limit - e->ptr;
 
-  if ((e->options & UPB_ENCODE_SKIPUNKNOWN) == 0) {
+  if ((e->options & UPB_ENCODE_SKIPUNKNOWN) == 0)
+  {
     size_t unknown_size;
     const char *unknown = upb_msg_getunknown(msg, &unknown_size);
 
-    if (unknown) {
+    if (unknown)
+    {
       encode_bytes(e, unknown, unknown_size);
     }
   }
 
-  if (m->ext != _UPB_MSGEXT_NONE) {
+  if (m->ext != _UPB_MSGEXT_NONE)
+  {
     /* Encode all extensions together. Unlike C++, we do not attempt to keep
      * these in field number order relative to normal fields or even to each
      * other. */
     size_t ext_count;
     const upb_msg_ext *ext = _upb_msg_getexts(msg, &ext_count);
     const upb_msg_ext *end = ext + ext_count;
-    if (ext_count) {
-      for (; ext != end; ext++) {
-        if (UPB_UNLIKELY(m->ext == _UPB_MSGEXT_MSGSET)) {
+    if (ext_count)
+    {
+      for (; ext != end; ext++)
+      {
+        if (UPB_UNLIKELY(m->ext == _UPB_MSGEXT_MSGSET))
+        {
           encode_msgset_item(e, ext);
-        } else {
+        }
+        else
+        {
           encode_field(e, &ext->data, &ext->ext->sub, &ext->ext->field);
         }
       }
@@ -527,9 +607,11 @@ static void encode_message(upb_encstate *e, const upb_msg *msg,
 
   const upb_msglayout_field *f = &m->fields[m->field_count];
   const upb_msglayout_field *first = &m->fields[0];
-  while (f != first) {
+  while (f != first)
+  {
     f--;
-    if (encode_shouldencode(e, msg, m->subs, f)) {
+    if (encode_shouldencode(e, msg, m->subs, f))
+    {
       encode_field(e, msg, m->subs, f);
     }
   }
@@ -538,7 +620,8 @@ static void encode_message(upb_encstate *e, const upb_msg *msg,
 }
 
 char *upb_encode_ex(const void *msg, const upb_msglayout *l, int options,
-                    upb_arena *arena, size_t *size) {
+                    upb_arena *arena, size_t *size)
+{
   upb_encstate e;
   unsigned depth = (unsigned)options >> 16;
 
@@ -551,16 +634,22 @@ char *upb_encode_ex(const void *msg, const upb_msglayout *l, int options,
   _upb_mapsorter_init(&e.sorter);
   char *ret = NULL;
 
-  if (UPB_SETJMP(e.err)) {
+  if (UPB_SETJMP(e.err))
+  {
     *size = 0;
     ret = NULL;
-  } else {
+  }
+  else
+  {
     encode_message(&e, msg, l, size);
     *size = e.limit - e.ptr;
-    if (*size == 0) {
+    if (*size == 0)
+    {
       static char ch;
       ret = &ch;
-    } else {
+    }
+    else
+    {
       UPB_ASSERT(e.ptr);
       ret = e.ptr;
     }


### PR DESCRIPTION
1) Rework the varint encoding loop to be less code
https://godbolt.org/z/r9aW5hh1e

2) Use fixed size power of 2 memcpy that compiles to a single load/store instead of a function call.

Didn't do extensive benchmarks

New
BM_SerializeDescriptor_Upb                          9009 ns         9009 ns        77066 bytes_per_second=794.783M/s

Old
BM_SerializeDescriptor_Upb                          9416 ns         9416 ns        70574 bytes_per_second=760.212M/s
