### PR TITLE
Fix conformance test getting stuck on big-endian system

### DIFF
--- a/tests/conformance_upb.c
+++ b/tests/conformance_upb.c
@@ -296,7 +296,8 @@ bool DoTestIo(upb_symtab *symtab) {
   output = conformance_ConformanceResponse_serialize(c.response, c.arena,
                                                      &output_size);
 
-  CheckedWrite(STDOUT_FILENO, &output_size, sizeof(uint32_t));
+  uint32_t network_out = (uint32_t) output_size;
+  CheckedWrite(STDOUT_FILENO, &network_out, sizeof(uint32_t));
   CheckedWrite(STDOUT_FILENO, output, output_size);
 
   test_count++;


### PR DESCRIPTION
The output size is stored as `size_t`, a 64-bit value. However, on a
big-endian system this would be truncated to 0 since the low memory
addresses wold be sent.

To fix this, we cast the `size_t` to `uint32_t` and send that. Note that
calling `htonl()` would also work, but casting is simpler and does not
require including platform-specific header files.

Note that the tests now run, but there are 59 unexpected failures.

Closes https://github.com/protocolbuffers/upb/issues/446