### PR TITLE
Remove uses of `incompatible_use_toolchain_transition` now that it is…

### DIFF
--- a/bazel/upb_proto_library.bzl
+++ b/bazel/upb_proto_library.bzl
@@ -311,7 +311,6 @@ _upb_proto_library_aspect = aspect(
     attr_aspects = ["deps"],
     fragments = ["cpp"],
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
 )
 
 upb_proto_library = rule(
@@ -366,7 +365,6 @@ _upb_proto_reflection_library_aspect = aspect(
     attr_aspects = ["deps"],
     fragments = ["cpp"],
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
 )
 
 upb_proto_reflection_library = rule(


### PR DESCRIPTION
… enabled by

default in Bazel 5.0.

This is a step towards removing it entirely.

Part of https://github.com/bazelbuild/bazel/issues/14127.