### PR TITLE
Fix LUA out-of-range checks to handle integer overflow

### DIFF
--- a/upb/bindings/lua/upb.c
+++ b/upb/bindings/lua/upb.c
@@ -181,7 +181,7 @@ const char *lupb_checkstring(lua_State *L, int narg, size_t *len) {
 /* Unlike luaL_checkinteger, these do not implicitly convert from string or
  * round an existing double value.  We allow floating-point input, but only if
  * the actual value is integral. */
-#define INTCHECK(type, ctype, min, max_bits)                                   \
+#define INTCHECK(type, ctype, min, max)                                        \
   ctype lupb_check##type(lua_State *L, int narg) {                             \
     double n;                                                                  \
     if (lua_isinteger(L, narg)) {                                              \
@@ -192,9 +192,17 @@ const char *lupb_checkstring(lua_State *L, int narg, size_t *len) {
     luaL_checktype(L, narg, LUA_TNUMBER);                                      \
     n = lua_tonumber(L, narg);                                                 \
                                                                                \
-    /* Check this double has no fractional part and remains in bounds. */      \
+    /* Check this double has no fractional part and remains in bounds.         \
+     * Consider INT64_MIN and INT64_MAX:                                       \
+     * 1. INT64_MIN -(2^63) is a power of 2, so this converts to a double.     \
+     * 2. INT64_MAX (2^63 - 1) is not a power of 2, and conversion of          \
+     * out-of-range integer values to a double can lead to undefined behavior. \
+     * On some compilers, this conversion can return 0, but it also can return \
+     * the max value. To deal with this, we can first divide by 2 to prevent   \
+     * the overflow, multiply it back, and add 1 to find the true limit. */    \
     double i;                                                                  \
-    if ((modf(n, &i) != 0.0) || n < min || n >= ldexp(1, max_bits)) {          \
+    double max_value = (((double) max / 2) * 2) + 1;                           \
+    if ((modf(n, &i) != 0.0) || n < min || n >= max_value) {                   \
       luaL_error(L, "number %f was not an integer or out of range for " #type, \
                  n);                                                           \
     }                                                                          \
@@ -207,10 +215,10 @@ const char *lupb_checkstring(lua_State *L, int narg, size_t *len) {
     lua_pushnumber(L, val);                                                    \
   }
 
-INTCHECK(int64,  int64_t, INT64_MIN, 63)
-INTCHECK(int32,  int32_t, INT32_MIN, 31)
-INTCHECK(uint64, uint64_t, 0, 64)
-INTCHECK(uint32, uint32_t, 0, 32)
+INTCHECK(int64,  int64_t, INT64_MIN, INT64_MAX)
+INTCHECK(int32,  int32_t, INT32_MIN, INT32_MAX)
+INTCHECK(uint64, uint64_t, 0, UINT64_MAX)
+INTCHECK(uint32, uint32_t, 0, UINT32_MAX)
 
 double lupb_checkdouble(lua_State *L, int narg) {
   /* If we were being really hard-nosed here, we'd check whether the input was


### PR DESCRIPTION
As discussed in https://github.com/protocolbuffers/upb/issues/439, the LUA binding tests were failing on some compilers (e.g. s390x) since conversion of out-of-range integers values (e.g. 2^64 or 18446744073709551616) to a double can lead to undefined behavior. On some compilers, this conversion can return 0, but it can also return the max value.

To make this check work across platforms, we do the following:

1. Break the double into its integral and fractional components.
2. If there any fractional components, return an error.
3. Compare the min and max values in an intelligent way. We can't simply
compare against UINT64_MAX since that value will get implicitly
converted to a double in an undefined way, and 18446744073709551616 >
UINT64_MAX can return false.  Instead, we divide the max value by 2, multiply it back, and add 1 to obtain the true out-of-bounds value as a double.

Closes https://github.com/protocolbuffers/upb/issues/439