### PR TITLE
Fix conformance test failures on big-endian systems

### DIFF
--- a/upb/decode.c
+++ b/upb/decode.c
@@ -278,7 +278,7 @@ static void decode_munge(int type, wireval *val) {
       val->bool_val = val->uint64_val != 0;
       break;
     case UPB_DESCRIPTOR_TYPE_SINT32: {
-      uint32_t n = val->uint32_val;
+      uint32_t n = val->uint64_val;
       val->uint32_val = (n >> 1) ^ -(int32_t)(n & 1);
       break;
     }

--- a/upb/json_decode.c
+++ b/upb/json_decode.c
@@ -719,7 +719,8 @@ static upb_msgval jsondec_int(jsondec *d, const upb_fielddef *f) {
       jsondec_err(d, "Expected number or string");
   }
 
-  if (upb_fielddef_type(f) == UPB_TYPE_INT32) {
+  if (upb_fielddef_type(f) == UPB_TYPE_INT32 ||
+      upb_fielddef_type(f) == UPB_TYPE_ENUM) {
     if (val.int64_val > INT32_MAX || val.int64_val < INT32_MIN) {
       jsondec_err(d, "Integer out of range.");
     }


### PR DESCRIPTION
Previously 59 tests were failing in the conformance tests. These were
failing in SINT32 and JSON enum handling. In both cases, we need to cast
int64 values to int32 to avoid losing bytes in a big-endian system.

Closes https://github.com/protocolbuffers/upb/issues/449