### PR TITLE
Fix big endian handling of enums

### DIFF
--- a/upb/decode.c
+++ b/upb/decode.c
@@ -282,6 +282,7 @@ static void decode_munge(int type, wireval *val) {
     }
     case UPB_DESCRIPTOR_TYPE_INT32:
     case UPB_DESCRIPTOR_TYPE_UINT32:
+    case UPB_DESCRIPTOR_TYPE_ENUM:
       if (!_upb_isle()) {
         /* The next stage will memcpy(dst, &val, 4) */
         val->uint32_val = val->uint64_val;

--- a/upb/decode.c
+++ b/upb/decode.c
@@ -484,6 +484,7 @@ static const char *decode_enum_packed(upb_decstate *d, const char *ptr,
   while (!decode_isdone(d, &ptr)) {
     wireval elem;
     ptr = decode_varint64(d, ptr, &elem.uint64_val);
+    decode_munge(field->descriptortype, &elem);
     if (!decode_checkenum(d, ptr, msg, e, field, &elem)) {
       continue;
     }


### PR DESCRIPTION
Previously using an enum for a field on big-endian process such as the
s390x would fail to decode properly. We need to munge it in the correct
byte order before decoding it.