### PR TITLE
Required fields checking in the parser

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -109,6 +109,7 @@ cc_library(
 cc_library(
     name = "fastdecode",
     srcs = [
+        "upb/decode.h",
         "upb/decode_internal.h",
         "upb/decode_fast.c",
         "upb/decode_fast.h",

--- a/benchmarks/benchmark.cc
+++ b/benchmarks/benchmark.cc
@@ -163,7 +163,7 @@ static void BM_Parse_Upb_FileDesc(benchmark::State& state) {
     upb_benchmark_FileDescriptorProto* set =
         upb_benchmark_FileDescriptorProto_parse_ex(
             descriptor.data, descriptor.size, NULL,
-            Copy == Alias ? UPB_DECODE_ALIAS : 0, arena);
+            Copy == Alias ? kUpb_DecodeOption_AliasString : 0, arena);
     if (!set) {
       printf("Failed to parse.\n");
       exit(1);

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -82,6 +82,7 @@ target_link_libraries(upb
   port
   /third_party/utf8_range)
 add_library(fastdecode
+  ../upb/decode.h
   ../upb/decode_internal.h
   ../upb/decode_fast.c
   ../upb/decode_fast.h

--- a/cmake/google/protobuf/descriptor.upb.c
+++ b/cmake/google/protobuf/descriptor.upb.c
@@ -23,7 +23,7 @@ static const upb_msglayout_field google_protobuf_FileDescriptorSet__fields[1] = 
 const upb_msglayout google_protobuf_FileDescriptorSet_msginit = {
   &google_protobuf_FileDescriptorSet_submsgs[0],
   &google_protobuf_FileDescriptorSet__fields[0],
-  UPB_SIZE(8, 8), 1, _UPB_MSGEXT_NONE, 1, 255,
+  0, UPB_SIZE(8, 8), 1, _UPB_MSGEXT_NONE, 1, 255,
 };
 
 static const upb_msglayout_sub google_protobuf_FileDescriptorProto_submsgs[6] = {
@@ -53,7 +53,7 @@ static const upb_msglayout_field google_protobuf_FileDescriptorProto__fields[12]
 const upb_msglayout google_protobuf_FileDescriptorProto_msginit = {
   &google_protobuf_FileDescriptorProto_submsgs[0],
   &google_protobuf_FileDescriptorProto__fields[0],
-  UPB_SIZE(64, 128), 12, _UPB_MSGEXT_NONE, 12, 255,
+  0, UPB_SIZE(64, 128), 12, _UPB_MSGEXT_NONE, 12, 255,
 };
 
 static const upb_msglayout_sub google_protobuf_DescriptorProto_submsgs[7] = {
@@ -82,7 +82,7 @@ static const upb_msglayout_field google_protobuf_DescriptorProto__fields[10] = {
 const upb_msglayout google_protobuf_DescriptorProto_msginit = {
   &google_protobuf_DescriptorProto_submsgs[0],
   &google_protobuf_DescriptorProto__fields[0],
-  UPB_SIZE(48, 96), 10, _UPB_MSGEXT_NONE, 10, 255,
+  0, UPB_SIZE(48, 96), 10, _UPB_MSGEXT_NONE, 10, 255,
 };
 
 static const upb_msglayout_sub google_protobuf_DescriptorProto_ExtensionRange_submsgs[1] = {
@@ -98,7 +98,7 @@ static const upb_msglayout_field google_protobuf_DescriptorProto_ExtensionRange_
 const upb_msglayout google_protobuf_DescriptorProto_ExtensionRange_msginit = {
   &google_protobuf_DescriptorProto_ExtensionRange_submsgs[0],
   &google_protobuf_DescriptorProto_ExtensionRange__fields[0],
-  UPB_SIZE(16, 24), 3, _UPB_MSGEXT_NONE, 3, 255,
+  0, UPB_SIZE(16, 24), 3, _UPB_MSGEXT_NONE, 3, 255,
 };
 
 static const upb_msglayout_field google_protobuf_DescriptorProto_ReservedRange__fields[2] = {
@@ -109,7 +109,7 @@ static const upb_msglayout_field google_protobuf_DescriptorProto_ReservedRange__
 const upb_msglayout google_protobuf_DescriptorProto_ReservedRange_msginit = {
   NULL,
   &google_protobuf_DescriptorProto_ReservedRange__fields[0],
-  UPB_SIZE(16, 16), 2, _UPB_MSGEXT_NONE, 2, 255,
+  0, UPB_SIZE(16, 16), 2, _UPB_MSGEXT_NONE, 2, 255,
 };
 
 static const upb_msglayout_sub google_protobuf_ExtensionRangeOptions_submsgs[1] = {
@@ -123,7 +123,7 @@ static const upb_msglayout_field google_protobuf_ExtensionRangeOptions__fields[1
 const upb_msglayout google_protobuf_ExtensionRangeOptions_msginit = {
   &google_protobuf_ExtensionRangeOptions_submsgs[0],
   &google_protobuf_ExtensionRangeOptions__fields[0],
-  UPB_SIZE(8, 8), 1, _UPB_MSGEXT_EXTENDABLE, 0, 255,
+  0, UPB_SIZE(8, 8), 1, _UPB_MSGEXT_EXTENDABLE, 0, 255,
 };
 
 static const upb_msglayout_sub google_protobuf_FieldDescriptorProto_submsgs[3] = {
@@ -149,7 +149,7 @@ static const upb_msglayout_field google_protobuf_FieldDescriptorProto__fields[11
 const upb_msglayout google_protobuf_FieldDescriptorProto_msginit = {
   &google_protobuf_FieldDescriptorProto_submsgs[0],
   &google_protobuf_FieldDescriptorProto__fields[0],
-  UPB_SIZE(72, 112), 11, _UPB_MSGEXT_NONE, 10, 255,
+  0, UPB_SIZE(72, 112), 11, _UPB_MSGEXT_NONE, 10, 255,
 };
 
 static const upb_msglayout_sub google_protobuf_OneofDescriptorProto_submsgs[1] = {
@@ -164,7 +164,7 @@ static const upb_msglayout_field google_protobuf_OneofDescriptorProto__fields[2]
 const upb_msglayout google_protobuf_OneofDescriptorProto_msginit = {
   &google_protobuf_OneofDescriptorProto_submsgs[0],
   &google_protobuf_OneofDescriptorProto__fields[0],
-  UPB_SIZE(16, 32), 2, _UPB_MSGEXT_NONE, 2, 255,
+  0, UPB_SIZE(16, 32), 2, _UPB_MSGEXT_NONE, 2, 255,
 };
 
 static const upb_msglayout_sub google_protobuf_EnumDescriptorProto_submsgs[3] = {
@@ -184,7 +184,7 @@ static const upb_msglayout_field google_protobuf_EnumDescriptorProto__fields[5] 
 const upb_msglayout google_protobuf_EnumDescriptorProto_msginit = {
   &google_protobuf_EnumDescriptorProto_submsgs[0],
   &google_protobuf_EnumDescriptorProto__fields[0],
-  UPB_SIZE(32, 64), 5, _UPB_MSGEXT_NONE, 5, 255,
+  0, UPB_SIZE(32, 64), 5, _UPB_MSGEXT_NONE, 5, 255,
 };
 
 static const upb_msglayout_field google_protobuf_EnumDescriptorProto_EnumReservedRange__fields[2] = {
@@ -195,7 +195,7 @@ static const upb_msglayout_field google_protobuf_EnumDescriptorProto_EnumReserve
 const upb_msglayout google_protobuf_EnumDescriptorProto_EnumReservedRange_msginit = {
   NULL,
   &google_protobuf_EnumDescriptorProto_EnumReservedRange__fields[0],
-  UPB_SIZE(16, 16), 2, _UPB_MSGEXT_NONE, 2, 255,
+  0, UPB_SIZE(16, 16), 2, _UPB_MSGEXT_NONE, 2, 255,
 };
 
 static const upb_msglayout_sub google_protobuf_EnumValueDescriptorProto_submsgs[1] = {
@@ -211,7 +211,7 @@ static const upb_msglayout_field google_protobuf_EnumValueDescriptorProto__field
 const upb_msglayout google_protobuf_EnumValueDescriptorProto_msginit = {
   &google_protobuf_EnumValueDescriptorProto_submsgs[0],
   &google_protobuf_EnumValueDescriptorProto__fields[0],
-  UPB_SIZE(24, 32), 3, _UPB_MSGEXT_NONE, 3, 255,
+  0, UPB_SIZE(24, 32), 3, _UPB_MSGEXT_NONE, 3, 255,
 };
 
 static const upb_msglayout_sub google_protobuf_ServiceDescriptorProto_submsgs[2] = {
@@ -228,7 +228,7 @@ static const upb_msglayout_field google_protobuf_ServiceDescriptorProto__fields[
 const upb_msglayout google_protobuf_ServiceDescriptorProto_msginit = {
   &google_protobuf_ServiceDescriptorProto_submsgs[0],
   &google_protobuf_ServiceDescriptorProto__fields[0],
-  UPB_SIZE(24, 48), 3, _UPB_MSGEXT_NONE, 3, 255,
+  0, UPB_SIZE(24, 48), 3, _UPB_MSGEXT_NONE, 3, 255,
 };
 
 static const upb_msglayout_sub google_protobuf_MethodDescriptorProto_submsgs[1] = {
@@ -247,7 +247,7 @@ static const upb_msglayout_field google_protobuf_MethodDescriptorProto__fields[6
 const upb_msglayout google_protobuf_MethodDescriptorProto_msginit = {
   &google_protobuf_MethodDescriptorProto_submsgs[0],
   &google_protobuf_MethodDescriptorProto__fields[0],
-  UPB_SIZE(32, 64), 6, _UPB_MSGEXT_NONE, 6, 255,
+  0, UPB_SIZE(32, 64), 6, _UPB_MSGEXT_NONE, 6, 255,
 };
 
 static const upb_msglayout_sub google_protobuf_FileOptions_submsgs[2] = {
@@ -282,7 +282,7 @@ static const upb_msglayout_field google_protobuf_FileOptions__fields[21] = {
 const upb_msglayout google_protobuf_FileOptions_msginit = {
   &google_protobuf_FileOptions_submsgs[0],
   &google_protobuf_FileOptions__fields[0],
-  UPB_SIZE(104, 192), 21, _UPB_MSGEXT_EXTENDABLE, 1, 255,
+  0, UPB_SIZE(104, 192), 21, _UPB_MSGEXT_EXTENDABLE, 1, 255,
 };
 
 static const upb_msglayout_sub google_protobuf_MessageOptions_submsgs[1] = {
@@ -300,7 +300,7 @@ static const upb_msglayout_field google_protobuf_MessageOptions__fields[5] = {
 const upb_msglayout google_protobuf_MessageOptions_msginit = {
   &google_protobuf_MessageOptions_submsgs[0],
   &google_protobuf_MessageOptions__fields[0],
-  UPB_SIZE(16, 16), 5, _UPB_MSGEXT_EXTENDABLE, 3, 255,
+  0, UPB_SIZE(16, 16), 5, _UPB_MSGEXT_EXTENDABLE, 3, 255,
 };
 
 static const upb_msglayout_sub google_protobuf_FieldOptions_submsgs[3] = {
@@ -322,7 +322,7 @@ static const upb_msglayout_field google_protobuf_FieldOptions__fields[7] = {
 const upb_msglayout google_protobuf_FieldOptions_msginit = {
   &google_protobuf_FieldOptions_submsgs[0],
   &google_protobuf_FieldOptions__fields[0],
-  UPB_SIZE(24, 24), 7, _UPB_MSGEXT_EXTENDABLE, 3, 255,
+  0, UPB_SIZE(24, 24), 7, _UPB_MSGEXT_EXTENDABLE, 3, 255,
 };
 
 static const upb_msglayout_sub google_protobuf_OneofOptions_submsgs[1] = {
@@ -336,7 +336,7 @@ static const upb_msglayout_field google_protobuf_OneofOptions__fields[1] = {
 const upb_msglayout google_protobuf_OneofOptions_msginit = {
   &google_protobuf_OneofOptions_submsgs[0],
   &google_protobuf_OneofOptions__fields[0],
-  UPB_SIZE(8, 8), 1, _UPB_MSGEXT_EXTENDABLE, 0, 255,
+  0, UPB_SIZE(8, 8), 1, _UPB_MSGEXT_EXTENDABLE, 0, 255,
 };
 
 static const upb_msglayout_sub google_protobuf_EnumOptions_submsgs[1] = {
@@ -352,7 +352,7 @@ static const upb_msglayout_field google_protobuf_EnumOptions__fields[3] = {
 const upb_msglayout google_protobuf_EnumOptions_msginit = {
   &google_protobuf_EnumOptions_submsgs[0],
   &google_protobuf_EnumOptions__fields[0],
-  UPB_SIZE(8, 16), 3, _UPB_MSGEXT_EXTENDABLE, 0, 255,
+  0, UPB_SIZE(8, 16), 3, _UPB_MSGEXT_EXTENDABLE, 0, 255,
 };
 
 static const upb_msglayout_sub google_protobuf_EnumValueOptions_submsgs[1] = {
@@ -367,7 +367,7 @@ static const upb_msglayout_field google_protobuf_EnumValueOptions__fields[2] = {
 const upb_msglayout google_protobuf_EnumValueOptions_msginit = {
   &google_protobuf_EnumValueOptions_submsgs[0],
   &google_protobuf_EnumValueOptions__fields[0],
-  UPB_SIZE(8, 16), 2, _UPB_MSGEXT_EXTENDABLE, 1, 255,
+  0, UPB_SIZE(8, 16), 2, _UPB_MSGEXT_EXTENDABLE, 1, 255,
 };
 
 static const upb_msglayout_sub google_protobuf_ServiceOptions_submsgs[1] = {
@@ -382,7 +382,7 @@ static const upb_msglayout_field google_protobuf_ServiceOptions__fields[2] = {
 const upb_msglayout google_protobuf_ServiceOptions_msginit = {
   &google_protobuf_ServiceOptions_submsgs[0],
   &google_protobuf_ServiceOptions__fields[0],
-  UPB_SIZE(8, 16), 2, _UPB_MSGEXT_EXTENDABLE, 0, 255,
+  0, UPB_SIZE(8, 16), 2, _UPB_MSGEXT_EXTENDABLE, 0, 255,
 };
 
 static const upb_msglayout_sub google_protobuf_MethodOptions_submsgs[2] = {
@@ -399,7 +399,7 @@ static const upb_msglayout_field google_protobuf_MethodOptions__fields[3] = {
 const upb_msglayout google_protobuf_MethodOptions_msginit = {
   &google_protobuf_MethodOptions_submsgs[0],
   &google_protobuf_MethodOptions__fields[0],
-  UPB_SIZE(16, 24), 3, _UPB_MSGEXT_EXTENDABLE, 0, 255,
+  0, UPB_SIZE(16, 24), 3, _UPB_MSGEXT_EXTENDABLE, 0, 255,
 };
 
 static const upb_msglayout_sub google_protobuf_UninterpretedOption_submsgs[1] = {
@@ -419,7 +419,7 @@ static const upb_msglayout_field google_protobuf_UninterpretedOption__fields[7] 
 const upb_msglayout google_protobuf_UninterpretedOption_msginit = {
   &google_protobuf_UninterpretedOption_submsgs[0],
   &google_protobuf_UninterpretedOption__fields[0],
-  UPB_SIZE(64, 96), 7, _UPB_MSGEXT_NONE, 0, 255,
+  0, UPB_SIZE(64, 96), 7, _UPB_MSGEXT_NONE, 0, 255,
 };
 
 static const upb_msglayout_field google_protobuf_UninterpretedOption_NamePart__fields[2] = {
@@ -430,7 +430,7 @@ static const upb_msglayout_field google_protobuf_UninterpretedOption_NamePart__f
 const upb_msglayout google_protobuf_UninterpretedOption_NamePart_msginit = {
   NULL,
   &google_protobuf_UninterpretedOption_NamePart__fields[0],
-  UPB_SIZE(16, 32), 2, _UPB_MSGEXT_NONE, 2, 255,
+  6, UPB_SIZE(16, 32), 2, _UPB_MSGEXT_NONE, 2, 255,
 };
 
 static const upb_msglayout_sub google_protobuf_SourceCodeInfo_submsgs[1] = {
@@ -444,7 +444,7 @@ static const upb_msglayout_field google_protobuf_SourceCodeInfo__fields[1] = {
 const upb_msglayout google_protobuf_SourceCodeInfo_msginit = {
   &google_protobuf_SourceCodeInfo_submsgs[0],
   &google_protobuf_SourceCodeInfo__fields[0],
-  UPB_SIZE(8, 8), 1, _UPB_MSGEXT_NONE, 1, 255,
+  0, UPB_SIZE(8, 8), 1, _UPB_MSGEXT_NONE, 1, 255,
 };
 
 static const upb_msglayout_field google_protobuf_SourceCodeInfo_Location__fields[5] = {
@@ -458,7 +458,7 @@ static const upb_msglayout_field google_protobuf_SourceCodeInfo_Location__fields
 const upb_msglayout google_protobuf_SourceCodeInfo_Location_msginit = {
   NULL,
   &google_protobuf_SourceCodeInfo_Location__fields[0],
-  UPB_SIZE(32, 64), 5, _UPB_MSGEXT_NONE, 4, 255,
+  0, UPB_SIZE(32, 64), 5, _UPB_MSGEXT_NONE, 4, 255,
 };
 
 static const upb_msglayout_sub google_protobuf_GeneratedCodeInfo_submsgs[1] = {
@@ -472,7 +472,7 @@ static const upb_msglayout_field google_protobuf_GeneratedCodeInfo__fields[1] = 
 const upb_msglayout google_protobuf_GeneratedCodeInfo_msginit = {
   &google_protobuf_GeneratedCodeInfo_submsgs[0],
   &google_protobuf_GeneratedCodeInfo__fields[0],
-  UPB_SIZE(8, 8), 1, _UPB_MSGEXT_NONE, 1, 255,
+  0, UPB_SIZE(8, 8), 1, _UPB_MSGEXT_NONE, 1, 255,
 };
 
 static const upb_msglayout_field google_protobuf_GeneratedCodeInfo_Annotation__fields[4] = {
@@ -485,7 +485,7 @@ static const upb_msglayout_field google_protobuf_GeneratedCodeInfo_Annotation__f
 const upb_msglayout google_protobuf_GeneratedCodeInfo_Annotation_msginit = {
   NULL,
   &google_protobuf_GeneratedCodeInfo_Annotation__fields[0],
-  UPB_SIZE(24, 48), 4, _UPB_MSGEXT_NONE, 4, 255,
+  0, UPB_SIZE(24, 48), 4, _UPB_MSGEXT_NONE, 4, 255,
 };
 
 static const upb_msglayout *messages_layout[27] = {
@@ -518,15 +518,21 @@ static const upb_msglayout *messages_layout[27] = {
   &google_protobuf_GeneratedCodeInfo_Annotation_msginit,
 };
 
+const upb_enumlayout google_protobuf_FieldDescriptorProto_Type_enuminit = {
+  NULL,
+  0x7fffeULL,
+  0,
+};
+
 const upb_enumlayout google_protobuf_FieldDescriptorProto_Label_enuminit = {
   NULL,
   0xeULL,
   0,
 };
 
-const upb_enumlayout google_protobuf_FieldDescriptorProto_Type_enuminit = {
+const upb_enumlayout google_protobuf_FileOptions_OptimizeMode_enuminit = {
   NULL,
-  0x7fffeULL,
+  0xeULL,
   0,
 };
 
@@ -542,12 +548,6 @@ const upb_enumlayout google_protobuf_FieldOptions_JSType_enuminit = {
   0,
 };
 
-const upb_enumlayout google_protobuf_FileOptions_OptimizeMode_enuminit = {
-  NULL,
-  0xeULL,
-  0,
-};
-
 const upb_enumlayout google_protobuf_MethodOptions_IdempotencyLevel_enuminit = {
   NULL,
   0x7ULL,
@@ -555,11 +555,11 @@ const upb_enumlayout google_protobuf_MethodOptions_IdempotencyLevel_enuminit = {
 };
 
 static const upb_enumlayout *enums_layout[6] = {
-  &google_protobuf_FieldDescriptorProto_Label_enuminit,
   &google_protobuf_FieldDescriptorProto_Type_enuminit,
+  &google_protobuf_FieldDescriptorProto_Label_enuminit,
+  &google_protobuf_FileOptions_OptimizeMode_enuminit,
   &google_protobuf_FieldOptions_CType_enuminit,
   &google_protobuf_FieldOptions_JSType_enuminit,
-  &google_protobuf_FileOptions_OptimizeMode_enuminit,
   &google_protobuf_MethodOptions_IdempotencyLevel_enuminit,
 };
 

--- a/cmake/google/protobuf/descriptor.upb.c
+++ b/cmake/google/protobuf/descriptor.upb.c
@@ -23,7 +23,7 @@ static const upb_msglayout_field google_protobuf_FileDescriptorSet__fields[1] = 
 const upb_msglayout google_protobuf_FileDescriptorSet_msginit = {
   &google_protobuf_FileDescriptorSet_submsgs[0],
   &google_protobuf_FileDescriptorSet__fields[0],
-  0, UPB_SIZE(8, 8), 1, _UPB_MSGEXT_NONE, 1, 255,
+  UPB_SIZE(8, 8), 1, _UPB_MSGEXT_NONE, 1, 255, 0,
 };
 
 static const upb_msglayout_sub google_protobuf_FileDescriptorProto_submsgs[6] = {
@@ -53,7 +53,7 @@ static const upb_msglayout_field google_protobuf_FileDescriptorProto__fields[12]
 const upb_msglayout google_protobuf_FileDescriptorProto_msginit = {
   &google_protobuf_FileDescriptorProto_submsgs[0],
   &google_protobuf_FileDescriptorProto__fields[0],
-  0, UPB_SIZE(64, 128), 12, _UPB_MSGEXT_NONE, 12, 255,
+  UPB_SIZE(64, 128), 12, _UPB_MSGEXT_NONE, 12, 255, 0,
 };
 
 static const upb_msglayout_sub google_protobuf_DescriptorProto_submsgs[7] = {
@@ -82,7 +82,7 @@ static const upb_msglayout_field google_protobuf_DescriptorProto__fields[10] = {
 const upb_msglayout google_protobuf_DescriptorProto_msginit = {
   &google_protobuf_DescriptorProto_submsgs[0],
   &google_protobuf_DescriptorProto__fields[0],
-  0, UPB_SIZE(48, 96), 10, _UPB_MSGEXT_NONE, 10, 255,
+  UPB_SIZE(48, 96), 10, _UPB_MSGEXT_NONE, 10, 255, 0,
 };
 
 static const upb_msglayout_sub google_protobuf_DescriptorProto_ExtensionRange_submsgs[1] = {
@@ -98,7 +98,7 @@ static const upb_msglayout_field google_protobuf_DescriptorProto_ExtensionRange_
 const upb_msglayout google_protobuf_DescriptorProto_ExtensionRange_msginit = {
   &google_protobuf_DescriptorProto_ExtensionRange_submsgs[0],
   &google_protobuf_DescriptorProto_ExtensionRange__fields[0],
-  0, UPB_SIZE(16, 24), 3, _UPB_MSGEXT_NONE, 3, 255,
+  UPB_SIZE(16, 24), 3, _UPB_MSGEXT_NONE, 3, 255, 0,
 };
 
 static const upb_msglayout_field google_protobuf_DescriptorProto_ReservedRange__fields[2] = {
@@ -109,7 +109,7 @@ static const upb_msglayout_field google_protobuf_DescriptorProto_ReservedRange__
 const upb_msglayout google_protobuf_DescriptorProto_ReservedRange_msginit = {
   NULL,
   &google_protobuf_DescriptorProto_ReservedRange__fields[0],
-  0, UPB_SIZE(16, 16), 2, _UPB_MSGEXT_NONE, 2, 255,
+  UPB_SIZE(16, 16), 2, _UPB_MSGEXT_NONE, 2, 255, 0,
 };
 
 static const upb_msglayout_sub google_protobuf_ExtensionRangeOptions_submsgs[1] = {
@@ -123,7 +123,7 @@ static const upb_msglayout_field google_protobuf_ExtensionRangeOptions__fields[1
 const upb_msglayout google_protobuf_ExtensionRangeOptions_msginit = {
   &google_protobuf_ExtensionRangeOptions_submsgs[0],
   &google_protobuf_ExtensionRangeOptions__fields[0],
-  0, UPB_SIZE(8, 8), 1, _UPB_MSGEXT_EXTENDABLE, 0, 255,
+  UPB_SIZE(8, 8), 1, _UPB_MSGEXT_EXTENDABLE, 0, 255, 0,
 };
 
 static const upb_msglayout_sub google_protobuf_FieldDescriptorProto_submsgs[3] = {
@@ -149,7 +149,7 @@ static const upb_msglayout_field google_protobuf_FieldDescriptorProto__fields[11
 const upb_msglayout google_protobuf_FieldDescriptorProto_msginit = {
   &google_protobuf_FieldDescriptorProto_submsgs[0],
   &google_protobuf_FieldDescriptorProto__fields[0],
-  0, UPB_SIZE(72, 112), 11, _UPB_MSGEXT_NONE, 10, 255,
+  UPB_SIZE(72, 112), 11, _UPB_MSGEXT_NONE, 10, 255, 0,
 };
 
 static const upb_msglayout_sub google_protobuf_OneofDescriptorProto_submsgs[1] = {
@@ -164,7 +164,7 @@ static const upb_msglayout_field google_protobuf_OneofDescriptorProto__fields[2]
 const upb_msglayout google_protobuf_OneofDescriptorProto_msginit = {
   &google_protobuf_OneofDescriptorProto_submsgs[0],
   &google_protobuf_OneofDescriptorProto__fields[0],
-  0, UPB_SIZE(16, 32), 2, _UPB_MSGEXT_NONE, 2, 255,
+  UPB_SIZE(16, 32), 2, _UPB_MSGEXT_NONE, 2, 255, 0,
 };
 
 static const upb_msglayout_sub google_protobuf_EnumDescriptorProto_submsgs[3] = {
@@ -184,7 +184,7 @@ static const upb_msglayout_field google_protobuf_EnumDescriptorProto__fields[5] 
 const upb_msglayout google_protobuf_EnumDescriptorProto_msginit = {
   &google_protobuf_EnumDescriptorProto_submsgs[0],
   &google_protobuf_EnumDescriptorProto__fields[0],
-  0, UPB_SIZE(32, 64), 5, _UPB_MSGEXT_NONE, 5, 255,
+  UPB_SIZE(32, 64), 5, _UPB_MSGEXT_NONE, 5, 255, 0,
 };
 
 static const upb_msglayout_field google_protobuf_EnumDescriptorProto_EnumReservedRange__fields[2] = {
@@ -195,7 +195,7 @@ static const upb_msglayout_field google_protobuf_EnumDescriptorProto_EnumReserve
 const upb_msglayout google_protobuf_EnumDescriptorProto_EnumReservedRange_msginit = {
   NULL,
   &google_protobuf_EnumDescriptorProto_EnumReservedRange__fields[0],
-  0, UPB_SIZE(16, 16), 2, _UPB_MSGEXT_NONE, 2, 255,
+  UPB_SIZE(16, 16), 2, _UPB_MSGEXT_NONE, 2, 255, 0,
 };
 
 static const upb_msglayout_sub google_protobuf_EnumValueDescriptorProto_submsgs[1] = {
@@ -211,7 +211,7 @@ static const upb_msglayout_field google_protobuf_EnumValueDescriptorProto__field
 const upb_msglayout google_protobuf_EnumValueDescriptorProto_msginit = {
   &google_protobuf_EnumValueDescriptorProto_submsgs[0],
   &google_protobuf_EnumValueDescriptorProto__fields[0],
-  0, UPB_SIZE(24, 32), 3, _UPB_MSGEXT_NONE, 3, 255,
+  UPB_SIZE(24, 32), 3, _UPB_MSGEXT_NONE, 3, 255, 0,
 };
 
 static const upb_msglayout_sub google_protobuf_ServiceDescriptorProto_submsgs[2] = {
@@ -228,7 +228,7 @@ static const upb_msglayout_field google_protobuf_ServiceDescriptorProto__fields[
 const upb_msglayout google_protobuf_ServiceDescriptorProto_msginit = {
   &google_protobuf_ServiceDescriptorProto_submsgs[0],
   &google_protobuf_ServiceDescriptorProto__fields[0],
-  0, UPB_SIZE(24, 48), 3, _UPB_MSGEXT_NONE, 3, 255,
+  UPB_SIZE(24, 48), 3, _UPB_MSGEXT_NONE, 3, 255, 0,
 };
 
 static const upb_msglayout_sub google_protobuf_MethodDescriptorProto_submsgs[1] = {
@@ -247,7 +247,7 @@ static const upb_msglayout_field google_protobuf_MethodDescriptorProto__fields[6
 const upb_msglayout google_protobuf_MethodDescriptorProto_msginit = {
   &google_protobuf_MethodDescriptorProto_submsgs[0],
   &google_protobuf_MethodDescriptorProto__fields[0],
-  0, UPB_SIZE(32, 64), 6, _UPB_MSGEXT_NONE, 6, 255,
+  UPB_SIZE(32, 64), 6, _UPB_MSGEXT_NONE, 6, 255, 0,
 };
 
 static const upb_msglayout_sub google_protobuf_FileOptions_submsgs[2] = {
@@ -282,7 +282,7 @@ static const upb_msglayout_field google_protobuf_FileOptions__fields[21] = {
 const upb_msglayout google_protobuf_FileOptions_msginit = {
   &google_protobuf_FileOptions_submsgs[0],
   &google_protobuf_FileOptions__fields[0],
-  0, UPB_SIZE(104, 192), 21, _UPB_MSGEXT_EXTENDABLE, 1, 255,
+  UPB_SIZE(104, 192), 21, _UPB_MSGEXT_EXTENDABLE, 1, 255, 0,
 };
 
 static const upb_msglayout_sub google_protobuf_MessageOptions_submsgs[1] = {
@@ -300,7 +300,7 @@ static const upb_msglayout_field google_protobuf_MessageOptions__fields[5] = {
 const upb_msglayout google_protobuf_MessageOptions_msginit = {
   &google_protobuf_MessageOptions_submsgs[0],
   &google_protobuf_MessageOptions__fields[0],
-  0, UPB_SIZE(16, 16), 5, _UPB_MSGEXT_EXTENDABLE, 3, 255,
+  UPB_SIZE(16, 16), 5, _UPB_MSGEXT_EXTENDABLE, 3, 255, 0,
 };
 
 static const upb_msglayout_sub google_protobuf_FieldOptions_submsgs[3] = {
@@ -322,7 +322,7 @@ static const upb_msglayout_field google_protobuf_FieldOptions__fields[7] = {
 const upb_msglayout google_protobuf_FieldOptions_msginit = {
   &google_protobuf_FieldOptions_submsgs[0],
   &google_protobuf_FieldOptions__fields[0],
-  0, UPB_SIZE(24, 24), 7, _UPB_MSGEXT_EXTENDABLE, 3, 255,
+  UPB_SIZE(24, 24), 7, _UPB_MSGEXT_EXTENDABLE, 3, 255, 0,
 };
 
 static const upb_msglayout_sub google_protobuf_OneofOptions_submsgs[1] = {
@@ -336,7 +336,7 @@ static const upb_msglayout_field google_protobuf_OneofOptions__fields[1] = {
 const upb_msglayout google_protobuf_OneofOptions_msginit = {
   &google_protobuf_OneofOptions_submsgs[0],
   &google_protobuf_OneofOptions__fields[0],
-  0, UPB_SIZE(8, 8), 1, _UPB_MSGEXT_EXTENDABLE, 0, 255,
+  UPB_SIZE(8, 8), 1, _UPB_MSGEXT_EXTENDABLE, 0, 255, 0,
 };
 
 static const upb_msglayout_sub google_protobuf_EnumOptions_submsgs[1] = {
@@ -352,7 +352,7 @@ static const upb_msglayout_field google_protobuf_EnumOptions__fields[3] = {
 const upb_msglayout google_protobuf_EnumOptions_msginit = {
   &google_protobuf_EnumOptions_submsgs[0],
   &google_protobuf_EnumOptions__fields[0],
-  0, UPB_SIZE(8, 16), 3, _UPB_MSGEXT_EXTENDABLE, 0, 255,
+  UPB_SIZE(8, 16), 3, _UPB_MSGEXT_EXTENDABLE, 0, 255, 0,
 };
 
 static const upb_msglayout_sub google_protobuf_EnumValueOptions_submsgs[1] = {
@@ -367,7 +367,7 @@ static const upb_msglayout_field google_protobuf_EnumValueOptions__fields[2] = {
 const upb_msglayout google_protobuf_EnumValueOptions_msginit = {
   &google_protobuf_EnumValueOptions_submsgs[0],
   &google_protobuf_EnumValueOptions__fields[0],
-  0, UPB_SIZE(8, 16), 2, _UPB_MSGEXT_EXTENDABLE, 1, 255,
+  UPB_SIZE(8, 16), 2, _UPB_MSGEXT_EXTENDABLE, 1, 255, 0,
 };
 
 static const upb_msglayout_sub google_protobuf_ServiceOptions_submsgs[1] = {
@@ -382,7 +382,7 @@ static const upb_msglayout_field google_protobuf_ServiceOptions__fields[2] = {
 const upb_msglayout google_protobuf_ServiceOptions_msginit = {
   &google_protobuf_ServiceOptions_submsgs[0],
   &google_protobuf_ServiceOptions__fields[0],
-  0, UPB_SIZE(8, 16), 2, _UPB_MSGEXT_EXTENDABLE, 0, 255,
+  UPB_SIZE(8, 16), 2, _UPB_MSGEXT_EXTENDABLE, 0, 255, 0,
 };
 
 static const upb_msglayout_sub google_protobuf_MethodOptions_submsgs[2] = {
@@ -399,7 +399,7 @@ static const upb_msglayout_field google_protobuf_MethodOptions__fields[3] = {
 const upb_msglayout google_protobuf_MethodOptions_msginit = {
   &google_protobuf_MethodOptions_submsgs[0],
   &google_protobuf_MethodOptions__fields[0],
-  0, UPB_SIZE(16, 24), 3, _UPB_MSGEXT_EXTENDABLE, 0, 255,
+  UPB_SIZE(16, 24), 3, _UPB_MSGEXT_EXTENDABLE, 0, 255, 0,
 };
 
 static const upb_msglayout_sub google_protobuf_UninterpretedOption_submsgs[1] = {
@@ -419,7 +419,7 @@ static const upb_msglayout_field google_protobuf_UninterpretedOption__fields[7] 
 const upb_msglayout google_protobuf_UninterpretedOption_msginit = {
   &google_protobuf_UninterpretedOption_submsgs[0],
   &google_protobuf_UninterpretedOption__fields[0],
-  0, UPB_SIZE(64, 96), 7, _UPB_MSGEXT_NONE, 0, 255,
+  UPB_SIZE(64, 96), 7, _UPB_MSGEXT_NONE, 0, 255, 0,
 };
 
 static const upb_msglayout_field google_protobuf_UninterpretedOption_NamePart__fields[2] = {
@@ -430,7 +430,7 @@ static const upb_msglayout_field google_protobuf_UninterpretedOption_NamePart__f
 const upb_msglayout google_protobuf_UninterpretedOption_NamePart_msginit = {
   NULL,
   &google_protobuf_UninterpretedOption_NamePart__fields[0],
-  6, UPB_SIZE(16, 32), 2, _UPB_MSGEXT_NONE, 2, 255,
+  UPB_SIZE(16, 32), 2, _UPB_MSGEXT_NONE, 2, 255, 2,
 };
 
 static const upb_msglayout_sub google_protobuf_SourceCodeInfo_submsgs[1] = {
@@ -444,7 +444,7 @@ static const upb_msglayout_field google_protobuf_SourceCodeInfo__fields[1] = {
 const upb_msglayout google_protobuf_SourceCodeInfo_msginit = {
   &google_protobuf_SourceCodeInfo_submsgs[0],
   &google_protobuf_SourceCodeInfo__fields[0],
-  0, UPB_SIZE(8, 8), 1, _UPB_MSGEXT_NONE, 1, 255,
+  UPB_SIZE(8, 8), 1, _UPB_MSGEXT_NONE, 1, 255, 0,
 };
 
 static const upb_msglayout_field google_protobuf_SourceCodeInfo_Location__fields[5] = {
@@ -458,7 +458,7 @@ static const upb_msglayout_field google_protobuf_SourceCodeInfo_Location__fields
 const upb_msglayout google_protobuf_SourceCodeInfo_Location_msginit = {
   NULL,
   &google_protobuf_SourceCodeInfo_Location__fields[0],
-  0, UPB_SIZE(32, 64), 5, _UPB_MSGEXT_NONE, 4, 255,
+  UPB_SIZE(32, 64), 5, _UPB_MSGEXT_NONE, 4, 255, 0,
 };
 
 static const upb_msglayout_sub google_protobuf_GeneratedCodeInfo_submsgs[1] = {
@@ -472,7 +472,7 @@ static const upb_msglayout_field google_protobuf_GeneratedCodeInfo__fields[1] = 
 const upb_msglayout google_protobuf_GeneratedCodeInfo_msginit = {
   &google_protobuf_GeneratedCodeInfo_submsgs[0],
   &google_protobuf_GeneratedCodeInfo__fields[0],
-  0, UPB_SIZE(8, 8), 1, _UPB_MSGEXT_NONE, 1, 255,
+  UPB_SIZE(8, 8), 1, _UPB_MSGEXT_NONE, 1, 255, 0,
 };
 
 static const upb_msglayout_field google_protobuf_GeneratedCodeInfo_Annotation__fields[4] = {
@@ -485,7 +485,7 @@ static const upb_msglayout_field google_protobuf_GeneratedCodeInfo_Annotation__f
 const upb_msglayout google_protobuf_GeneratedCodeInfo_Annotation_msginit = {
   NULL,
   &google_protobuf_GeneratedCodeInfo_Annotation__fields[0],
-  0, UPB_SIZE(24, 48), 4, _UPB_MSGEXT_NONE, 4, 255,
+  UPB_SIZE(24, 48), 4, _UPB_MSGEXT_NONE, 4, 255, 0,
 };
 
 static const upb_msglayout *messages_layout[27] = {
@@ -518,21 +518,15 @@ static const upb_msglayout *messages_layout[27] = {
   &google_protobuf_GeneratedCodeInfo_Annotation_msginit,
 };
 
-const upb_enumlayout google_protobuf_FieldDescriptorProto_Type_enuminit = {
-  NULL,
-  0x7fffeULL,
-  0,
-};
-
 const upb_enumlayout google_protobuf_FieldDescriptorProto_Label_enuminit = {
   NULL,
   0xeULL,
   0,
 };
 
-const upb_enumlayout google_protobuf_FileOptions_OptimizeMode_enuminit = {
+const upb_enumlayout google_protobuf_FieldDescriptorProto_Type_enuminit = {
   NULL,
-  0xeULL,
+  0x7fffeULL,
   0,
 };
 
@@ -548,6 +542,12 @@ const upb_enumlayout google_protobuf_FieldOptions_JSType_enuminit = {
   0,
 };
 
+const upb_enumlayout google_protobuf_FileOptions_OptimizeMode_enuminit = {
+  NULL,
+  0xeULL,
+  0,
+};
+
 const upb_enumlayout google_protobuf_MethodOptions_IdempotencyLevel_enuminit = {
   NULL,
   0x7ULL,
@@ -555,11 +555,11 @@ const upb_enumlayout google_protobuf_MethodOptions_IdempotencyLevel_enuminit = {
 };
 
 static const upb_enumlayout *enums_layout[6] = {
-  &google_protobuf_FieldDescriptorProto_Type_enuminit,
   &google_protobuf_FieldDescriptorProto_Label_enuminit,
-  &google_protobuf_FileOptions_OptimizeMode_enuminit,
+  &google_protobuf_FieldDescriptorProto_Type_enuminit,
   &google_protobuf_FieldOptions_CType_enuminit,
   &google_protobuf_FieldOptions_JSType_enuminit,
+  &google_protobuf_FileOptions_OptimizeMode_enuminit,
   &google_protobuf_MethodOptions_IdempotencyLevel_enuminit,
 };
 

--- a/cmake/google/protobuf/descriptor.upb.h
+++ b/cmake/google/protobuf/descriptor.upb.h
@@ -103,6 +103,12 @@ extern const upb_msglayout google_protobuf_GeneratedCodeInfo_msginit;
 extern const upb_msglayout google_protobuf_GeneratedCodeInfo_Annotation_msginit;
 
 typedef enum {
+  google_protobuf_FieldDescriptorProto_LABEL_OPTIONAL = 1,
+  google_protobuf_FieldDescriptorProto_LABEL_REQUIRED = 2,
+  google_protobuf_FieldDescriptorProto_LABEL_REPEATED = 3
+} google_protobuf_FieldDescriptorProto_Label;
+
+typedef enum {
   google_protobuf_FieldDescriptorProto_TYPE_DOUBLE = 1,
   google_protobuf_FieldDescriptorProto_TYPE_FLOAT = 2,
   google_protobuf_FieldDescriptorProto_TYPE_INT64 = 3,
@@ -124,18 +130,6 @@ typedef enum {
 } google_protobuf_FieldDescriptorProto_Type;
 
 typedef enum {
-  google_protobuf_FieldDescriptorProto_LABEL_OPTIONAL = 1,
-  google_protobuf_FieldDescriptorProto_LABEL_REQUIRED = 2,
-  google_protobuf_FieldDescriptorProto_LABEL_REPEATED = 3
-} google_protobuf_FieldDescriptorProto_Label;
-
-typedef enum {
-  google_protobuf_FileOptions_SPEED = 1,
-  google_protobuf_FileOptions_CODE_SIZE = 2,
-  google_protobuf_FileOptions_LITE_RUNTIME = 3
-} google_protobuf_FileOptions_OptimizeMode;
-
-typedef enum {
   google_protobuf_FieldOptions_STRING = 0,
   google_protobuf_FieldOptions_CORD = 1,
   google_protobuf_FieldOptions_STRING_PIECE = 2
@@ -148,17 +142,23 @@ typedef enum {
 } google_protobuf_FieldOptions_JSType;
 
 typedef enum {
+  google_protobuf_FileOptions_SPEED = 1,
+  google_protobuf_FileOptions_CODE_SIZE = 2,
+  google_protobuf_FileOptions_LITE_RUNTIME = 3
+} google_protobuf_FileOptions_OptimizeMode;
+
+typedef enum {
   google_protobuf_MethodOptions_IDEMPOTENCY_UNKNOWN = 0,
   google_protobuf_MethodOptions_NO_SIDE_EFFECTS = 1,
   google_protobuf_MethodOptions_IDEMPOTENT = 2
 } google_protobuf_MethodOptions_IdempotencyLevel;
 
 
-extern const upb_enumlayout google_protobuf_FieldDescriptorProto_Type_enuminit;
 extern const upb_enumlayout google_protobuf_FieldDescriptorProto_Label_enuminit;
-extern const upb_enumlayout google_protobuf_FileOptions_OptimizeMode_enuminit;
+extern const upb_enumlayout google_protobuf_FieldDescriptorProto_Type_enuminit;
 extern const upb_enumlayout google_protobuf_FieldOptions_CType_enuminit;
 extern const upb_enumlayout google_protobuf_FieldOptions_JSType_enuminit;
+extern const upb_enumlayout google_protobuf_FileOptions_OptimizeMode_enuminit;
 extern const upb_enumlayout google_protobuf_MethodOptions_IdempotencyLevel_enuminit;
 
 /* google.protobuf.FileDescriptorSet */

--- a/cmake/google/protobuf/descriptor.upb.h
+++ b/cmake/google/protobuf/descriptor.upb.h
@@ -103,12 +103,6 @@ extern const upb_msglayout google_protobuf_GeneratedCodeInfo_msginit;
 extern const upb_msglayout google_protobuf_GeneratedCodeInfo_Annotation_msginit;
 
 typedef enum {
-  google_protobuf_FieldDescriptorProto_LABEL_OPTIONAL = 1,
-  google_protobuf_FieldDescriptorProto_LABEL_REQUIRED = 2,
-  google_protobuf_FieldDescriptorProto_LABEL_REPEATED = 3
-} google_protobuf_FieldDescriptorProto_Label;
-
-typedef enum {
   google_protobuf_FieldDescriptorProto_TYPE_DOUBLE = 1,
   google_protobuf_FieldDescriptorProto_TYPE_FLOAT = 2,
   google_protobuf_FieldDescriptorProto_TYPE_INT64 = 3,
@@ -130,6 +124,18 @@ typedef enum {
 } google_protobuf_FieldDescriptorProto_Type;
 
 typedef enum {
+  google_protobuf_FieldDescriptorProto_LABEL_OPTIONAL = 1,
+  google_protobuf_FieldDescriptorProto_LABEL_REQUIRED = 2,
+  google_protobuf_FieldDescriptorProto_LABEL_REPEATED = 3
+} google_protobuf_FieldDescriptorProto_Label;
+
+typedef enum {
+  google_protobuf_FileOptions_SPEED = 1,
+  google_protobuf_FileOptions_CODE_SIZE = 2,
+  google_protobuf_FileOptions_LITE_RUNTIME = 3
+} google_protobuf_FileOptions_OptimizeMode;
+
+typedef enum {
   google_protobuf_FieldOptions_STRING = 0,
   google_protobuf_FieldOptions_CORD = 1,
   google_protobuf_FieldOptions_STRING_PIECE = 2
@@ -142,23 +148,17 @@ typedef enum {
 } google_protobuf_FieldOptions_JSType;
 
 typedef enum {
-  google_protobuf_FileOptions_SPEED = 1,
-  google_protobuf_FileOptions_CODE_SIZE = 2,
-  google_protobuf_FileOptions_LITE_RUNTIME = 3
-} google_protobuf_FileOptions_OptimizeMode;
-
-typedef enum {
   google_protobuf_MethodOptions_IDEMPOTENCY_UNKNOWN = 0,
   google_protobuf_MethodOptions_NO_SIDE_EFFECTS = 1,
   google_protobuf_MethodOptions_IDEMPOTENT = 2
 } google_protobuf_MethodOptions_IdempotencyLevel;
 
 
-extern const upb_enumlayout google_protobuf_FieldDescriptorProto_Label_enuminit;
 extern const upb_enumlayout google_protobuf_FieldDescriptorProto_Type_enuminit;
+extern const upb_enumlayout google_protobuf_FieldDescriptorProto_Label_enuminit;
+extern const upb_enumlayout google_protobuf_FileOptions_OptimizeMode_enuminit;
 extern const upb_enumlayout google_protobuf_FieldOptions_CType_enuminit;
 extern const upb_enumlayout google_protobuf_FieldOptions_JSType_enuminit;
-extern const upb_enumlayout google_protobuf_FileOptions_OptimizeMode_enuminit;
 extern const upb_enumlayout google_protobuf_MethodOptions_IdempotencyLevel_enuminit;
 
 /* google.protobuf.FileDescriptorSet */
@@ -170,7 +170,7 @@ UPB_INLINE google_protobuf_FileDescriptorSet *google_protobuf_FileDescriptorSet_
                         upb_arena *arena) {
   google_protobuf_FileDescriptorSet *ret = google_protobuf_FileDescriptorSet_new(arena);
   if (!ret) return NULL;
-  if (!upb_decode(buf, size, ret, &google_protobuf_FileDescriptorSet_msginit, arena)) return NULL;
+  if (upb_decode(buf, size, ret, &google_protobuf_FileDescriptorSet_msginit, arena)) return NULL;
   return ret;
 }
 UPB_INLINE google_protobuf_FileDescriptorSet *google_protobuf_FileDescriptorSet_parse_ex(const char *buf, size_t size,
@@ -178,7 +178,7 @@ UPB_INLINE google_protobuf_FileDescriptorSet *google_protobuf_FileDescriptorSet_
                            upb_arena *arena) {
   google_protobuf_FileDescriptorSet *ret = google_protobuf_FileDescriptorSet_new(arena);
   if (!ret) return NULL;
-  if (!_upb_decode(buf, size, ret, &google_protobuf_FileDescriptorSet_msginit, extreg, options, arena)) {
+  if (_upb_decode(buf, size, ret, &google_protobuf_FileDescriptorSet_msginit, extreg, options, arena)) {
     return NULL;
   }
   return ret;
@@ -213,7 +213,7 @@ UPB_INLINE google_protobuf_FileDescriptorProto *google_protobuf_FileDescriptorPr
                         upb_arena *arena) {
   google_protobuf_FileDescriptorProto *ret = google_protobuf_FileDescriptorProto_new(arena);
   if (!ret) return NULL;
-  if (!upb_decode(buf, size, ret, &google_protobuf_FileDescriptorProto_msginit, arena)) return NULL;
+  if (upb_decode(buf, size, ret, &google_protobuf_FileDescriptorProto_msginit, arena)) return NULL;
   return ret;
 }
 UPB_INLINE google_protobuf_FileDescriptorProto *google_protobuf_FileDescriptorProto_parse_ex(const char *buf, size_t size,
@@ -221,7 +221,7 @@ UPB_INLINE google_protobuf_FileDescriptorProto *google_protobuf_FileDescriptorPr
                            upb_arena *arena) {
   google_protobuf_FileDescriptorProto *ret = google_protobuf_FileDescriptorProto_new(arena);
   if (!ret) return NULL;
-  if (!_upb_decode(buf, size, ret, &google_protobuf_FileDescriptorProto_msginit, extreg, options, arena)) {
+  if (_upb_decode(buf, size, ret, &google_protobuf_FileDescriptorProto_msginit, extreg, options, arena)) {
     return NULL;
   }
   return ret;
@@ -382,7 +382,7 @@ UPB_INLINE google_protobuf_DescriptorProto *google_protobuf_DescriptorProto_pars
                         upb_arena *arena) {
   google_protobuf_DescriptorProto *ret = google_protobuf_DescriptorProto_new(arena);
   if (!ret) return NULL;
-  if (!upb_decode(buf, size, ret, &google_protobuf_DescriptorProto_msginit, arena)) return NULL;
+  if (upb_decode(buf, size, ret, &google_protobuf_DescriptorProto_msginit, arena)) return NULL;
   return ret;
 }
 UPB_INLINE google_protobuf_DescriptorProto *google_protobuf_DescriptorProto_parse_ex(const char *buf, size_t size,
@@ -390,7 +390,7 @@ UPB_INLINE google_protobuf_DescriptorProto *google_protobuf_DescriptorProto_pars
                            upb_arena *arena) {
   google_protobuf_DescriptorProto *ret = google_protobuf_DescriptorProto_new(arena);
   if (!ret) return NULL;
-  if (!_upb_decode(buf, size, ret, &google_protobuf_DescriptorProto_msginit, extreg, options, arena)) {
+  if (_upb_decode(buf, size, ret, &google_protobuf_DescriptorProto_msginit, extreg, options, arena)) {
     return NULL;
   }
   return ret;
@@ -547,7 +547,7 @@ UPB_INLINE google_protobuf_DescriptorProto_ExtensionRange *google_protobuf_Descr
                         upb_arena *arena) {
   google_protobuf_DescriptorProto_ExtensionRange *ret = google_protobuf_DescriptorProto_ExtensionRange_new(arena);
   if (!ret) return NULL;
-  if (!upb_decode(buf, size, ret, &google_protobuf_DescriptorProto_ExtensionRange_msginit, arena)) return NULL;
+  if (upb_decode(buf, size, ret, &google_protobuf_DescriptorProto_ExtensionRange_msginit, arena)) return NULL;
   return ret;
 }
 UPB_INLINE google_protobuf_DescriptorProto_ExtensionRange *google_protobuf_DescriptorProto_ExtensionRange_parse_ex(const char *buf, size_t size,
@@ -555,7 +555,7 @@ UPB_INLINE google_protobuf_DescriptorProto_ExtensionRange *google_protobuf_Descr
                            upb_arena *arena) {
   google_protobuf_DescriptorProto_ExtensionRange *ret = google_protobuf_DescriptorProto_ExtensionRange_new(arena);
   if (!ret) return NULL;
-  if (!_upb_decode(buf, size, ret, &google_protobuf_DescriptorProto_ExtensionRange_msginit, extreg, options, arena)) {
+  if (_upb_decode(buf, size, ret, &google_protobuf_DescriptorProto_ExtensionRange_msginit, extreg, options, arena)) {
     return NULL;
   }
   return ret;
@@ -602,7 +602,7 @@ UPB_INLINE google_protobuf_DescriptorProto_ReservedRange *google_protobuf_Descri
                         upb_arena *arena) {
   google_protobuf_DescriptorProto_ReservedRange *ret = google_protobuf_DescriptorProto_ReservedRange_new(arena);
   if (!ret) return NULL;
-  if (!upb_decode(buf, size, ret, &google_protobuf_DescriptorProto_ReservedRange_msginit, arena)) return NULL;
+  if (upb_decode(buf, size, ret, &google_protobuf_DescriptorProto_ReservedRange_msginit, arena)) return NULL;
   return ret;
 }
 UPB_INLINE google_protobuf_DescriptorProto_ReservedRange *google_protobuf_DescriptorProto_ReservedRange_parse_ex(const char *buf, size_t size,
@@ -610,7 +610,7 @@ UPB_INLINE google_protobuf_DescriptorProto_ReservedRange *google_protobuf_Descri
                            upb_arena *arena) {
   google_protobuf_DescriptorProto_ReservedRange *ret = google_protobuf_DescriptorProto_ReservedRange_new(arena);
   if (!ret) return NULL;
-  if (!_upb_decode(buf, size, ret, &google_protobuf_DescriptorProto_ReservedRange_msginit, extreg, options, arena)) {
+  if (_upb_decode(buf, size, ret, &google_protobuf_DescriptorProto_ReservedRange_msginit, extreg, options, arena)) {
     return NULL;
   }
   return ret;
@@ -642,7 +642,7 @@ UPB_INLINE google_protobuf_ExtensionRangeOptions *google_protobuf_ExtensionRange
                         upb_arena *arena) {
   google_protobuf_ExtensionRangeOptions *ret = google_protobuf_ExtensionRangeOptions_new(arena);
   if (!ret) return NULL;
-  if (!upb_decode(buf, size, ret, &google_protobuf_ExtensionRangeOptions_msginit, arena)) return NULL;
+  if (upb_decode(buf, size, ret, &google_protobuf_ExtensionRangeOptions_msginit, arena)) return NULL;
   return ret;
 }
 UPB_INLINE google_protobuf_ExtensionRangeOptions *google_protobuf_ExtensionRangeOptions_parse_ex(const char *buf, size_t size,
@@ -650,7 +650,7 @@ UPB_INLINE google_protobuf_ExtensionRangeOptions *google_protobuf_ExtensionRange
                            upb_arena *arena) {
   google_protobuf_ExtensionRangeOptions *ret = google_protobuf_ExtensionRangeOptions_new(arena);
   if (!ret) return NULL;
-  if (!_upb_decode(buf, size, ret, &google_protobuf_ExtensionRangeOptions_msginit, extreg, options, arena)) {
+  if (_upb_decode(buf, size, ret, &google_protobuf_ExtensionRangeOptions_msginit, extreg, options, arena)) {
     return NULL;
   }
   return ret;
@@ -685,7 +685,7 @@ UPB_INLINE google_protobuf_FieldDescriptorProto *google_protobuf_FieldDescriptor
                         upb_arena *arena) {
   google_protobuf_FieldDescriptorProto *ret = google_protobuf_FieldDescriptorProto_new(arena);
   if (!ret) return NULL;
-  if (!upb_decode(buf, size, ret, &google_protobuf_FieldDescriptorProto_msginit, arena)) return NULL;
+  if (upb_decode(buf, size, ret, &google_protobuf_FieldDescriptorProto_msginit, arena)) return NULL;
   return ret;
 }
 UPB_INLINE google_protobuf_FieldDescriptorProto *google_protobuf_FieldDescriptorProto_parse_ex(const char *buf, size_t size,
@@ -693,7 +693,7 @@ UPB_INLINE google_protobuf_FieldDescriptorProto *google_protobuf_FieldDescriptor
                            upb_arena *arena) {
   google_protobuf_FieldDescriptorProto *ret = google_protobuf_FieldDescriptorProto_new(arena);
   if (!ret) return NULL;
-  if (!_upb_decode(buf, size, ret, &google_protobuf_FieldDescriptorProto_msginit, extreg, options, arena)) {
+  if (_upb_decode(buf, size, ret, &google_protobuf_FieldDescriptorProto_msginit, extreg, options, arena)) {
     return NULL;
   }
   return ret;
@@ -709,9 +709,9 @@ UPB_INLINE upb_strview google_protobuf_FieldDescriptorProto_extendee(const googl
 UPB_INLINE bool google_protobuf_FieldDescriptorProto_has_number(const google_protobuf_FieldDescriptorProto *msg) { return _upb_hasbit(msg, 3); }
 UPB_INLINE int32_t google_protobuf_FieldDescriptorProto_number(const google_protobuf_FieldDescriptorProto *msg) { return *UPB_PTR_AT(msg, UPB_SIZE(12, 12), int32_t); }
 UPB_INLINE bool google_protobuf_FieldDescriptorProto_has_label(const google_protobuf_FieldDescriptorProto *msg) { return _upb_hasbit(msg, 4); }
-UPB_INLINE int32_t google_protobuf_FieldDescriptorProto_label(const google_protobuf_FieldDescriptorProto *msg) { return *UPB_PTR_AT(msg, UPB_SIZE(4, 4), int32_t); }
+UPB_INLINE int32_t google_protobuf_FieldDescriptorProto_label(const google_protobuf_FieldDescriptorProto *msg) { return google_protobuf_FieldDescriptorProto_has_label(msg) ? *UPB_PTR_AT(msg, UPB_SIZE(4, 4), int32_t) : 1; }
 UPB_INLINE bool google_protobuf_FieldDescriptorProto_has_type(const google_protobuf_FieldDescriptorProto *msg) { return _upb_hasbit(msg, 5); }
-UPB_INLINE int32_t google_protobuf_FieldDescriptorProto_type(const google_protobuf_FieldDescriptorProto *msg) { return *UPB_PTR_AT(msg, UPB_SIZE(8, 8), int32_t); }
+UPB_INLINE int32_t google_protobuf_FieldDescriptorProto_type(const google_protobuf_FieldDescriptorProto *msg) { return google_protobuf_FieldDescriptorProto_has_type(msg) ? *UPB_PTR_AT(msg, UPB_SIZE(8, 8), int32_t) : 1; }
 UPB_INLINE bool google_protobuf_FieldDescriptorProto_has_type_name(const google_protobuf_FieldDescriptorProto *msg) { return _upb_hasbit(msg, 6); }
 UPB_INLINE upb_strview google_protobuf_FieldDescriptorProto_type_name(const google_protobuf_FieldDescriptorProto *msg) { return *UPB_PTR_AT(msg, UPB_SIZE(40, 56), upb_strview); }
 UPB_INLINE bool google_protobuf_FieldDescriptorProto_has_default_value(const google_protobuf_FieldDescriptorProto *msg) { return _upb_hasbit(msg, 7); }
@@ -788,7 +788,7 @@ UPB_INLINE google_protobuf_OneofDescriptorProto *google_protobuf_OneofDescriptor
                         upb_arena *arena) {
   google_protobuf_OneofDescriptorProto *ret = google_protobuf_OneofDescriptorProto_new(arena);
   if (!ret) return NULL;
-  if (!upb_decode(buf, size, ret, &google_protobuf_OneofDescriptorProto_msginit, arena)) return NULL;
+  if (upb_decode(buf, size, ret, &google_protobuf_OneofDescriptorProto_msginit, arena)) return NULL;
   return ret;
 }
 UPB_INLINE google_protobuf_OneofDescriptorProto *google_protobuf_OneofDescriptorProto_parse_ex(const char *buf, size_t size,
@@ -796,7 +796,7 @@ UPB_INLINE google_protobuf_OneofDescriptorProto *google_protobuf_OneofDescriptor
                            upb_arena *arena) {
   google_protobuf_OneofDescriptorProto *ret = google_protobuf_OneofDescriptorProto_new(arena);
   if (!ret) return NULL;
-  if (!_upb_decode(buf, size, ret, &google_protobuf_OneofDescriptorProto_msginit, extreg, options, arena)) {
+  if (_upb_decode(buf, size, ret, &google_protobuf_OneofDescriptorProto_msginit, extreg, options, arena)) {
     return NULL;
   }
   return ret;
@@ -837,7 +837,7 @@ UPB_INLINE google_protobuf_EnumDescriptorProto *google_protobuf_EnumDescriptorPr
                         upb_arena *arena) {
   google_protobuf_EnumDescriptorProto *ret = google_protobuf_EnumDescriptorProto_new(arena);
   if (!ret) return NULL;
-  if (!upb_decode(buf, size, ret, &google_protobuf_EnumDescriptorProto_msginit, arena)) return NULL;
+  if (upb_decode(buf, size, ret, &google_protobuf_EnumDescriptorProto_msginit, arena)) return NULL;
   return ret;
 }
 UPB_INLINE google_protobuf_EnumDescriptorProto *google_protobuf_EnumDescriptorProto_parse_ex(const char *buf, size_t size,
@@ -845,7 +845,7 @@ UPB_INLINE google_protobuf_EnumDescriptorProto *google_protobuf_EnumDescriptorPr
                            upb_arena *arena) {
   google_protobuf_EnumDescriptorProto *ret = google_protobuf_EnumDescriptorProto_new(arena);
   if (!ret) return NULL;
-  if (!_upb_decode(buf, size, ret, &google_protobuf_EnumDescriptorProto_msginit, extreg, options, arena)) {
+  if (_upb_decode(buf, size, ret, &google_protobuf_EnumDescriptorProto_msginit, extreg, options, arena)) {
     return NULL;
   }
   return ret;
@@ -927,7 +927,7 @@ UPB_INLINE google_protobuf_EnumDescriptorProto_EnumReservedRange *google_protobu
                         upb_arena *arena) {
   google_protobuf_EnumDescriptorProto_EnumReservedRange *ret = google_protobuf_EnumDescriptorProto_EnumReservedRange_new(arena);
   if (!ret) return NULL;
-  if (!upb_decode(buf, size, ret, &google_protobuf_EnumDescriptorProto_EnumReservedRange_msginit, arena)) return NULL;
+  if (upb_decode(buf, size, ret, &google_protobuf_EnumDescriptorProto_EnumReservedRange_msginit, arena)) return NULL;
   return ret;
 }
 UPB_INLINE google_protobuf_EnumDescriptorProto_EnumReservedRange *google_protobuf_EnumDescriptorProto_EnumReservedRange_parse_ex(const char *buf, size_t size,
@@ -935,7 +935,7 @@ UPB_INLINE google_protobuf_EnumDescriptorProto_EnumReservedRange *google_protobu
                            upb_arena *arena) {
   google_protobuf_EnumDescriptorProto_EnumReservedRange *ret = google_protobuf_EnumDescriptorProto_EnumReservedRange_new(arena);
   if (!ret) return NULL;
-  if (!_upb_decode(buf, size, ret, &google_protobuf_EnumDescriptorProto_EnumReservedRange_msginit, extreg, options, arena)) {
+  if (_upb_decode(buf, size, ret, &google_protobuf_EnumDescriptorProto_EnumReservedRange_msginit, extreg, options, arena)) {
     return NULL;
   }
   return ret;
@@ -967,7 +967,7 @@ UPB_INLINE google_protobuf_EnumValueDescriptorProto *google_protobuf_EnumValueDe
                         upb_arena *arena) {
   google_protobuf_EnumValueDescriptorProto *ret = google_protobuf_EnumValueDescriptorProto_new(arena);
   if (!ret) return NULL;
-  if (!upb_decode(buf, size, ret, &google_protobuf_EnumValueDescriptorProto_msginit, arena)) return NULL;
+  if (upb_decode(buf, size, ret, &google_protobuf_EnumValueDescriptorProto_msginit, arena)) return NULL;
   return ret;
 }
 UPB_INLINE google_protobuf_EnumValueDescriptorProto *google_protobuf_EnumValueDescriptorProto_parse_ex(const char *buf, size_t size,
@@ -975,7 +975,7 @@ UPB_INLINE google_protobuf_EnumValueDescriptorProto *google_protobuf_EnumValueDe
                            upb_arena *arena) {
   google_protobuf_EnumValueDescriptorProto *ret = google_protobuf_EnumValueDescriptorProto_new(arena);
   if (!ret) return NULL;
-  if (!_upb_decode(buf, size, ret, &google_protobuf_EnumValueDescriptorProto_msginit, extreg, options, arena)) {
+  if (_upb_decode(buf, size, ret, &google_protobuf_EnumValueDescriptorProto_msginit, extreg, options, arena)) {
     return NULL;
   }
   return ret;
@@ -1022,7 +1022,7 @@ UPB_INLINE google_protobuf_ServiceDescriptorProto *google_protobuf_ServiceDescri
                         upb_arena *arena) {
   google_protobuf_ServiceDescriptorProto *ret = google_protobuf_ServiceDescriptorProto_new(arena);
   if (!ret) return NULL;
-  if (!upb_decode(buf, size, ret, &google_protobuf_ServiceDescriptorProto_msginit, arena)) return NULL;
+  if (upb_decode(buf, size, ret, &google_protobuf_ServiceDescriptorProto_msginit, arena)) return NULL;
   return ret;
 }
 UPB_INLINE google_protobuf_ServiceDescriptorProto *google_protobuf_ServiceDescriptorProto_parse_ex(const char *buf, size_t size,
@@ -1030,7 +1030,7 @@ UPB_INLINE google_protobuf_ServiceDescriptorProto *google_protobuf_ServiceDescri
                            upb_arena *arena) {
   google_protobuf_ServiceDescriptorProto *ret = google_protobuf_ServiceDescriptorProto_new(arena);
   if (!ret) return NULL;
-  if (!_upb_decode(buf, size, ret, &google_protobuf_ServiceDescriptorProto_msginit, extreg, options, arena)) {
+  if (_upb_decode(buf, size, ret, &google_protobuf_ServiceDescriptorProto_msginit, extreg, options, arena)) {
     return NULL;
   }
   return ret;
@@ -1086,7 +1086,7 @@ UPB_INLINE google_protobuf_MethodDescriptorProto *google_protobuf_MethodDescript
                         upb_arena *arena) {
   google_protobuf_MethodDescriptorProto *ret = google_protobuf_MethodDescriptorProto_new(arena);
   if (!ret) return NULL;
-  if (!upb_decode(buf, size, ret, &google_protobuf_MethodDescriptorProto_msginit, arena)) return NULL;
+  if (upb_decode(buf, size, ret, &google_protobuf_MethodDescriptorProto_msginit, arena)) return NULL;
   return ret;
 }
 UPB_INLINE google_protobuf_MethodDescriptorProto *google_protobuf_MethodDescriptorProto_parse_ex(const char *buf, size_t size,
@@ -1094,7 +1094,7 @@ UPB_INLINE google_protobuf_MethodDescriptorProto *google_protobuf_MethodDescript
                            upb_arena *arena) {
   google_protobuf_MethodDescriptorProto *ret = google_protobuf_MethodDescriptorProto_new(arena);
   if (!ret) return NULL;
-  if (!_upb_decode(buf, size, ret, &google_protobuf_MethodDescriptorProto_msginit, extreg, options, arena)) {
+  if (_upb_decode(buf, size, ret, &google_protobuf_MethodDescriptorProto_msginit, extreg, options, arena)) {
     return NULL;
   }
   return ret;
@@ -1159,7 +1159,7 @@ UPB_INLINE google_protobuf_FileOptions *google_protobuf_FileOptions_parse(const 
                         upb_arena *arena) {
   google_protobuf_FileOptions *ret = google_protobuf_FileOptions_new(arena);
   if (!ret) return NULL;
-  if (!upb_decode(buf, size, ret, &google_protobuf_FileOptions_msginit, arena)) return NULL;
+  if (upb_decode(buf, size, ret, &google_protobuf_FileOptions_msginit, arena)) return NULL;
   return ret;
 }
 UPB_INLINE google_protobuf_FileOptions *google_protobuf_FileOptions_parse_ex(const char *buf, size_t size,
@@ -1167,7 +1167,7 @@ UPB_INLINE google_protobuf_FileOptions *google_protobuf_FileOptions_parse_ex(con
                            upb_arena *arena) {
   google_protobuf_FileOptions *ret = google_protobuf_FileOptions_new(arena);
   if (!ret) return NULL;
-  if (!_upb_decode(buf, size, ret, &google_protobuf_FileOptions_msginit, extreg, options, arena)) {
+  if (_upb_decode(buf, size, ret, &google_protobuf_FileOptions_msginit, extreg, options, arena)) {
     return NULL;
   }
   return ret;
@@ -1181,7 +1181,7 @@ UPB_INLINE upb_strview google_protobuf_FileOptions_java_package(const google_pro
 UPB_INLINE bool google_protobuf_FileOptions_has_java_outer_classname(const google_protobuf_FileOptions *msg) { return _upb_hasbit(msg, 2); }
 UPB_INLINE upb_strview google_protobuf_FileOptions_java_outer_classname(const google_protobuf_FileOptions *msg) { return *UPB_PTR_AT(msg, UPB_SIZE(28, 40), upb_strview); }
 UPB_INLINE bool google_protobuf_FileOptions_has_optimize_for(const google_protobuf_FileOptions *msg) { return _upb_hasbit(msg, 3); }
-UPB_INLINE int32_t google_protobuf_FileOptions_optimize_for(const google_protobuf_FileOptions *msg) { return *UPB_PTR_AT(msg, UPB_SIZE(4, 4), int32_t); }
+UPB_INLINE int32_t google_protobuf_FileOptions_optimize_for(const google_protobuf_FileOptions *msg) { return google_protobuf_FileOptions_has_optimize_for(msg) ? *UPB_PTR_AT(msg, UPB_SIZE(4, 4), int32_t) : 1; }
 UPB_INLINE bool google_protobuf_FileOptions_has_java_multiple_files(const google_protobuf_FileOptions *msg) { return _upb_hasbit(msg, 4); }
 UPB_INLINE bool google_protobuf_FileOptions_java_multiple_files(const google_protobuf_FileOptions *msg) { return *UPB_PTR_AT(msg, UPB_SIZE(8, 8), bool); }
 UPB_INLINE bool google_protobuf_FileOptions_has_go_package(const google_protobuf_FileOptions *msg) { return _upb_hasbit(msg, 5); }
@@ -1199,7 +1199,7 @@ UPB_INLINE bool google_protobuf_FileOptions_deprecated(const google_protobuf_Fil
 UPB_INLINE bool google_protobuf_FileOptions_has_java_string_check_utf8(const google_protobuf_FileOptions *msg) { return _upb_hasbit(msg, 11); }
 UPB_INLINE bool google_protobuf_FileOptions_java_string_check_utf8(const google_protobuf_FileOptions *msg) { return *UPB_PTR_AT(msg, UPB_SIZE(14, 14), bool); }
 UPB_INLINE bool google_protobuf_FileOptions_has_cc_enable_arenas(const google_protobuf_FileOptions *msg) { return _upb_hasbit(msg, 12); }
-UPB_INLINE bool google_protobuf_FileOptions_cc_enable_arenas(const google_protobuf_FileOptions *msg) { return *UPB_PTR_AT(msg, UPB_SIZE(15, 15), bool); }
+UPB_INLINE bool google_protobuf_FileOptions_cc_enable_arenas(const google_protobuf_FileOptions *msg) { return google_protobuf_FileOptions_has_cc_enable_arenas(msg) ? *UPB_PTR_AT(msg, UPB_SIZE(15, 15), bool) : true; }
 UPB_INLINE bool google_protobuf_FileOptions_has_objc_class_prefix(const google_protobuf_FileOptions *msg) { return _upb_hasbit(msg, 13); }
 UPB_INLINE upb_strview google_protobuf_FileOptions_objc_class_prefix(const google_protobuf_FileOptions *msg) { return *UPB_PTR_AT(msg, UPB_SIZE(44, 72), upb_strview); }
 UPB_INLINE bool google_protobuf_FileOptions_has_csharp_namespace(const google_protobuf_FileOptions *msg) { return _upb_hasbit(msg, 14); }
@@ -1322,7 +1322,7 @@ UPB_INLINE google_protobuf_MessageOptions *google_protobuf_MessageOptions_parse(
                         upb_arena *arena) {
   google_protobuf_MessageOptions *ret = google_protobuf_MessageOptions_new(arena);
   if (!ret) return NULL;
-  if (!upb_decode(buf, size, ret, &google_protobuf_MessageOptions_msginit, arena)) return NULL;
+  if (upb_decode(buf, size, ret, &google_protobuf_MessageOptions_msginit, arena)) return NULL;
   return ret;
 }
 UPB_INLINE google_protobuf_MessageOptions *google_protobuf_MessageOptions_parse_ex(const char *buf, size_t size,
@@ -1330,7 +1330,7 @@ UPB_INLINE google_protobuf_MessageOptions *google_protobuf_MessageOptions_parse_
                            upb_arena *arena) {
   google_protobuf_MessageOptions *ret = google_protobuf_MessageOptions_new(arena);
   if (!ret) return NULL;
-  if (!_upb_decode(buf, size, ret, &google_protobuf_MessageOptions_msginit, extreg, options, arena)) {
+  if (_upb_decode(buf, size, ret, &google_protobuf_MessageOptions_msginit, extreg, options, arena)) {
     return NULL;
   }
   return ret;
@@ -1389,7 +1389,7 @@ UPB_INLINE google_protobuf_FieldOptions *google_protobuf_FieldOptions_parse(cons
                         upb_arena *arena) {
   google_protobuf_FieldOptions *ret = google_protobuf_FieldOptions_new(arena);
   if (!ret) return NULL;
-  if (!upb_decode(buf, size, ret, &google_protobuf_FieldOptions_msginit, arena)) return NULL;
+  if (upb_decode(buf, size, ret, &google_protobuf_FieldOptions_msginit, arena)) return NULL;
   return ret;
 }
 UPB_INLINE google_protobuf_FieldOptions *google_protobuf_FieldOptions_parse_ex(const char *buf, size_t size,
@@ -1397,7 +1397,7 @@ UPB_INLINE google_protobuf_FieldOptions *google_protobuf_FieldOptions_parse_ex(c
                            upb_arena *arena) {
   google_protobuf_FieldOptions *ret = google_protobuf_FieldOptions_new(arena);
   if (!ret) return NULL;
-  if (!_upb_decode(buf, size, ret, &google_protobuf_FieldOptions_msginit, extreg, options, arena)) {
+  if (_upb_decode(buf, size, ret, &google_protobuf_FieldOptions_msginit, extreg, options, arena)) {
     return NULL;
   }
   return ret;
@@ -1468,7 +1468,7 @@ UPB_INLINE google_protobuf_OneofOptions *google_protobuf_OneofOptions_parse(cons
                         upb_arena *arena) {
   google_protobuf_OneofOptions *ret = google_protobuf_OneofOptions_new(arena);
   if (!ret) return NULL;
-  if (!upb_decode(buf, size, ret, &google_protobuf_OneofOptions_msginit, arena)) return NULL;
+  if (upb_decode(buf, size, ret, &google_protobuf_OneofOptions_msginit, arena)) return NULL;
   return ret;
 }
 UPB_INLINE google_protobuf_OneofOptions *google_protobuf_OneofOptions_parse_ex(const char *buf, size_t size,
@@ -1476,7 +1476,7 @@ UPB_INLINE google_protobuf_OneofOptions *google_protobuf_OneofOptions_parse_ex(c
                            upb_arena *arena) {
   google_protobuf_OneofOptions *ret = google_protobuf_OneofOptions_new(arena);
   if (!ret) return NULL;
-  if (!_upb_decode(buf, size, ret, &google_protobuf_OneofOptions_msginit, extreg, options, arena)) {
+  if (_upb_decode(buf, size, ret, &google_protobuf_OneofOptions_msginit, extreg, options, arena)) {
     return NULL;
   }
   return ret;
@@ -1511,7 +1511,7 @@ UPB_INLINE google_protobuf_EnumOptions *google_protobuf_EnumOptions_parse(const 
                         upb_arena *arena) {
   google_protobuf_EnumOptions *ret = google_protobuf_EnumOptions_new(arena);
   if (!ret) return NULL;
-  if (!upb_decode(buf, size, ret, &google_protobuf_EnumOptions_msginit, arena)) return NULL;
+  if (upb_decode(buf, size, ret, &google_protobuf_EnumOptions_msginit, arena)) return NULL;
   return ret;
 }
 UPB_INLINE google_protobuf_EnumOptions *google_protobuf_EnumOptions_parse_ex(const char *buf, size_t size,
@@ -1519,7 +1519,7 @@ UPB_INLINE google_protobuf_EnumOptions *google_protobuf_EnumOptions_parse_ex(con
                            upb_arena *arena) {
   google_protobuf_EnumOptions *ret = google_protobuf_EnumOptions_new(arena);
   if (!ret) return NULL;
-  if (!_upb_decode(buf, size, ret, &google_protobuf_EnumOptions_msginit, extreg, options, arena)) {
+  if (_upb_decode(buf, size, ret, &google_protobuf_EnumOptions_msginit, extreg, options, arena)) {
     return NULL;
   }
   return ret;
@@ -1566,7 +1566,7 @@ UPB_INLINE google_protobuf_EnumValueOptions *google_protobuf_EnumValueOptions_pa
                         upb_arena *arena) {
   google_protobuf_EnumValueOptions *ret = google_protobuf_EnumValueOptions_new(arena);
   if (!ret) return NULL;
-  if (!upb_decode(buf, size, ret, &google_protobuf_EnumValueOptions_msginit, arena)) return NULL;
+  if (upb_decode(buf, size, ret, &google_protobuf_EnumValueOptions_msginit, arena)) return NULL;
   return ret;
 }
 UPB_INLINE google_protobuf_EnumValueOptions *google_protobuf_EnumValueOptions_parse_ex(const char *buf, size_t size,
@@ -1574,7 +1574,7 @@ UPB_INLINE google_protobuf_EnumValueOptions *google_protobuf_EnumValueOptions_pa
                            upb_arena *arena) {
   google_protobuf_EnumValueOptions *ret = google_protobuf_EnumValueOptions_new(arena);
   if (!ret) return NULL;
-  if (!_upb_decode(buf, size, ret, &google_protobuf_EnumValueOptions_msginit, extreg, options, arena)) {
+  if (_upb_decode(buf, size, ret, &google_protobuf_EnumValueOptions_msginit, extreg, options, arena)) {
     return NULL;
   }
   return ret;
@@ -1615,7 +1615,7 @@ UPB_INLINE google_protobuf_ServiceOptions *google_protobuf_ServiceOptions_parse(
                         upb_arena *arena) {
   google_protobuf_ServiceOptions *ret = google_protobuf_ServiceOptions_new(arena);
   if (!ret) return NULL;
-  if (!upb_decode(buf, size, ret, &google_protobuf_ServiceOptions_msginit, arena)) return NULL;
+  if (upb_decode(buf, size, ret, &google_protobuf_ServiceOptions_msginit, arena)) return NULL;
   return ret;
 }
 UPB_INLINE google_protobuf_ServiceOptions *google_protobuf_ServiceOptions_parse_ex(const char *buf, size_t size,
@@ -1623,7 +1623,7 @@ UPB_INLINE google_protobuf_ServiceOptions *google_protobuf_ServiceOptions_parse_
                            upb_arena *arena) {
   google_protobuf_ServiceOptions *ret = google_protobuf_ServiceOptions_new(arena);
   if (!ret) return NULL;
-  if (!_upb_decode(buf, size, ret, &google_protobuf_ServiceOptions_msginit, extreg, options, arena)) {
+  if (_upb_decode(buf, size, ret, &google_protobuf_ServiceOptions_msginit, extreg, options, arena)) {
     return NULL;
   }
   return ret;
@@ -1664,7 +1664,7 @@ UPB_INLINE google_protobuf_MethodOptions *google_protobuf_MethodOptions_parse(co
                         upb_arena *arena) {
   google_protobuf_MethodOptions *ret = google_protobuf_MethodOptions_new(arena);
   if (!ret) return NULL;
-  if (!upb_decode(buf, size, ret, &google_protobuf_MethodOptions_msginit, arena)) return NULL;
+  if (upb_decode(buf, size, ret, &google_protobuf_MethodOptions_msginit, arena)) return NULL;
   return ret;
 }
 UPB_INLINE google_protobuf_MethodOptions *google_protobuf_MethodOptions_parse_ex(const char *buf, size_t size,
@@ -1672,7 +1672,7 @@ UPB_INLINE google_protobuf_MethodOptions *google_protobuf_MethodOptions_parse_ex
                            upb_arena *arena) {
   google_protobuf_MethodOptions *ret = google_protobuf_MethodOptions_new(arena);
   if (!ret) return NULL;
-  if (!_upb_decode(buf, size, ret, &google_protobuf_MethodOptions_msginit, extreg, options, arena)) {
+  if (_upb_decode(buf, size, ret, &google_protobuf_MethodOptions_msginit, extreg, options, arena)) {
     return NULL;
   }
   return ret;
@@ -1719,7 +1719,7 @@ UPB_INLINE google_protobuf_UninterpretedOption *google_protobuf_UninterpretedOpt
                         upb_arena *arena) {
   google_protobuf_UninterpretedOption *ret = google_protobuf_UninterpretedOption_new(arena);
   if (!ret) return NULL;
-  if (!upb_decode(buf, size, ret, &google_protobuf_UninterpretedOption_msginit, arena)) return NULL;
+  if (upb_decode(buf, size, ret, &google_protobuf_UninterpretedOption_msginit, arena)) return NULL;
   return ret;
 }
 UPB_INLINE google_protobuf_UninterpretedOption *google_protobuf_UninterpretedOption_parse_ex(const char *buf, size_t size,
@@ -1727,7 +1727,7 @@ UPB_INLINE google_protobuf_UninterpretedOption *google_protobuf_UninterpretedOpt
                            upb_arena *arena) {
   google_protobuf_UninterpretedOption *ret = google_protobuf_UninterpretedOption_new(arena);
   if (!ret) return NULL;
-  if (!_upb_decode(buf, size, ret, &google_protobuf_UninterpretedOption_msginit, extreg, options, arena)) {
+  if (_upb_decode(buf, size, ret, &google_protobuf_UninterpretedOption_msginit, extreg, options, arena)) {
     return NULL;
   }
   return ret;
@@ -1798,7 +1798,7 @@ UPB_INLINE google_protobuf_UninterpretedOption_NamePart *google_protobuf_Uninter
                         upb_arena *arena) {
   google_protobuf_UninterpretedOption_NamePart *ret = google_protobuf_UninterpretedOption_NamePart_new(arena);
   if (!ret) return NULL;
-  if (!upb_decode(buf, size, ret, &google_protobuf_UninterpretedOption_NamePart_msginit, arena)) return NULL;
+  if (upb_decode(buf, size, ret, &google_protobuf_UninterpretedOption_NamePart_msginit, arena)) return NULL;
   return ret;
 }
 UPB_INLINE google_protobuf_UninterpretedOption_NamePart *google_protobuf_UninterpretedOption_NamePart_parse_ex(const char *buf, size_t size,
@@ -1806,7 +1806,7 @@ UPB_INLINE google_protobuf_UninterpretedOption_NamePart *google_protobuf_Uninter
                            upb_arena *arena) {
   google_protobuf_UninterpretedOption_NamePart *ret = google_protobuf_UninterpretedOption_NamePart_new(arena);
   if (!ret) return NULL;
-  if (!_upb_decode(buf, size, ret, &google_protobuf_UninterpretedOption_NamePart_msginit, extreg, options, arena)) {
+  if (_upb_decode(buf, size, ret, &google_protobuf_UninterpretedOption_NamePart_msginit, extreg, options, arena)) {
     return NULL;
   }
   return ret;
@@ -1838,7 +1838,7 @@ UPB_INLINE google_protobuf_SourceCodeInfo *google_protobuf_SourceCodeInfo_parse(
                         upb_arena *arena) {
   google_protobuf_SourceCodeInfo *ret = google_protobuf_SourceCodeInfo_new(arena);
   if (!ret) return NULL;
-  if (!upb_decode(buf, size, ret, &google_protobuf_SourceCodeInfo_msginit, arena)) return NULL;
+  if (upb_decode(buf, size, ret, &google_protobuf_SourceCodeInfo_msginit, arena)) return NULL;
   return ret;
 }
 UPB_INLINE google_protobuf_SourceCodeInfo *google_protobuf_SourceCodeInfo_parse_ex(const char *buf, size_t size,
@@ -1846,7 +1846,7 @@ UPB_INLINE google_protobuf_SourceCodeInfo *google_protobuf_SourceCodeInfo_parse_
                            upb_arena *arena) {
   google_protobuf_SourceCodeInfo *ret = google_protobuf_SourceCodeInfo_new(arena);
   if (!ret) return NULL;
-  if (!_upb_decode(buf, size, ret, &google_protobuf_SourceCodeInfo_msginit, extreg, options, arena)) {
+  if (_upb_decode(buf, size, ret, &google_protobuf_SourceCodeInfo_msginit, extreg, options, arena)) {
     return NULL;
   }
   return ret;
@@ -1881,7 +1881,7 @@ UPB_INLINE google_protobuf_SourceCodeInfo_Location *google_protobuf_SourceCodeIn
                         upb_arena *arena) {
   google_protobuf_SourceCodeInfo_Location *ret = google_protobuf_SourceCodeInfo_Location_new(arena);
   if (!ret) return NULL;
-  if (!upb_decode(buf, size, ret, &google_protobuf_SourceCodeInfo_Location_msginit, arena)) return NULL;
+  if (upb_decode(buf, size, ret, &google_protobuf_SourceCodeInfo_Location_msginit, arena)) return NULL;
   return ret;
 }
 UPB_INLINE google_protobuf_SourceCodeInfo_Location *google_protobuf_SourceCodeInfo_Location_parse_ex(const char *buf, size_t size,
@@ -1889,7 +1889,7 @@ UPB_INLINE google_protobuf_SourceCodeInfo_Location *google_protobuf_SourceCodeIn
                            upb_arena *arena) {
   google_protobuf_SourceCodeInfo_Location *ret = google_protobuf_SourceCodeInfo_Location_new(arena);
   if (!ret) return NULL;
-  if (!_upb_decode(buf, size, ret, &google_protobuf_SourceCodeInfo_Location_msginit, extreg, options, arena)) {
+  if (_upb_decode(buf, size, ret, &google_protobuf_SourceCodeInfo_Location_msginit, extreg, options, arena)) {
     return NULL;
   }
   return ret;
@@ -1954,7 +1954,7 @@ UPB_INLINE google_protobuf_GeneratedCodeInfo *google_protobuf_GeneratedCodeInfo_
                         upb_arena *arena) {
   google_protobuf_GeneratedCodeInfo *ret = google_protobuf_GeneratedCodeInfo_new(arena);
   if (!ret) return NULL;
-  if (!upb_decode(buf, size, ret, &google_protobuf_GeneratedCodeInfo_msginit, arena)) return NULL;
+  if (upb_decode(buf, size, ret, &google_protobuf_GeneratedCodeInfo_msginit, arena)) return NULL;
   return ret;
 }
 UPB_INLINE google_protobuf_GeneratedCodeInfo *google_protobuf_GeneratedCodeInfo_parse_ex(const char *buf, size_t size,
@@ -1962,7 +1962,7 @@ UPB_INLINE google_protobuf_GeneratedCodeInfo *google_protobuf_GeneratedCodeInfo_
                            upb_arena *arena) {
   google_protobuf_GeneratedCodeInfo *ret = google_protobuf_GeneratedCodeInfo_new(arena);
   if (!ret) return NULL;
-  if (!_upb_decode(buf, size, ret, &google_protobuf_GeneratedCodeInfo_msginit, extreg, options, arena)) {
+  if (_upb_decode(buf, size, ret, &google_protobuf_GeneratedCodeInfo_msginit, extreg, options, arena)) {
     return NULL;
   }
   return ret;
@@ -1997,7 +1997,7 @@ UPB_INLINE google_protobuf_GeneratedCodeInfo_Annotation *google_protobuf_Generat
                         upb_arena *arena) {
   google_protobuf_GeneratedCodeInfo_Annotation *ret = google_protobuf_GeneratedCodeInfo_Annotation_new(arena);
   if (!ret) return NULL;
-  if (!upb_decode(buf, size, ret, &google_protobuf_GeneratedCodeInfo_Annotation_msginit, arena)) return NULL;
+  if (upb_decode(buf, size, ret, &google_protobuf_GeneratedCodeInfo_Annotation_msginit, arena)) return NULL;
   return ret;
 }
 UPB_INLINE google_protobuf_GeneratedCodeInfo_Annotation *google_protobuf_GeneratedCodeInfo_Annotation_parse_ex(const char *buf, size_t size,
@@ -2005,7 +2005,7 @@ UPB_INLINE google_protobuf_GeneratedCodeInfo_Annotation *google_protobuf_Generat
                            upb_arena *arena) {
   google_protobuf_GeneratedCodeInfo_Annotation *ret = google_protobuf_GeneratedCodeInfo_Annotation_new(arena);
   if (!ret) return NULL;
-  if (!_upb_decode(buf, size, ret, &google_protobuf_GeneratedCodeInfo_Annotation_msginit, extreg, options, arena)) {
+  if (_upb_decode(buf, size, ret, &google_protobuf_GeneratedCodeInfo_Annotation_msginit, extreg, options, arena)) {
     return NULL;
   }
   return ret;

--- a/tests/conformance_upb.c
+++ b/tests/conformance_upb.c
@@ -88,7 +88,7 @@ bool parse_proto(upb_msg *msg, const upb_msgdef *m, const ctx* c) {
   upb_strview proto =
       conformance_ConformanceRequest_protobuf_payload(c->request);
   if (upb_decode(proto.data, proto.size, msg, upb_msgdef_layout(m), c->arena) ==
-      UPB_DECODE_OK) {
+      kUpb_DecodeStatus_Ok) {
     return true;
   } else {
     static const char msg[] = "Parse error";

--- a/tests/conformance_upb.c
+++ b/tests/conformance_upb.c
@@ -87,7 +87,8 @@ typedef struct {
 bool parse_proto(upb_msg *msg, const upb_msgdef *m, const ctx* c) {
   upb_strview proto =
       conformance_ConformanceRequest_protobuf_payload(c->request);
-  if (upb_decode(proto.data, proto.size, msg, upb_msgdef_layout(m), c->arena)) {
+  if (upb_decode(proto.data, proto.size, msg, upb_msgdef_layout(m), c->arena) ==
+      UPB_DECODE_OK) {
     return true;
   } else {
     static const char msg[] = "Parse error";

--- a/tests/test_table.cc
+++ b/tests/test_table.cc
@@ -155,7 +155,7 @@ class StrTable {
   std::pair<bool, upb_value> Remove(const std::string& key) {
     std::pair<bool, upb_value> ret;
     ret.first =
-        upb_strtable_remove(&table_, key.c_str(), key.size(), &ret.second);
+        upb_strtable_remove2(&table_, key.c_str(), key.size(), &ret.second);
     return ret;
   }
 

--- a/upb/bindings/lua/def.c
+++ b/upb/bindings/lua/def.c
@@ -908,7 +908,6 @@ static int lupb_symtab_lookupenumval(lua_State *L) {
 }
 
 static int lupb_symtab_tostring(lua_State *L) {
-  const upb_symtab *s = lupb_symtab_check(L, 1);
   lua_pushfstring(L, "<upb.SymbolTable>");
   return 1;
 }

--- a/upb/bindings/lua/msg.c
+++ b/upb/bindings/lua/msg.c
@@ -961,7 +961,7 @@ static int lupb_decode(lua_State *L) {
   buf = upb_arena_malloc(arena, len);
   memcpy(buf, pb, len);
 
-  ok = _upb_decode(buf, len, msg, layout, NULL, UPB_DECODE_ALIAS, arena) == 0;
+  ok = _upb_decode(buf, len, msg, layout, NULL, kUpb_DecodeOption_AliasString, arena) == 0;
 
   if (!ok) {
     lua_pushstring(L, "Error decoding protobuf.");

--- a/upb/bindings/lua/msg.c
+++ b/upb/bindings/lua/msg.c
@@ -961,7 +961,7 @@ static int lupb_decode(lua_State *L) {
   buf = upb_arena_malloc(arena, len);
   memcpy(buf, pb, len);
 
-  ok = _upb_decode(buf, len, msg, layout, NULL, UPB_DECODE_ALIAS, arena);
+  ok = _upb_decode(buf, len, msg, layout, NULL, UPB_DECODE_ALIAS, arena) == 0;
 
   if (!ok) {
     lua_pushstring(L, "Error decoding protobuf.");

--- a/upb/decode.h
+++ b/upb/decode.h
@@ -45,17 +45,46 @@ enum {
   /* If set, strings will alias the input buffer instead of copying into the
    * arena. */
   UPB_DECODE_ALIAS = 1,
+
+  /* If set, the parse will return failure if any message is missing any required
+   * fields when the message data ends.  The parse will still continue, and the
+   * failure will only be reported at the end.
+   *
+   * IMPORTANT CAVEATS:
+   *
+   * 1. This can throw a false positive failure if an incomplete message is seen
+   *    on the wire but is later completed when the sub-message occurs again.
+   *    For this reason, a second pass is required to verify a failure, to be
+   *    truly robust.
+   *
+   * 2. This can return a false success if you are decoding into a message that
+   *    already has some sub-message fields present.  If the sub-message does
+   *    not occur in the binary payload, we will never visit it and discover the
+   *    incomplete sub-message.  For this reason, this check is only useful for
+   *    implemting ParseFromString() semantics.  For MergeFromString(), a
+   *    post-parse validation step will always be necessary. */
+  UPB_CHECK_REQUIRED = 2,
 };
 
 #define UPB_DECODE_MAXDEPTH(depth) ((depth) << 16)
 
-bool _upb_decode(const char *buf, size_t size, upb_msg *msg,
-                 const upb_msglayout *l, const upb_extreg *extreg, int options,
-                 upb_arena *arena);
+typedef enum {
+  UPB_DECODE_OK = 0,
+  // UPB_CHECK_REQUIRED failed (see above), but the parse otherwise succeeded.
+  UPB_DECODE_MISSING_REQUIRED = 1,
+  UPB_DECODE_OOM = 2,               // Arena alloc failed.
+  UPB_DECODE_BAD_UTF8 = 3,          // String field had bad UTF-8.
+  UPB_DECODE_MAXDEPTH_EXCEEDED = 4,
+  UPB_DECODE_MALFORMED = 5,         // Binary data was malformed.
+} upb_decodestatus;
+
+upb_decodestatus _upb_decode(const char *buf, size_t size, upb_msg *msg,
+                             const upb_msglayout *l, const upb_extreg *extreg,
+                             int options, upb_arena *arena);
 
 UPB_INLINE
-bool upb_decode(const char *buf, size_t size, upb_msg *msg,
-                const upb_msglayout *l, upb_arena *arena) {
+upb_decodestatus upb_decode(const char *buf, size_t size, upb_msg *msg,
+                            const upb_msglayout *l, upb_arena *arena) {
   return _upb_decode(buf, size, msg, l, NULL, 0, arena);
 }
 

--- a/upb/decode.h
+++ b/upb/decode.h
@@ -44,7 +44,7 @@ extern "C" {
 enum {
   /* If set, strings will alias the input buffer instead of copying into the
    * arena. */
-  UPB_DECODE_ALIAS = 1,
+  kUpb_DecodeOption_AliasString = 1,
 
   /* If set, the parse will return failure if any message is missing any required
    * fields when the message data ends.  The parse will still continue, and the
@@ -63,27 +63,29 @@ enum {
    *    incomplete sub-message.  For this reason, this check is only useful for
    *    implemting ParseFromString() semantics.  For MergeFromString(), a
    *    post-parse validation step will always be necessary. */
-  UPB_CHECK_REQUIRED = 2,
+  kUpb_DecodeOption_CheckRequired = 2,
 };
 
 #define UPB_DECODE_MAXDEPTH(depth) ((depth) << 16)
 
 typedef enum {
-  UPB_DECODE_OK = 0,
-  // UPB_CHECK_REQUIRED failed (see above), but the parse otherwise succeeded.
-  UPB_DECODE_MISSING_REQUIRED = 1,
-  UPB_DECODE_OOM = 2,               // Arena alloc failed.
-  UPB_DECODE_BAD_UTF8 = 3,          // String field had bad UTF-8.
-  UPB_DECODE_MAXDEPTH_EXCEEDED = 4,
-  UPB_DECODE_MALFORMED = 5,         // Binary data was malformed.
-} upb_decodestatus;
+  kUpb_DecodeStatus_Ok = 0,
+  kUpb_DecodeStatus_Malformed = 1,          // Wire format was corrupt
+  kUpb_DecodeStatus_OutOfMemory = 2,        // Arena alloc failed
+  kUpb_DecodeStatus_BadUtf8 = 3,            // String field had bad UTF-8
+  kUpb_DecodeStatus_MaxDepthExceeded = 4,   // Exceeded UPB_DECODE_MAXDEPTH
 
-upb_decodestatus _upb_decode(const char *buf, size_t size, upb_msg *msg,
+  // kUpb_DecodeOption_CheckRequired failed (see above), but the parse otherwise
+  // succeeded.
+  kUpb_DecodeStatus_MissingRequired = 5,
+} upb_DecodeStatus;
+
+upb_DecodeStatus _upb_decode(const char *buf, size_t size, upb_msg *msg,
                              const upb_msglayout *l, const upb_extreg *extreg,
                              int options, upb_arena *arena);
 
 UPB_INLINE
-upb_decodestatus upb_decode(const char *buf, size_t size, upb_msg *msg,
+upb_DecodeStatus upb_decode(const char *buf, size_t size, upb_msg *msg,
                             const upb_msglayout *l, upb_arena *arena) {
   return _upb_decode(buf, size, msg, l, NULL, 0, arena);
 }

--- a/upb/decode_fast.c
+++ b/upb/decode_fast.c
@@ -84,7 +84,10 @@ static const char *fastdecode_dispatch(UPB_PARSE_PARAMS) {
     if (UPB_LIKELY(overrun == d->limit)) {
       // Parse is finished.
       *(uint32_t*)msg |= hasbits;  // Sync hasbits.
-      return ptr;
+      const upb_msglayout *l = decode_totablep(table);
+      return UPB_UNLIKELY(l->required_count)
+                 ? decode_checkrequired(d, ptr, msg, l)
+                 : ptr;
     } else {
       data = overrun;
       UPB_MUSTTAIL return fastdecode_isdonefallback(UPB_PARSE_ARGS);

--- a/upb/decode_fast.c
+++ b/upb/decode_fast.c
@@ -68,9 +68,10 @@ typedef enum {
 UPB_NOINLINE
 static const char *fastdecode_isdonefallback(UPB_PARSE_PARAMS) {
   int overrun = data;
-  ptr = decode_isdonefallback_inl(d, ptr, overrun);
+  int status;
+  ptr = decode_isdonefallback_inl(d, ptr, overrun, &status);
   if (ptr == NULL) {
-    return fastdecode_err(d);
+    return fastdecode_err(d, status);
   }
   data = fastdecode_loadtag(ptr);
   UPB_MUSTTAIL return fastdecode_tagdispatch(UPB_PARSE_ARGS);
@@ -397,8 +398,7 @@ done:
                                                                                \
   ptr += tagbytes;                                                             \
   ptr = fastdecode_varint64(ptr, &val);                                        \
-  if (ptr == NULL)                                                             \
-    return fastdecode_err(d);                                                  \
+  if (ptr == NULL) return fastdecode_err(d, UPB_DECODE_MALFORMED);             \
   val = fastdecode_munge(val, valbytes, zigzag);                               \
   memcpy(dst, &val, valbytes);                                                 \
                                                                                \
@@ -406,14 +406,14 @@ done:
     fastdecode_nextret ret = fastdecode_nextrepeated(                          \
         d, dst, &ptr, &farr, data, tagbytes, valbytes);                        \
     switch (ret.next) {                                                        \
-    case FD_NEXT_SAMEFIELD:                                                    \
-      dst = ret.dst;                                                           \
-      goto again;                                                              \
-    case FD_NEXT_OTHERFIELD:                                                   \
-      data = ret.tag;                                                          \
-      UPB_MUSTTAIL return fastdecode_tagdispatch(UPB_PARSE_ARGS);              \
-    case FD_NEXT_ATLIMIT:                                                      \
-      return ptr;                                                              \
+      case FD_NEXT_SAMEFIELD:                                                  \
+        dst = ret.dst;                                                         \
+        goto again;                                                            \
+      case FD_NEXT_OTHERFIELD:                                                 \
+        data = ret.tag;                                                        \
+        UPB_MUSTTAIL return fastdecode_tagdispatch(UPB_PARSE_ARGS);            \
+      case FD_NEXT_ATLIMIT:                                                    \
+        return ptr;                                                            \
     }                                                                          \
   }                                                                            \
                                                                                \
@@ -462,7 +462,7 @@ static const char *fastdecode_topackedvarint(upb_decstate *d, const char *ptr,
   ptr = fastdecode_delimited(d, ptr, &fastdecode_topackedvarint, &ctx);        \
                                                                                \
   if (UPB_UNLIKELY(ptr == NULL)) {                                             \
-    return fastdecode_err(d);                                                  \
+    return fastdecode_err(d, UPB_DECODE_MALFORMED);                            \
   }                                                                            \
                                                                                \
   UPB_MUSTTAIL return fastdecode_dispatch(d, ptr, msg, table, hasbits, 0);
@@ -579,7 +579,7 @@ TAGBYTES(p)
                                                                             \
   if (UPB_UNLIKELY(fastdecode_boundscheck(ptr, size, d->limit_ptr) ||       \
                    (size % valbytes) != 0)) {                               \
-    return fastdecode_err(d);                                               \
+    return fastdecode_err(d, UPB_DECODE_MALFORMED);                         \
   }                                                                         \
                                                                             \
   upb_array **arr_p = fastdecode_fieldmem(msg, data);                       \
@@ -590,7 +590,7 @@ TAGBYTES(p)
   if (UPB_LIKELY(!arr)) {                                                   \
     *arr_p = arr = _upb_array_new(&d->arena, elems, elem_size_lg2);         \
     if (!arr) {                                                             \
-      return fastdecode_err(d);                                             \
+      return fastdecode_err(d, UPB_DECODE_MALFORMED);                       \
     }                                                                       \
   } else {                                                                  \
     _upb_array_resize(arr, elems, &d->arena);                               \
@@ -656,7 +656,7 @@ static const char *fastdecode_verifyutf8(upb_decstate *d, const char *ptr,
                                          uint64_t hasbits, uint64_t data) {
   upb_strview *dst = (upb_strview*)data;
   if (!decode_verifyutf8_inl(dst->data, dst->size)) {
-    return fastdecode_err(d);
+    return fastdecode_err(d, UPB_DECODE_BAD_UTF8);
   }
   UPB_MUSTTAIL return fastdecode_dispatch(UPB_PARSE_ARGS);
 }
@@ -670,16 +670,16 @@ static const char *fastdecode_verifyutf8(upb_decstate *d, const char *ptr,
                                                                                \
   if (UPB_UNLIKELY(fastdecode_boundscheck(ptr, size, d->limit_ptr))) {         \
     dst->size = 0;                                                             \
-    return fastdecode_err(d);                                                  \
+    return fastdecode_err(d, UPB_DECODE_MALFORMED);                            \
   }                                                                            \
                                                                                \
-  if (d->alias) {                                                              \
+  if (d->options & UPB_DECODE_ALIAS) {                                         \
     dst->data = ptr;                                                           \
     dst->size = size;                                                          \
   } else {                                                                     \
     char *data = upb_arena_malloc(&d->arena, size);                            \
     if (!data) {                                                               \
-      return fastdecode_err(d);                                                \
+      return fastdecode_err(d, UPB_DECODE_OOM);                                \
     }                                                                          \
     memcpy(data, ptr, size);                                                   \
     dst->data = data;                                                          \
@@ -732,7 +732,7 @@ static void fastdecode_docopy(upb_decstate *d, const char *ptr, uint32_t size,
   size_t common_has;                                                           \
   char *buf;                                                                   \
                                                                                \
-  UPB_ASSERT(!d->alias);                                                       \
+  UPB_ASSERT((d->options & UPB_DECODE_ALIAS) == 0);                            \
   UPB_ASSERT(fastdecode_checktag(data, tagbytes));                             \
                                                                                \
   dst = fastdecode_getfield(d, ptr, msg, &data, &hasbits, &farr,               \
@@ -752,22 +752,18 @@ static void fastdecode_docopy(upb_decstate *d, const char *ptr, uint32_t size,
   common_has = UPB_MIN(arena_has, (d->end - ptr) + 16);                        \
                                                                                \
   if (UPB_LIKELY(size <= 15 - tagbytes)) {                                     \
-    if (arena_has < 16)                                                        \
-      goto longstr;                                                            \
+    if (arena_has < 16) goto longstr;                                          \
     d->arena.head.ptr += 16;                                                   \
     memcpy(buf, ptr - tagbytes - 1, 16);                                       \
     dst->data = buf + tagbytes + 1;                                            \
   } else if (UPB_LIKELY(size <= 32)) {                                         \
-    if (UPB_UNLIKELY(common_has < 32))                                         \
-      goto longstr;                                                            \
+    if (UPB_UNLIKELY(common_has < 32)) goto longstr;                           \
     fastdecode_docopy(d, ptr, size, 32, buf, dst);                             \
   } else if (UPB_LIKELY(size <= 64)) {                                         \
-    if (UPB_UNLIKELY(common_has < 64))                                         \
-      goto longstr;                                                            \
+    if (UPB_UNLIKELY(common_has < 64)) goto longstr;                           \
     fastdecode_docopy(d, ptr, size, 64, buf, dst);                             \
   } else if (UPB_LIKELY(size < 128)) {                                         \
-    if (UPB_UNLIKELY(common_has < 128))                                        \
-      goto longstr;                                                            \
+    if (UPB_UNLIKELY(common_has < 128)) goto longstr;                          \
     fastdecode_docopy(d, ptr, size, 128, buf, dst);                            \
   } else {                                                                     \
     goto longstr;                                                              \
@@ -777,19 +773,19 @@ static void fastdecode_docopy(upb_decstate *d, const char *ptr, uint32_t size,
                                                                                \
   if (card == CARD_r) {                                                        \
     if (validate_utf8 && !decode_verifyutf8_inl(dst->data, dst->size)) {       \
-      return fastdecode_err(d);                                                \
+      return fastdecode_err(d, UPB_DECODE_BAD_UTF8);                           \
     }                                                                          \
     fastdecode_nextret ret = fastdecode_nextrepeated(                          \
         d, dst, &ptr, &farr, data, tagbytes, sizeof(upb_strview));             \
     switch (ret.next) {                                                        \
-    case FD_NEXT_SAMEFIELD:                                                    \
-      dst = ret.dst;                                                           \
-      goto again;                                                              \
-    case FD_NEXT_OTHERFIELD:                                                   \
-      data = ret.tag;                                                          \
-      UPB_MUSTTAIL return fastdecode_tagdispatch(UPB_PARSE_ARGS);              \
-    case FD_NEXT_ATLIMIT:                                                      \
-      return ptr;                                                              \
+      case FD_NEXT_SAMEFIELD:                                                  \
+        dst = ret.dst;                                                         \
+        goto again;                                                            \
+      case FD_NEXT_OTHERFIELD:                                                 \
+        data = ret.tag;                                                        \
+        UPB_MUSTTAIL return fastdecode_tagdispatch(UPB_PARSE_ARGS);            \
+      case FD_NEXT_ATLIMIT:                                                    \
+        return ptr;                                                            \
     }                                                                          \
   }                                                                            \
                                                                                \
@@ -820,7 +816,7 @@ static void fastdecode_docopy(upb_decstate *d, const char *ptr, uint32_t size,
     RETURN_GENERIC("string field tag mismatch\n");                             \
   }                                                                            \
                                                                                \
-  if (UPB_UNLIKELY(!d->alias)) {                                               \
+  if (UPB_UNLIKELY((d->options & UPB_DECODE_ALIAS) == 0)) {                    \
     UPB_MUSTTAIL return copyfunc(UPB_PARSE_ARGS);                              \
   }                                                                            \
                                                                                \
@@ -852,27 +848,27 @@ static void fastdecode_docopy(upb_decstate *d, const char *ptr, uint32_t size,
                                                                                \
   if (card == CARD_r) {                                                        \
     if (validate_utf8 && !decode_verifyutf8_inl(dst->data, dst->size)) {       \
-      return fastdecode_err(d);                                                \
+      return fastdecode_err(d, UPB_DECODE_BAD_UTF8);                           \
     }                                                                          \
     fastdecode_nextret ret = fastdecode_nextrepeated(                          \
         d, dst, &ptr, &farr, data, tagbytes, sizeof(upb_strview));             \
     switch (ret.next) {                                                        \
-    case FD_NEXT_SAMEFIELD:                                                    \
-      dst = ret.dst;                                                           \
-      if (UPB_UNLIKELY(!d->alias)) {                                           \
-        /* Buffer flipped and we can't alias any more. Bounce to */            \
-        /* copyfunc(), but via dispatch since we need to reload table */       \
-        /* data also. */                                                       \
-        fastdecode_commitarr(dst, &farr, sizeof(upb_strview));                 \
+      case FD_NEXT_SAMEFIELD:                                                  \
+        dst = ret.dst;                                                         \
+        if (UPB_UNLIKELY((d->options & UPB_DECODE_ALIAS) == 0)) {              \
+          /* Buffer flipped and we can't alias any more. Bounce to */          \
+          /* copyfunc(), but via dispatch since we need to reload table */     \
+          /* data also. */                                                     \
+          fastdecode_commitarr(dst, &farr, sizeof(upb_strview));               \
+          data = ret.tag;                                                      \
+          UPB_MUSTTAIL return fastdecode_tagdispatch(UPB_PARSE_ARGS);          \
+        }                                                                      \
+        goto again;                                                            \
+      case FD_NEXT_OTHERFIELD:                                                 \
         data = ret.tag;                                                        \
         UPB_MUSTTAIL return fastdecode_tagdispatch(UPB_PARSE_ARGS);            \
-      }                                                                        \
-      goto again;                                                              \
-    case FD_NEXT_OTHERFIELD:                                                   \
-      data = ret.tag;                                                          \
-      UPB_MUSTTAIL return fastdecode_tagdispatch(UPB_PARSE_ARGS);              \
-    case FD_NEXT_ATLIMIT:                                                      \
-      return ptr;                                                              \
+      case FD_NEXT_ATLIMIT:                                                    \
+        return ptr;                                                            \
     }                                                                          \
   }                                                                            \
                                                                                \
@@ -964,7 +960,9 @@ static const char *fastdecode_tosubmsg(upb_decstate *d, const char *ptr,
     RETURN_GENERIC("submessage field tag mismatch\n");                    \
   }                                                                       \
                                                                           \
-  if (--d->depth == 0) return fastdecode_err(d);                          \
+  if (--d->depth == 0) {                                                  \
+    return fastdecode_err(d, UPB_DECODE_MAXDEPTH_EXCEEDED);               \
+  }                                                                       \
                                                                           \
   upb_msg **dst;                                                          \
   uint32_t submsg_idx = (data >> 16) & 0xff;                              \
@@ -1000,7 +998,7 @@ static const char *fastdecode_tosubmsg(upb_decstate *d, const char *ptr,
   ptr = fastdecode_delimited(d, ptr, fastdecode_tosubmsg, &submsg);       \
                                                                           \
   if (UPB_UNLIKELY(ptr == NULL || d->end_group != DECODE_NOGROUP)) {      \
-    return fastdecode_err(d);                                             \
+    return fastdecode_err(d, UPB_DECODE_MALFORMED);                       \
   }                                                                       \
                                                                           \
   if (card == CARD_r) {                                                   \

--- a/upb/decode_internal.h
+++ b/upb/decode_internal.h
@@ -35,9 +35,10 @@
 
 #include <setjmp.h>
 
+#include "third_party/utf8_range/utf8_range.h"
+#include "upb/decode.h"
 #include "upb/msg_internal.h"
 #include "upb/upb_internal.h"
-#include "third_party/utf8_range/utf8_range.h"
 
 /* Must be last. */
 #include "upb/port_def.inc"
@@ -51,9 +52,10 @@ typedef struct upb_decstate {
   const char *unknown;     /* Start of unknown data. */
   const upb_extreg *extreg;  /* For looking up extensions during the parse. */
   int limit;               /* Submessage limit relative to end. */
-  int depth;
+  int depth;               /* Tracks recursion depth to bound stack usage. */
   uint32_t end_group;   /* field number of END_GROUP tag, else DECODE_NOGROUP */
-  bool alias;
+  uint16_t options;
+  bool missing_required;
   char patch[32];
   upb_arena arena;
   jmp_buf err;
@@ -66,7 +68,7 @@ typedef struct upb_decstate {
  * of our optimizations. That is also why we must declare it in a separate file,
  * otherwise the compiler will see that it calls longjmp() and deduce that it is
  * noreturn. */
-const char *fastdecode_err(upb_decstate *d);
+const char *fastdecode_err(upb_decstate *d, int status);
 
 extern const uint8_t upb_utf8_offsets[];
 
@@ -106,13 +108,14 @@ UPB_INLINE const upb_msglayout *decode_totablep(intptr_t table) {
 
 UPB_INLINE
 const char *decode_isdonefallback_inl(upb_decstate *d, const char *ptr,
-                                      int overrun) {
+                                      int overrun, int *status) {
   if (overrun < d->limit) {
     /* Need to copy remaining data into patch buffer. */
     UPB_ASSERT(overrun < 16);
     if (d->unknown_msg) {
       if (!_upb_msg_addunknown(d->unknown_msg, d->unknown, ptr - d->unknown,
                                &d->arena)) {
+        *status = UPB_DECODE_OOM;
         return NULL;
       }
       d->unknown = &d->patch[0] + overrun;
@@ -123,10 +126,11 @@ const char *decode_isdonefallback_inl(upb_decstate *d, const char *ptr,
     d->end = &d->patch[16];
     d->limit -= 16;
     d->limit_ptr = d->end + d->limit;
-    d->alias = false;
+    d->options &= ~UPB_DECODE_ALIAS;
     UPB_ASSERT(ptr < d->limit_ptr);
     return ptr;
   } else {
+    *status = UPB_DECODE_MALFORMED;
     return NULL;
   }
 }

--- a/upb/decode_internal.h
+++ b/upb/decode_internal.h
@@ -59,6 +59,11 @@ typedef struct upb_decstate {
   char patch[32];
   upb_arena arena;
   jmp_buf err;
+
+#ifndef NDEBUG
+  const char *debug_tagstart;
+  const char *debug_valstart;
+#endif
 } upb_decstate;
 
 /* Error function that will abort decoding with longjmp(). We can't declare this
@@ -115,7 +120,7 @@ const char *decode_isdonefallback_inl(upb_decstate *d, const char *ptr,
     if (d->unknown_msg) {
       if (!_upb_msg_addunknown(d->unknown_msg, d->unknown, ptr - d->unknown,
                                &d->arena)) {
-        *status = UPB_DECODE_OOM;
+        *status = kUpb_DecodeStatus_OutOfMemory;
         return NULL;
       }
       d->unknown = &d->patch[0] + overrun;
@@ -126,11 +131,11 @@ const char *decode_isdonefallback_inl(upb_decstate *d, const char *ptr,
     d->end = &d->patch[16];
     d->limit -= 16;
     d->limit_ptr = d->end + d->limit;
-    d->options &= ~UPB_DECODE_ALIAS;
+    d->options &= ~kUpb_DecodeOption_AliasString;
     UPB_ASSERT(ptr < d->limit_ptr);
     return ptr;
   } else {
-    *status = UPB_DECODE_MALFORMED;
+    *status = kUpb_DecodeStatus_Malformed;
     return NULL;
   }
 }

--- a/upb/def.c
+++ b/upb/def.c
@@ -1592,6 +1592,7 @@ static void make_layout(symtab_addctx *ctx, const upb_msgdef *m) {
   l->fields = fields;
   l->subs = subs;
   l->table_mask = 0;
+  l->required_count = 0;
 
   if (upb_msgdef_extrangecount(m) > 0) {
     if (google_protobuf_MessageOptions_message_set_wire_format(m->opts)) {
@@ -1653,6 +1654,19 @@ static void make_layout(symtab_addctx *ctx, const upb_msgdef *m) {
 
   /* Assign hasbits for required fields first. */
   size_t hasbit = 0;
+
+  for (int i = 0; i < m->field_count; i++) {
+    const upb_fielddef* f = &m->fields[i];
+    upb_msglayout_field *field = &fields[upb_fielddef_index(f)];
+    if (upb_fielddef_label(f) == UPB_LABEL_REQUIRED) {
+      field->presence = ++hasbit;
+      if (hasbit >= 63) {
+        symtab_errf(ctx, "Message with >=63 required fields: %s",
+                    upb_msgdef_fullname(m));
+      }
+      l->required_count++;
+    }
+  }
 
   /* Allocate hasbits and set basic field attributes. */
   sublayout_count = 0;
@@ -2998,7 +3012,7 @@ bool _upb_symtab_loaddefinit(upb_symtab *s, const upb_def_init *init) {
   }
 
   file = google_protobuf_FileDescriptorProto_parse_ex(
-      init->descriptor.data, init->descriptor.size, NULL, UPB_DECODE_ALIAS,
+      init->descriptor.data, init->descriptor.size, NULL, kUpb_DecodeOption_AliasString,
       arena);
   s->bytes_loaded += init->descriptor.size;
 

--- a/upb/def.c
+++ b/upb/def.c
@@ -2200,7 +2200,7 @@ static void create_fielddef(
       if (ctx->symtab->allow_name_conflicts &&
           deftype(existing_v) == UPB_DEFTYPE_FIELD_JSONNAME) {
         // Field name takes precedence over json name.
-        upb_strtable_remove(&m->ntof, shortname, strlen(shortname), NULL);
+        upb_strtable_remove2(&m->ntof, shortname, strlen(shortname), NULL);
       } else {
         symtab_errf(ctx, "duplicate field name (%s)", shortname);
       }

--- a/upb/def.c
+++ b/upb/def.c
@@ -2214,7 +2214,7 @@ static void create_fielddef(
       if (ctx->symtab->allow_name_conflicts &&
           deftype(existing_v) == UPB_DEFTYPE_FIELD_JSONNAME) {
         // Field name takes precedence over json name.
-        upb_strtable_remove2(&m->ntof, shortname, strlen(shortname), NULL);
+        upb_strtable_remove(&m->ntof, shortname, NULL);
       } else {
         symtab_errf(ctx, "duplicate field name (%s)", shortname);
       }

--- a/upb/json_encode.c
+++ b/upb/json_encode.c
@@ -374,7 +374,7 @@ static void jsonenc_any(jsonenc *e, const upb_msg *msg, const upb_msgdef *m) {
   upb_arena *arena = jsonenc_arena(e);
   upb_msg *any = upb_msg_new(any_m, arena);
 
-  if (!upb_decode(value.data, value.size, any, any_layout, arena)) {
+  if (upb_decode(value.data, value.size, any, any_layout, arena)) {
     jsonenc_err(e, "Error decoding message in Any");
   }
 

--- a/upb/msg.c
+++ b/upb/msg.c
@@ -392,7 +392,7 @@ failure:
   for (end = e, e = start; e < end; e++) {
     const upb_msglayout_ext *ext = *e;
     extreg_key(buf, ext->extendee, ext->field.number);
-    upb_strtable_remove(&r->exts, buf, EXTREG_KEY_SIZE, NULL);
+    upb_strtable_remove2(&r->exts, buf, EXTREG_KEY_SIZE, NULL);
   }
   return false;
 }

--- a/upb/msg_internal.h
+++ b/upb/msg_internal.h
@@ -169,7 +169,6 @@ typedef enum {
 struct upb_msglayout {
   const upb_msglayout_sub *subs;
   const upb_msglayout_field *fields;
-  uint64_t required_mask;
   /* Must be aligned to sizeof(void*).  Doesn't include internal members like
    * unknown fields, extension dict, pointer to msglayout, etc. */
   uint16_t size;
@@ -177,8 +176,10 @@ struct upb_msglayout {
   uint8_t ext;  // upb_msgext_mode, declared as uint8_t so sizeof(ext) == 1
   uint8_t dense_below;
   uint8_t table_mask;
-  /* To constant-initialize the tables of variable length, we need a flexible
-   * array member, and we need to compile in C99 mode. */
+  uint8_t required_count;  // Required fields have the lowest hasbits.
+  /* To statically initialize the tables of variable length, we need a flexible
+   * array member, and we need to compile in gnu99 mode (constant initialization
+   * of flexible array members is a GNU extension, not in C99 unfortunately. */
   _upb_fasttable_entry fasttable[];
 };
 

--- a/upb/msg_test.cc
+++ b/upb/msg_test.cc
@@ -158,7 +158,8 @@ TEST(MessageTest, MessageSet) {
 
 TEST(MessageTest, Proto2Enum) {
   upb::Arena arena;
-  upb_test_Proto2FakeEnumMessage *fake_msg = upb_test_Proto2FakeEnumMessage_new(arena.ptr());
+  upb_test_Proto2FakeEnumMessage *fake_msg =
+      upb_test_Proto2FakeEnumMessage_new(arena.ptr());
 
   upb_test_Proto2FakeEnumMessage_set_optional_enum(fake_msg, 999);
 
@@ -230,4 +231,90 @@ TEST(MessageTest, TestBadUTF8) {
   std::string serialized("r\x03\xed\xa0\x81");
   EXPECT_EQ(nullptr, protobuf_test_messages_proto3_TestAllTypesProto3_parse(
                          serialized.data(), serialized.size(), arena.ptr()));
+}
+
+TEST(MessageTest, RequiredFieldsTopLevelMessage) {
+  upb::Arena arena;
+  upb_test_TestRequiredFields *test_msg;
+  upb_test_EmptyMessage *empty_msg;
+
+  // Succeeds, because we did not request required field checks.
+  test_msg = upb_test_TestRequiredFields_parse(NULL, 0, arena.ptr());
+  EXPECT_NE(nullptr, test_msg);
+
+  // Fails, because required fields are missing.
+  EXPECT_EQ(kUpb_DecodeStatus_MissingRequired,
+            _upb_decode(NULL, 0, test_msg, &upb_test_TestRequiredFields_msginit,
+                        NULL, kUpb_DecodeOption_CheckRequired, arena.ptr()));
+
+  upb_test_TestRequiredFields_set_required_int32(test_msg, 1);
+  size_t size;
+  char *serialized =
+      upb_test_TestRequiredFields_serialize(test_msg, arena.ptr(), &size);
+  ASSERT_TRUE(serialized != nullptr);
+  EXPECT_NE(0, size);
+
+  // Fails, but the code path is slightly different because the serialized
+  // payload is not empty.
+  EXPECT_EQ(kUpb_DecodeStatus_MissingRequired,
+            _upb_decode(serialized, size, test_msg,
+                        &upb_test_TestRequiredFields_msginit, NULL,
+                        kUpb_DecodeOption_CheckRequired, arena.ptr()));
+
+  empty_msg = upb_test_EmptyMessage_new(arena.ptr());
+  upb_test_TestRequiredFields_set_required_int32(test_msg, 1);
+  upb_test_TestRequiredFields_set_required_int64(test_msg, 2);
+  upb_test_TestRequiredFields_set_required_message(test_msg, empty_msg);
+
+  // Succeeds, because required fields are present (though not in the input).
+  EXPECT_EQ(kUpb_DecodeStatus_Ok,
+            _upb_decode(NULL, 0, test_msg, &upb_test_TestRequiredFields_msginit,
+                        NULL, kUpb_DecodeOption_CheckRequired, arena.ptr()));
+
+  // Serialize a complete payload.
+  serialized =
+      upb_test_TestRequiredFields_serialize(test_msg, arena.ptr(), &size);
+  ASSERT_TRUE(serialized != nullptr);
+  EXPECT_NE(0, size);
+
+  upb_test_TestRequiredFields *test_msg2 = upb_test_TestRequiredFields_parse_ex(
+      serialized, size, NULL, kUpb_DecodeOption_CheckRequired, arena.ptr());
+  EXPECT_NE(nullptr, test_msg2);
+
+  // When we add an incomplete sub-message, this is not flagged by the parser.
+  // This makes parser checking unsuitable for MergeFrom().
+  upb_test_TestRequiredFields_set_optional_message(
+      test_msg2, upb_test_TestRequiredFields_new(arena.ptr()));
+  EXPECT_EQ(kUpb_DecodeStatus_Ok,
+            _upb_decode(serialized, size, test_msg2,
+                        &upb_test_TestRequiredFields_msginit, NULL,
+                        kUpb_DecodeOption_CheckRequired, arena.ptr()));
+}
+
+TEST(MessageTest, RequiredFieldsSubMessage) {
+  upb::Arena arena;
+  upb_test_TestRequiredFields *test_msg =
+      upb_test_TestRequiredFields_new(arena.ptr());
+  upb_test_SubMessageHasRequired *sub_msg =
+      upb_test_SubMessageHasRequired_new(arena.ptr());
+  upb_test_EmptyMessage *empty_msg = upb_test_EmptyMessage_new(arena.ptr());
+
+  upb_test_SubMessageHasRequired_set_optional_message(sub_msg, test_msg);
+  size_t size;
+  char *serialized =
+      upb_test_SubMessageHasRequired_serialize(sub_msg, arena.ptr(), &size);
+  EXPECT_NE(0, size);
+
+  // No parse error when parsing normally.
+  EXPECT_NE(nullptr, upb_test_SubMessageHasRequired_parse(serialized, size, arena.ptr()));
+
+  fprintf(stderr, "YO, here goes!\n");
+  // Parse error when verifying required fields, due to incomplete sub-message.
+  EXPECT_EQ(nullptr, upb_test_SubMessageHasRequired_parse_ex(
+                         serialized, size, NULL,
+                         kUpb_DecodeOption_CheckRequired, arena.ptr()));
+
+  upb_test_TestRequiredFields_set_required_int32(test_msg, 1);
+  upb_test_TestRequiredFields_set_required_int64(test_msg, 2);
+  upb_test_TestRequiredFields_set_required_message(test_msg, empty_msg);
 }

--- a/upb/msg_test.cc
+++ b/upb/msg_test.cc
@@ -308,7 +308,6 @@ TEST(MessageTest, RequiredFieldsSubMessage) {
   // No parse error when parsing normally.
   EXPECT_NE(nullptr, upb_test_SubMessageHasRequired_parse(serialized, size, arena.ptr()));
 
-  fprintf(stderr, "YO, here goes!\n");
   // Parse error when verifying required fields, due to incomplete sub-message.
   EXPECT_EQ(nullptr, upb_test_SubMessageHasRequired_parse_ex(
                          serialized, size, NULL,
@@ -317,4 +316,13 @@ TEST(MessageTest, RequiredFieldsSubMessage) {
   upb_test_TestRequiredFields_set_required_int32(test_msg, 1);
   upb_test_TestRequiredFields_set_required_int64(test_msg, 2);
   upb_test_TestRequiredFields_set_required_message(test_msg, empty_msg);
+
+  serialized =
+      upb_test_SubMessageHasRequired_serialize(sub_msg, arena.ptr(), &size);
+  EXPECT_NE(0, size);
+
+  // No parse error; sub-message now is complete.
+  EXPECT_NE(nullptr, upb_test_SubMessageHasRequired_parse_ex(
+                         serialized, size, NULL,
+                         kUpb_DecodeOption_CheckRequired, arena.ptr()));
 }

--- a/upb/msg_test.proto
+++ b/upb/msg_test.proto
@@ -79,3 +79,17 @@ message Proto2FakeEnumMessage {
   repeated int32 repeated_enum = 2;
   repeated int32 packed_enum = 3 [packed = true];
 }
+
+message EmptyMessage {}
+
+message TestRequiredFields {
+  required int32 required_int32 = 1;
+  optional int32 optional_int32 = 2;
+  required int64 required_int64 = 3;
+  optional TestRequiredFields optional_message = 4;
+  required EmptyMessage required_message = 5;
+}
+
+message SubMessageHasRequired {
+  optional TestRequiredFields optional_message = 1;
+}

--- a/upb/table.c
+++ b/upb/table.c
@@ -812,7 +812,7 @@ bool upb_inttable_next2(const upb_inttable *t, uintptr_t *key, upb_value *val,
     while (++i < t->array_size) {
       upb_tabval ent = t->array[i];
       if (upb_arrhas(ent)) {
-        *key = i; 
+        *key = i;
         *val = _upb_value_val(ent.val);
         *iter = i;
         return true;

--- a/upb/table.c
+++ b/upb/table.c
@@ -516,8 +516,8 @@ bool upb_strtable_lookup2(const upb_strtable *t, const char *key, size_t len,
   return lookup(&t->t, strkey2(key, len), v, hash, &streql);
 }
 
-bool upb_strtable_remove(upb_strtable *t, const char *key, size_t len,
-                         upb_value *val) {
+bool upb_strtable_remove2(upb_strtable *t, const char *key, size_t len,
+                          upb_value *val) {
   uint32_t hash = table_hash(key, len);
   upb_tabkey tabkey;
   return rm(&t->t, strkey2(key, len), val, &tabkey, hash, &streql);
@@ -812,7 +812,7 @@ bool upb_inttable_next2(const upb_inttable *t, uintptr_t *key, upb_value *val,
     while (++i < t->array_size) {
       upb_tabval ent = t->array[i];
       if (upb_arrhas(ent)) {
-        *key = i;
+        *key = i; 
         *val = _upb_value_val(ent.val);
         *iter = i;
         return true;

--- a/upb/table_internal.h
+++ b/upb/table_internal.h
@@ -245,8 +245,13 @@ UPB_INLINE bool upb_strtable_lookup(const upb_strtable *t, const char *key,
 /* Removes an item from the table.  Returns true if the remove was successful,
  * and stores the removed item in *val if non-NULL. */
 bool upb_inttable_remove(upb_inttable *t, uintptr_t key, upb_value *val);
-bool upb_strtable_remove(upb_strtable *t, const char *key, size_t len,
+bool upb_strtable_remove2(upb_strtable *t, const char *key, size_t len,
                           upb_value *val);
+
+UPB_INLINE bool upb_strtable_remove(upb_strtable *t, const char *key,
+                                    upb_value *v) {
+  return upb_strtable_remove2(t, key, strlen(key), v);
+}
 
 /* Updates an existing entry in an inttable.  If the entry does not exist,
  * returns false and does nothing.  Unlike insert/remove, this does not

--- a/upbc/message_layout.cc
+++ b/upbc/message_layout.cc
@@ -167,7 +167,7 @@ void MessageLayout::PlaceNonOneofFields(
 
   // Place/count hasbits.
   hasbit_count_ = 0;
-  required_mask_ = 0;
+  required_count_ = 0;
   for (auto field : FieldHotnessOrder(descriptor)) {
     if (HasHasbit(field)) {
       // We don't use hasbit 0, so that 0 can indicate "no presence" in the
@@ -175,13 +175,15 @@ void MessageLayout::PlaceNonOneofFields(
       int index = ++hasbit_count_;
       hasbit_indexes_[field] = index;
       if (field->is_required()) {
-        if (index > 63) {
-          std::cerr << "upb does not support messages with more than 64 "
+        if (index >= 63) {
+          // This could be fixed in the decoder without too much trouble.  But
+          // we expect this to be so rare that we don't worry about it for now.
+          std::cerr << "upb does not support messages with more than 63 "
                        "required fields: "
                     << field->full_name() << "\n";
           exit(1);
         }
-        required_mask_ |= 1 << index;
+        required_count_++;
       }
     }
   }

--- a/upbc/message_layout.h
+++ b/upbc/message_layout.h
@@ -85,6 +85,10 @@ class MessageLayout {
 
   Size message_size() const { return size_; }
 
+  int hasbit_count() const { return hasbit_count_; }
+  int hasbit_bytes() const { return hasbit_bytes_; }
+  uint64_t required_mask() const { return required_mask_; }
+
   static bool HasHasbit(const google::protobuf::FieldDescriptor* field);
   static SizeAndAlign SizeOfUnwrapped(
       const google::protobuf::FieldDescriptor* field);
@@ -126,6 +130,9 @@ class MessageLayout {
       oneof_case_offsets_;
   Size maxalign_;
   Size size_;
+  int hasbit_count_;
+  int hasbit_bytes_;
+  uint64_t required_mask_;
 };
 
 // Returns fields in order of "hotness", eg. how frequently they appear in
@@ -140,7 +147,8 @@ inline std::vector<const google::protobuf::FieldDescriptor*> FieldHotnessOrder(
   std::sort(fields.begin(), fields.end(),
             [](const google::protobuf::FieldDescriptor* a,
                const google::protobuf::FieldDescriptor* b) {
-              return a->number() < b->number();
+              return std::make_pair(!a->is_required(), a->number()) <
+                     std::make_pair(!b->is_required(), b->number());
             });
   return fields;
 }

--- a/upbc/message_layout.h
+++ b/upbc/message_layout.h
@@ -87,7 +87,9 @@ class MessageLayout {
 
   int hasbit_count() const { return hasbit_count_; }
   int hasbit_bytes() const { return hasbit_bytes_; }
-  uint64_t required_mask() const { return required_mask_; }
+
+  // Required fields always have the lowest hasbits.
+  int required_count() const { return required_count_; }
 
   static bool HasHasbit(const google::protobuf::FieldDescriptor* field);
   static SizeAndAlign SizeOfUnwrapped(
@@ -132,7 +134,7 @@ class MessageLayout {
   Size size_;
   int hasbit_count_;
   int hasbit_bytes_;
-  uint64_t required_mask_;
+  int required_count_;
 };
 
 // Returns fields in order of "hotness", eg. how frequently they appear in

--- a/upbc/protoc-gen-upb.cc
+++ b/upbc/protoc-gen-upb.cc
@@ -83,6 +83,12 @@ void AddEnums(const protobuf::Descriptor* message,
   }
 }
 
+template <class T>
+void SortDefs(std::vector<T>* defs) {
+  std::sort(defs->begin(), defs->end(),
+            [](T a, T b) { return a->full_name() < b->full_name(); });
+}
+
 std::vector<const protobuf::EnumDescriptor*> SortedEnums(
     const protobuf::FileDescriptor* file) {
   std::vector<const protobuf::EnumDescriptor*> enums;
@@ -92,6 +98,7 @@ std::vector<const protobuf::EnumDescriptor*> SortedEnums(
   for (int i = 0; i < file->message_type_count(); i++) {
     AddEnums(file->message_type(i), &enums);
   }
+  SortDefs(&enums);
   return enums;
 }
 
@@ -1354,7 +1361,8 @@ void WriteExtension(const protobuf::FieldDescriptor* ext, Output& output) {
   output("    &$0,\n", MessageInit(ext->containing_type()));
   if (ext->message_type()) {
     output("    {.submsg = &$0},\n", MessageInit(ext->message_type()));
-  } else if (ext->enum_type() && ext->enum_type()->file()->syntax() == protobuf::FileDescriptor::SYNTAX_PROTO2) {
+  } else if (ext->enum_type() && ext->enum_type()->file()->syntax() ==
+                                     protobuf::FileDescriptor::SYNTAX_PROTO2) {
     output("    {.subenum = &$0},\n", EnumInit(ext->enum_type()));
   } else {
     output("    {.submsg = NULL},\n");

--- a/upbc/protoc-gen-upb.cc
+++ b/upbc/protoc-gen-upb.cc
@@ -1253,12 +1253,12 @@ void WriteMessage(const protobuf::Descriptor* message, Output& output,
   output("  $0,\n", submsgs_array_ref);
   output("  $0,\n", fields_array_ref);
   output("  $0, $1, $2, $3, $4, $5,\n",
-         layout.required_mask(),
          GetSizeInit(layout.message_size()),
          field_number_order.size(),
          msgext,
          dense_below,
-         table_mask
+         table_mask,
+         layout.required_count()
   );
   if (!table.empty()) {
     output("  UPB_FASTTABLE_INIT({\n");


### PR DESCRIPTION
This PR adds required field checking to the parser. While parsing, a check will be performed at the end of each message or sub-message that occurs in the input that all required fields are present. If a special decoder option is set (`kUpb_DecodeOption_CheckRequired`) the parse will fail with a special error code (`kUpb_DecodeStatus_MissingRequired`) if the parse succeeded in every way except for having missing required fields.

This is not a complete required fields solution on its own. In particular:
- This check can throw false positives if a sub-message is parsed as incomplete, but the sub-message re-occurs later in the payload and "fills in" the missing required fields.
- This check can fail to detect missing required fields in a sub-message if we are merging against an existing message. The existing message could have an incomplete sub-message; if the sub-message does not occur in the binary payload, the parser will never visit it and detect that it is incomplete.

For these reasons, we also need a function that will visit the entire message tree checking for required fields (this is coming in a follow-up PR). This separate function will be used as a second pass for the hard cases. Most cases will be able to avoid the second pass -- which is good for performance -- but edge cases such as `MergeFromString()`.

The general implementation strategy here is:
1. The message mini-table stores how many required fields the message has.
2. Required fields always have the lowest hasbits.
3. The parser will form a mask at parse time to check against the hasbits of a message.

There is also a bit of optimization in this PR to avoid perf or code size regression. In particular:
1. For unknown fields we no longer preserve a pointer to the beginning of the field, for the off-chance that the field will be unknown. Instead we walk the pointer backwards to find the beginning of the field when it is unknown (luckily we have just enough info to walk backward through varints).
2. The structure of the parse loop is changed a bit; the condition of the main `while()` loop is clearer. When fasttable parsing is enabled we need to try parsing at least one field before fast dispatch; this case is handled now in a way that doesn't penalize the parser when fasttable is *not* enabled.

Thanks to these optimizations, this PR ends up being code size neutral and perf positive:

```
name                                      old time/op  new time/op  delta
ArenaInitialBlockOneAlloc                 7.00ns ± 1%  6.29ns ± 0%  -10.26%  (p=0.000 n=12+11)
ArenaOneAlloc                             21.7ns ± 1%  20.8ns ± 1%   -3.99%  (p=0.000 n=12+12)
LoadAdsDescriptor_Proto2                  14.7ms ± 2%  15.2ms ± 7%   +3.34%  (p=0.000 n=10+12)
LoadAdsDescriptor_Upb                     3.86ms ± 1%  3.80ms ± 2%   -1.56%  (p=0.001 n=12+10)
LoadDescriptor_Proto2                      247µs ± 3%   247µs ± 1%     ~     (p=0.843 n=12+12)
LoadDescriptor_Upb                        48.6µs ± 3%  47.6µs ± 1%   -2.04%  (p=0.000 n=11+10)
Parse_Proto2<FileDesc,InitBlock,Copy>     16.9µs ± 2%  18.0µs ±18%     ~     (p=0.093 n=10+12)
Parse_Proto2<FileDesc,NoArena,Copy>       31.8µs ±10%  31.3µs ±11%     ~     (p=0.590 n=12+12)
Parse_Proto2<FileDescSV,InitBlock,Alias>  17.0µs ± 4%  17.8µs ±19%     ~     (p=0.203 n=10+12)
Parse_Proto2<FileDesc,UseArena,Copy>      19.9µs ± 3%  20.0µs ± 4%     ~     (p=0.756 n=10+11)
Parse_Upb_FileDesc<InitBlock,Alias>       9.53µs ± 1%  8.61µs ± 0%   -9.61%  (p=0.000 n=10+10)
Parse_Upb_FileDesc<InitBlock,Copy>        11.4µs ± 0%  10.2µs ± 0%  -10.84%  (p=0.000 n=12+11)
Parse_Upb_FileDesc<UseArena,Alias>        9.93µs ± 1%  9.08µs ± 2%   -8.54%  (p=0.000 n=11+10)
Parse_Upb_FileDesc<UseArena,Copy>         11.7µs ± 1%  10.7µs ± 0%   -9.16%  (p=0.000 n=12+11)
SerializeDescriptor_Proto2                6.49µs ±37%  5.52µs ± 1%  -14.96%  (p=0.001 n=12+11)
SerializeDescriptor_Upb                   11.3µs ± 0%  11.7µs ± 1%   +3.19%  (p=0.000 n=11+11)


    FILE SIZE        VM SIZE    
 --------------  -------------- 
  +0.6%    +176  +0.7%    +176    upb/def.c
    +4.0%    +144  +4.0%    +144    resolve_msgdef
    +1.4%     +32  +1.4%     +32    create_fielddef
  +0.5%     +39  +0.4%     +32    tests/conformance_upb.c
    +0.7%     +38  +0.7%     +38    write_output
    +7.4%      +7  [ = ]       0    stderr
    -9.1%      -6 -23.1%      -6    parse_proto.msg
  +0.2%      +7  [ = ]       0    upb/msg.c
    +4.1%      +7  [ = ]       0    _upb_msg_addunknown
  -0.1%      -6  [ = ]       0    upb/table.c
    [NEW]    +437  [NEW]    +392    upb_strtable_remove2
    -1.7%      -7  [ = ]       0    upb_inttable_sizedinit
    [DEL]    -436  [DEL]    -392    upb_strtable_remove
 -57.1%     -16 -57.1%     -16    [LOAD #2 [RX]]
    +100%      +3  +100%      +3    __libc_csu_fini
   -76.0%     -19 -76.0%     -19    [LOAD #2 [RX]]
  -0.3%     -26  -0.8%     -64    upb/decode.c
    [NEW]    +157  [NEW]    +112    decode_checkrequired
    +3.1%     +16  +3.4%     +16    _upb_decode
    +5.2%     +16  +6.1%     +16    decode_checkenum_slow
    +3.0%     +16  +3.3%     +16    decode_enum_packed
    +3.7%      +9  +8.3%     +16    decode_isdonefallback
   -15.0%     -16 -22.2%     -16    decode_err
    -3.9%    -224  -3.9%    -224    decode_msg
  -5.4%    -134  [ = ]       0    [Unmapped]
  +0.0%     +40  +0.1%    +128    TOTAL
```