### PR TITLE
Conversion functions between Python and upb data types

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,7 +6,7 @@ build --extra_toolchains=@system_python//:python_toolchain
 # Use our custom-configured c++ toolchain.
 
 build:m32 --copt=-m32 --linkopt=-m32
-build:asan --copt=-fsanitize=address --linkopt=-fsanitize=address
+build:asan --copt=-fsanitize=address --linkopt=-fsanitize=address --copt=-D__SANITIZE_ADDRESS__=1
 
 # For Valgrind, we have to disable checks of "possible" leaks because the Python
 # interpreter does the sorts of things that flag Valgrind "possible" leak checks.
@@ -14,7 +14,7 @@ build:asan --copt=-fsanitize=address --linkopt=-fsanitize=address
 # know of an easy way to do that.
 #
 # We also have to disable pymalloc to avoid triggering Valgrind.
-build:valgrind --run_under='valgrind --leak-check=full --trace-children=yes --show-possibly-lost=no --errors-for-leak-kinds=definite --error-exitcode=1' --action_env=PYTHONMALLOC=malloc
+build:valgrind --run_under='valgrind --leak-check=full --track-origins=yes --trace-children=yes --show-possibly-lost=no --errors-for-leak-kinds=definite --error-exitcode=1' --action_env=PYTHONMALLOC=malloc
 
 build:ubsan --copt=-fsanitize=undefined --linkopt=-fsanitize=undefined --action_env=UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1
 # Workaround for the fact that Bazel links with $CC, not $CXX

--- a/python/BUILD
+++ b/python/BUILD
@@ -63,6 +63,7 @@ cc_binary(
         ":version_script.lds",
         "//:reflection",
         "//:upb",
+        "//upb/util:compare",
         "@system_python//:python_headers",
     ],
 )

--- a/python/BUILD
+++ b/python/BUILD
@@ -35,6 +35,8 @@ load(
 cc_binary(
     name = "message",
     srcs = [
+        "convert.c",
+        "convert.h",
         "descriptor.c",
         "descriptor.h",
         "descriptor_containers.c",

--- a/python/convert.c
+++ b/python/convert.c
@@ -1,0 +1,327 @@
+/*
+ * Copyright (c) 2009-2021, Google LLC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Google LLC nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL Google LLC BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "python/convert.h"
+
+#include "python/protobuf.h"
+#include "upb/reflection.h"
+
+PyObject* PyUpb_UpbToPy(upb_msgval val, const upb_fielddef *f, PyObject *arena) {
+  switch (upb_fielddef_type(f)) {
+    case UPB_TYPE_ENUM:
+    case UPB_TYPE_INT32:
+      return PyLong_FromLong(val.int32_val);
+    case UPB_TYPE_INT64:
+      return PyLong_FromLongLong(val.int64_val);
+    case UPB_TYPE_UINT32:
+      return PyLong_FromSize_t(val.uint32_val);
+    case UPB_TYPE_UINT64:
+      return PyLong_FromUnsignedLongLong(val.uint64_val);
+    case UPB_TYPE_FLOAT:
+      return PyFloat_FromDouble(val.float_val);
+    case UPB_TYPE_DOUBLE:
+      return PyFloat_FromDouble(val.double_val);
+    case UPB_TYPE_BOOL:
+      return PyBool_FromLong(val.bool_val);
+    case UPB_TYPE_BYTES:
+      return PyBytes_FromStringAndSize(val.str_val.data, val.str_val.size);
+    case UPB_TYPE_STRING:
+      return PyUnicode_DecodeUTF8(val.str_val.data, val.str_val.size, NULL);
+    case UPB_TYPE_MESSAGE:
+      PyErr_Format(PyExc_NotImplementedError,
+                   "Conversion of message types not yet implemented");
+    default:
+      PyErr_Format(PyExc_SystemError,
+                   "Getting a value from a field of unknown type %d",
+                   upb_fielddef_type(f));
+      return NULL;
+  }
+}
+
+static bool PyUpb_GetInt64(PyObject *obj, int64_t *val) {
+  // If the value is already a Python long, retrieves it.  Otherwise performs
+  // any automatic conversions to long (using __index__() or __int__()) that
+  // users expect.
+  *val = PyLong_AsLongLong(obj);
+  if (!PyErr_Occurred()) return true;
+  if (PyErr_ExceptionMatches(PyExc_OverflowError)) {
+    // Rewrite OverflowError -> ValueError.
+    // But don't rewrite other errors such as TypeError.
+    PyErr_Clear();
+    PyErr_Format(PyExc_ValueError, "Value out of range: %S", obj);
+  }
+  return false;
+}
+
+static bool PyUpb_GetUint64(PyObject *obj, uint64_t *val) {
+  // For uint64 Python does not offer any functions as convenient as
+  // PyLong_AsLongLong().  If the object is not already a "long" we must
+  // manually perform the automatic conversion (using __index__() or __int__())
+  // that users expect.
+  if (PyLong_Check(obj)) {
+    *val = PyLong_AsUnsignedLongLong(obj);
+  } else {
+    PyObject* casted = PyNumber_Long(obj);
+    if (!casted) return false;
+    *val = PyLong_AsUnsignedLongLong(casted);
+    Py_DECREF(casted);
+  }
+  if (!PyErr_Occurred()) return true;
+  PyErr_Clear();
+  PyErr_Format(PyExc_ValueError, "Value out of range: %S", obj);
+  return false;
+}
+
+// If `arena` is specified, copies the string data into the given arena.
+// Otherwise aliases the given data.
+static upb_msgval PyUpb_MaybeCopyString(const char *ptr, size_t size,
+                                        upb_arena *arena) {
+  upb_msgval ret;
+  ret.str_val.size = size;
+  if (arena) {
+    char *buf = upb_arena_malloc(arena, size);
+    memcpy(buf, ptr, size);
+    ret.str_val.data = buf;
+  } else {
+    ret.str_val.data = ptr;
+  }
+  return ret;
+}
+
+#define CHECK_RANGE(in, out, low, high) \
+  ((out) = (in), ((out) >= (low) && (out) <= (high)))
+
+bool PyUpb_PyToUpb(PyObject *obj, const upb_fielddef *f, upb_msgval *val,
+                   upb_arena *arena) {
+  switch (upb_fielddef_type(f)) {
+    case UPB_TYPE_ENUM:
+      if (PyUnicode_Check(obj)) {
+        Py_ssize_t size;
+        const char *name = PyUnicode_AsUTF8AndSize(obj, &size);
+        const upb_enumdef *e = upb_fielddef_enumsubdef(f);
+        const upb_enumvaldef *ev = upb_enumdef_lookupname(e, name, size);
+        if (!ev) {
+          PyErr_Format(PyExc_ValueError, "unknown enum label \"%s\"", name);
+          return false;
+        }
+        val->int32_val = upb_enumvaldef_number(ev);
+        return true;
+      } else {
+        if (!PyUpb_GetInt64(obj, &val->int64_val) ||
+            !CHECK_RANGE(val->int64_val, val->int32_val, INT32_MIN,
+                         INT32_MAX)) {
+          return false;
+        }
+        const upb_enumdef *e = upb_fielddef_enumsubdef(f);
+        if (upb_filedef_syntax(upb_enumdef_file(e)) == UPB_SYNTAX_PROTO2 &&
+            !upb_enumdef_checknum(e, val->int32_val)) {
+          PyErr_Format(PyExc_ValueError, "invalid enumerator %d",
+                       (int)val->int32_val);
+          return false;
+        }
+        return true;
+      }
+    case UPB_TYPE_INT32:
+      return PyUpb_GetInt64(obj, &val->int64_val) &&
+             CHECK_RANGE(val->int64_val, val->int32_val, INT32_MIN, INT32_MAX);
+    case UPB_TYPE_INT64:
+      return PyUpb_GetInt64(obj, &val->int64_val);
+    case UPB_TYPE_UINT32:
+      return PyUpb_GetUint64(obj, &val->uint64_val) &&
+             CHECK_RANGE(val->uint64_val, val->uint32_val, 0, UINT32_MAX);
+    case UPB_TYPE_UINT64:
+      return PyUpb_GetUint64(obj, &val->uint64_val);
+    case UPB_TYPE_FLOAT:
+      val->float_val = PyFloat_AsDouble(obj);
+      return !PyErr_Occurred();
+    case UPB_TYPE_DOUBLE:
+      val->double_val = PyFloat_AsDouble(obj);
+      return !PyErr_Occurred();
+    case UPB_TYPE_BOOL:
+      val->bool_val = PyLong_AsLong(obj);
+      return !PyErr_Occurred();
+    case UPB_TYPE_BYTES: {
+      char *ptr;
+      Py_ssize_t size;
+      if (PyBytes_AsStringAndSize(obj, &ptr, &size) < 0) return false;
+      *val = PyUpb_MaybeCopyString(ptr, size, arena);
+      return true;
+    }
+    case UPB_TYPE_STRING: {
+      Py_ssize_t size;
+      const char *ptr;
+      PyObject *unicode = NULL;
+      if (PyBytes_Check(obj)) {
+        unicode = obj = PyUnicode_FromEncodedObject(obj, "utf-8", NULL);
+        if (!obj) return false;
+      }
+      ptr = PyUnicode_AsUTF8AndSize(obj, &size);
+      if (PyErr_Occurred()) {
+        Py_XDECREF(unicode);
+        return false;
+      }
+      *val = PyUpb_MaybeCopyString(ptr, size, arena);
+      Py_XDECREF(unicode);
+      return true;
+    }
+    case UPB_TYPE_MESSAGE:
+      PyErr_Format(
+          PyExc_ValueError, "Message objects may not be assigned",
+          upb_fielddef_type(f));
+      return false;
+    default:
+      PyErr_Format(
+          PyExc_SystemError, "Getting a value from a field of unknown type %d",
+          upb_fielddef_type(f));
+      return false;
+  }
+}
+
+bool PyUpb_Message_IsEqual(const upb_msg *msg1, const upb_msg *msg2,
+                           const upb_msgdef *m);
+
+// -----------------------------------------------------------------------------
+// Equal
+// -----------------------------------------------------------------------------
+
+bool PyUpb_ValueEq(upb_msgval val1, upb_msgval val2, const upb_fielddef *f) {
+  switch (upb_fielddef_type(f)) {
+    case UPB_TYPE_BOOL:
+      return val1.bool_val == val2.bool_val;
+    case UPB_TYPE_INT32:
+    case UPB_TYPE_UINT32:
+    case UPB_TYPE_ENUM:
+      return val1.int32_val == val2.int32_val;
+    case UPB_TYPE_INT64:
+    case UPB_TYPE_UINT64:
+      return val1.int64_val == val2.int64_val;
+    case UPB_TYPE_FLOAT:
+      return val1.float_val == val2.float_val;
+    case UPB_TYPE_DOUBLE:
+      return val1.double_val == val2.double_val;
+    case UPB_TYPE_STRING:
+    case UPB_TYPE_BYTES:
+      return val1.str_val.size == val2.str_val.size &&
+          memcmp(val1.str_val.data, val2.str_val.data, val1.str_val.size) == 0;
+    case UPB_TYPE_MESSAGE:
+      return PyUpb_Message_IsEqual(val1.msg_val, val2.msg_val,
+                                   upb_fielddef_msgsubdef(f));
+    default:
+      return false;
+  }
+}
+
+bool PyUpb_Map_IsEqual(const upb_map *map1, const upb_map *map2,
+                       const upb_fielddef *f) {
+  assert(upb_fielddef_ismap(f));
+  const upb_msgdef *entry_m = upb_fielddef_msgsubdef(f);
+  const upb_fielddef *val_f = upb_msgdef_field(entry_m, 1);
+  size_t iter = UPB_MAP_BEGIN;
+  size_t size1 = map1 ? upb_map_size(map1) : 0;
+  size_t size2 = map2 ? upb_map_size(map2) : 0;
+
+  if (map1 == map2) return true;
+  if (size1 != size2) return false;
+  if (size1 == 0) return true;
+
+  while (upb_mapiter_next(map1, &iter)) {
+    upb_msgval key = upb_mapiter_key(map1, iter);
+    upb_msgval val1 = upb_mapiter_value(map1, iter);
+    upb_msgval val2;
+    if (!upb_map_get(map2, key, &val2)) return false;
+    if (!PyUpb_ValueEq(val1, val2, val_f)) return false;
+  }
+
+  return true;
+}
+
+static bool PyUpb_ArrayElem_IsEqual(const upb_array *arr1,
+                                    const upb_array *arr2, size_t i,
+                                    const upb_fielddef *f) {
+  upb_msgval val1 = upb_array_get(arr1, i);
+  upb_msgval val2 = upb_array_get(arr2, i);
+  return PyUpb_ValueEq(val1, val2, f);
+}
+
+bool PyUpb_Array_IsEqual(const upb_array *arr1, const upb_array *arr2,
+                         const upb_fielddef *f) {
+  assert(upb_fielddef_isseq(f) && !upb_fielddef_ismap(f));
+  size_t n1 = arr1 ? upb_array_size(arr1) : 0;
+  size_t n2 = arr2 ? upb_array_size(arr2) : 0;
+
+  if (arr1 == arr2) return true;
+  if (n1 != n2) return false;
+
+  // Half the length rounded up.  Important: the empty list rounds to 0.
+  size_t half = (n1 + 1) / 2;
+
+  // Search from the ends-in.  We expect differences to more quickly manifest
+  // at the ends than in the middle.  We may compare the most middle element
+  // twice.
+  for (size_t i = 0; i < half; i++) {
+    if (!PyUpb_ArrayElem_IsEqual(arr1, arr2, i, f)) return false;
+    if (!PyUpb_ArrayElem_IsEqual(arr1, arr2, n1 - 1 - i, f)) return false;
+  }
+
+  return true;
+}
+
+bool PyUpb_Message_IsEqual(const upb_msg *msg1, const upb_msg *msg2,
+                           const upb_msgdef *m) {
+  size_t iter1 = UPB_MSG_BEGIN;
+  size_t iter2 = UPB_MSG_BEGIN;
+
+  if (msg1 == msg2) return true;
+
+  while (true) {
+    const upb_fielddef *f1, *f2;
+    upb_msgval val1, val2;
+    bool ok1 = msg1 && upb_msg_next(msg1, m, NULL, &f1, &val1, &iter1);
+    bool ok2 = msg2 && upb_msg_next(msg2, m, NULL, &f2, &val2, &iter2);
+    if (ok1 != ok2) return false;
+    if (!ok1) break;  // Both messages are at end.
+    if (f1 != f2) return false;
+    if (upb_fielddef_ismap(f1)) {
+      if (!PyUpb_Map_IsEqual(val1.map_val, val2.map_val, f1)) return false;
+    } else if (upb_fielddef_isseq(f1)) {
+      if (!PyUpb_Array_IsEqual(val1.array_val, val2.array_val, f1)) {
+        return false;
+      }
+    } else {
+      if (!PyUpb_ValueEq(val1, val2, f1)) return false;
+    }
+  }
+
+  size_t usize1, usize2;
+  const char *uf1 = upb_msg_getunknown(msg1, &usize1);
+  const char *uf2 = upb_msg_getunknown(msg2, &usize2);
+  // TODO(haberman): compare unknown fields one by one.
+  if (usize1 != usize2) return false;
+  if (memcmp(uf1, uf2, usize1)) return false;
+
+  return true;
+}

--- a/python/convert.c
+++ b/python/convert.c
@@ -29,6 +29,7 @@
 
 #include "python/protobuf.h"
 #include "upb/reflection.h"
+#include "upb/util/compare.h"
 
 PyObject* PyUpb_UpbToPy(upb_msgval val, const upb_fielddef *f, PyObject *arena) {
   switch (upb_fielddef_type(f)) {
@@ -330,9 +331,5 @@ bool PyUpb_Message_IsEqual(const upb_msg *msg1, const upb_msg *msg2,
   size_t usize1, usize2;
   const char *uf1 = upb_msg_getunknown(msg1, &usize1);
   const char *uf2 = upb_msg_getunknown(msg2, &usize2);
-  // TODO(haberman): compare unknown fields one by one.
-  if (usize1 != usize2) return false;
-  if (memcmp(uf1, uf2, usize1)) return false;
-
-  return true;
+  return upb_Message_UnknownFieldsAreEqual(uf1, usize1, uf2, usize2, 100);
 }

--- a/python/convert.h
+++ b/python/convert.h
@@ -34,9 +34,10 @@
 #include "protobuf.h"
 
 // Converts `val` to a Python object according to the type information in `f`.
-// Any newly-created objects that reference non-primitive data from `val` should
-// reference `arena` to keep the referent alive.  If the conversion cannot be
-// performed, returns NULL and sets a Python error.
+// Any newly-created Python objects that reference non-primitive data from `val`
+// will take a reference on `arena`; the caller must ensure that `val` belongs
+// to `arena`. If the conversion cannot be performed, returns NULL and sets a
+// Python error.
 PyObject *PyUpb_UpbToPy(upb_msgval val, const upb_fielddef *f, PyObject *arena);
 
 // Converts `obj` to a upb_msgval `*val` according to the type information in

--- a/python/convert.h
+++ b/python/convert.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2009-2021, Google LLC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Google LLC nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL Google LLC BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PYUPB_CONVERT_H__
+#define PYUPB_CONVERT_H__
+
+#include "upb/def.h"
+#include "upb/reflection.h"
+
+#include "protobuf.h"
+
+// Converts `val` to a Python object according to the type information in `f`.
+// Any newly-created objects that reference non-primitive data from `val` should
+// reference `arena` to keep the referent alive.  If the conversion cannot be
+// performed, returns NULL and sets a Python error.
+PyObject *PyUpb_UpbToPy(upb_msgval val, const upb_fielddef *f, PyObject *arena);
+
+// Converts `obj` to a upb_msgval `*val` according to the type information in
+// `f`. If `arena is provided, any string data will be copied into `arena`,
+// otherwise the returned value will alias the Python-owned data (this can be
+// useful for an ephemeral upb_msgval).  If the conversion cannot be performed,
+// returns false.
+bool PyUpb_PyToUpb(PyObject *obj, const upb_fielddef *f, upb_msgval *val,
+                   upb_arena *arena);
+
+// Returns true if the given values (of type `f`) are equal.
+bool PyUpb_ValueEq(upb_msgval val1, upb_msgval val2, const upb_fielddef *f);
+
+// Returns true if the given messages (of type `m`) are equal.
+bool PyUpb_Message_IsEqual(const upb_msg *msg1, const upb_msg *msg2,
+                           const upb_msgdef *m);
+
+// Returns true if the two arrays (with element type `f`) are equal.
+bool PyUpb_Array_IsEqual(const upb_array *arr1, const upb_array *arr2,
+                         const upb_fielddef *f);
+
+#endif  // PYUPB_CONVERT_H__

--- a/python/convert.h
+++ b/python/convert.h
@@ -40,7 +40,7 @@
 PyObject *PyUpb_UpbToPy(upb_msgval val, const upb_fielddef *f, PyObject *arena);
 
 // Converts `obj` to a upb_msgval `*val` according to the type information in
-// `f`. If `arena is provided, any string data will be copied into `arena`,
+// `f`. If `arena` is provided, any string data will be copied into `arena`,
 // otherwise the returned value will alias the Python-owned data (this can be
 // useful for an ephemeral upb_msgval).  If the conversion cannot be performed,
 // returns false.

--- a/upb/def.c
+++ b/upb/def.c
@@ -394,6 +394,12 @@ const upb_enumvaldef *upb_enumdef_lookupnum(const upb_enumdef *def, int32_t num)
                                                   : NULL;
 }
 
+bool upb_enumdef_checknum(const upb_enumdef *e, int32_t num) {
+  // We could use upb_enumdef_lookupnum(e, num) != NULL, but we expect this to
+  // be faster (especially for small numbers).
+  return _upb_enumlayout_checkval(e->layout, num);
+}
+
 const upb_enumvaldef *upb_enumdef_value(const upb_enumdef *e, int i) {
   UPB_ASSERT(0 <= i && i < e->value_count);
   return &e->values[i];

--- a/upb/def.h
+++ b/upb/def.h
@@ -318,6 +318,7 @@ const upb_enumvaldef *upb_enumdef_value(const upb_enumdef *e, int i);
 const upb_enumvaldef *upb_enumdef_lookupname(const upb_enumdef *e,
                                              const char *name, size_t len);
 const upb_enumvaldef *upb_enumdef_lookupnum(const upb_enumdef *e, int32_t num);
+bool upb_enumdef_checknum(const upb_enumdef *e, int32_t num);
 
 /* DEPRECATED, slated for removal */
 int upb_enumdef_numvals(const upb_enumdef *e);

--- a/upb/util/BUILD
+++ b/upb/util/BUILD
@@ -5,6 +5,8 @@ load(
     "upb_proto_reflection_library",
 )
 
+# Def to Proto
+
 cc_library(
     name = "def_to_proto",
     srcs = ["def_to_proto.c"],
@@ -47,6 +49,8 @@ cc_test(
     ],
 )
 
+# Required fields
+
 cc_library(
     name = "required_fields",
     srcs = ["required_fields.c"],
@@ -81,4 +85,13 @@ cc_test(
         ":required_fields_test_upb_proto",
         ":required_fields_test_upb_proto_reflection",
     ],
+)
+
+# Compare
+
+cc_library(
+    name = "compare",
+    srcs = ["compare.c"],
+    hdrs = ["compare.h"],
+    deps = ["//:reflection"],
 )

--- a/upb/util/BUILD
+++ b/upb/util/BUILD
@@ -95,3 +95,13 @@ cc_library(
     hdrs = ["compare.h"],
     deps = ["//:reflection"],
 )
+
+cc_test(
+    name = "compare_test",
+    srcs = ["compare_test.cc"],
+    deps = [
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest_main",
+        ":compare",
+    ],
+)

--- a/upb/util/BUILD
+++ b/upb/util/BUILD
@@ -94,6 +94,7 @@ cc_library(
     srcs = ["compare.c"],
     hdrs = ["compare.h"],
     deps = ["//:reflection"],
+    visibility = ["//visibility:public"],
 )
 
 cc_test(

--- a/upb/util/compare.c
+++ b/upb/util/compare.c
@@ -1,0 +1,197 @@
+
+#include "upb/util/compare.h"
+
+#include <stdbool.h>
+#include <setjmp.h>
+
+#include "upb/port_def.inc"
+
+struct upb_UnknownFields;
+typedef struct upb_UnknownFields upb_UnknownFields;
+
+typedef struct {
+  uint32_t tag;
+  union {
+    uint64_t varint;
+    uint64_t uint64;
+    uint32_t uint32;
+    upb_strview delimited;
+    upb_UnknownFields* group;
+  } data;
+} upb_UnknownField;
+
+struct upb_UnknownFields {
+  size_t size;
+  size_t capacity;
+  upb_UnknownField* fields;
+};
+
+typedef struct {
+  const char *end;
+  upb_arena *arena;
+  int depth;
+  jmp_buf err;
+} upb_UnknownField_Context;
+
+static void upb_UnknownFields_Grow(upb_UnknownField_Context *ctx,
+                                   upb_UnknownField **base,
+                                   upb_UnknownField **ptr,
+                                   upb_UnknownField **end) {
+  size_t old = (*ptr - *base);
+  size_t new = UPB_MAX(4, old * 2);
+
+  *base = upb_arena_realloc(ctx->arena, *base, old * sizeof(*base),
+                            new * sizeof(*base));
+  if (!*base) UPB_LONGJMP(ctx->err, kUpb_UnknownCompareResult_OutOfMemory);
+
+  *ptr = *base + old;
+  *end = *base + new;
+}
+
+static const char *upb_UnknownFields_ParseVarint(const char *ptr,
+                                                 const char *limit,
+                                                 uint64_t *val) {
+  uint8_t byte;
+  int bitpos = 0;
+  *val = 0;
+
+  do {
+    // Unknown field data must be valid.
+    UPB_ASSERT(bitpos < 70 && ptr < limit);
+    byte = *ptr;
+    *val |= (uint64_t)(byte & 0x7F) << bitpos;
+    ptr++;
+    bitpos += 7;
+  } while (byte & 0x80);
+
+  return ptr;
+}
+
+static upb_UnknownFields *upb_UnknownFields_DoBuild(
+    upb_UnknownField_Context *ctx, const char **buf) {
+  upb_UnknownField *arr_base = NULL;
+  upb_UnknownField *arr_ptr = NULL;
+  upb_UnknownField *arr_end = NULL;
+  const char *ptr = *buf;
+  while (ptr < ctx->end) {
+    if (arr_ptr == arr_end) {
+      upb_UnknownFields_Grow(ctx, &arr_base, &arr_ptr, &arr_end);
+    }
+    upb_UnknownField *field = arr_ptr;
+    arr_ptr++;
+    uint64_t val;
+    ptr = upb_UnknownFields_ParseVarint(ptr, ctx->end, &val);
+    UPB_ASSERT(val <= UINT32_MAX);
+    field->tag = val;
+    switch (field->tag & 7) {
+      case UPB_WIRE_TYPE_VARINT:
+        ptr = upb_UnknownFields_ParseVarint(ptr, ctx->end, &field->data.varint);
+        break;
+      case UPB_WIRE_TYPE_64BIT:
+        UPB_ASSERT(ctx->end - ptr >= 8);
+        memcpy(&field->data.uint64, ptr, 8);
+        ptr += 8;
+        break;
+      case UPB_WIRE_TYPE_32BIT:
+        UPB_ASSERT(ctx->end - ptr >= 4);
+        memcpy(&field->data.uint32, ptr, 4);
+        ptr += 8;
+        break;
+      case UPB_WIRE_TYPE_DELIMITED: {
+        uint64_t size;
+        ptr = upb_UnknownFields_ParseVarint(ptr, ctx->end, &size);
+        UPB_ASSERT(ctx->end - ptr >= size);
+        field->data.delimited.data = ptr;
+        field->data.delimited.size = size;
+        break;
+      }
+      case UPB_WIRE_TYPE_START_GROUP:
+        if (--ctx->depth == 0) {
+          UPB_LONGJMP(ctx->err, kUpb_UnknownCompareResult_MaxDepthExceeded);
+        }
+        field->data.group = upb_UnknownFields_DoBuild(ctx, &ptr);
+        ctx->depth++;
+        break;
+      case UPB_WIRE_TYPE_END_GROUP:
+        goto done;
+      default:
+        UPB_UNREACHABLE();
+    }
+  }
+
+done:
+  *buf = ptr;
+  upb_UnknownFields *ret = upb_arena_malloc(ctx->arena, sizeof(*ret));
+  if (!ret) UPB_LONGJMP(ctx->err, kUpb_UnknownCompareResult_OutOfMemory);
+  ret->fields = arr_base;
+  ret->size = arr_ptr - arr_base;
+  ret->capacity = arr_end - arr_base;
+  return ret;
+}
+
+static upb_UnknownFields *upb_UnknownFields_Build(upb_UnknownField_Context *ctx,
+                                                  const char *buf,
+                                                  size_t size) {
+  ctx->end = buf + size;
+  upb_UnknownFields *fields = upb_UnknownFields_DoBuild(ctx, &buf);
+  UPB_ASSERT(buf == ctx->end);
+  return fields;
+}
+
+static bool upb_UnknownFields_IsEqual(const upb_UnknownFields *uf1,
+                                      const upb_UnknownFields *uf2) {
+  if (uf1->size != uf2->size) return false;
+  for (size_t i = 0, n = uf1->size; i < n; i++) {
+    upb_UnknownField *f1 = &uf1->fields[i];
+    upb_UnknownField *f2 = &uf2->fields[i];
+    if (f1->tag != f2->tag) return false;
+    switch (f1->tag & 7) {
+      case UPB_WIRE_TYPE_VARINT:
+        if (f1->data.varint != f2->data.varint) return false;
+        break;
+      case UPB_WIRE_TYPE_64BIT:
+        if (f1->data.uint64 != f2->data.uint64) return false;
+        break;
+      case UPB_WIRE_TYPE_32BIT:
+        if (f1->data.uint32 != f2->data.uint32) return false;
+        break;
+      case UPB_WIRE_TYPE_DELIMITED:
+        if (!upb_strview_eql(f1->data.delimited, f2->data.delimited)) {
+          return false;
+        }
+        break;
+      case UPB_WIRE_TYPE_START_GROUP:
+        if (!upb_UnknownFields_IsEqual(f1->data.group, f2->data.group)) {
+          return false;
+        }
+        break;
+      default:
+        UPB_UNREACHABLE();
+    }
+  }
+  return true;
+}
+
+upb_UnknownCompareResult upb_Message_UnknownFieldsAreEqual(const upb_msg *msg1,
+                                                           const upb_msg *msg2,
+                                                           int max_depth) {
+  size_t size1, size2;
+  const char *buf1 = upb_msg_getunknown(msg1, &size1);
+  const char *buf2 = upb_msg_getunknown(msg2, &size2);
+  if (size1 == 0 && size2 == 0) return kUpb_UnknownCompareResult_Equal;
+  if (size1 == 0 || size2 == 0) return kUpb_UnknownCompareResult_NotEqual;
+  if (memcmp(buf1, buf2, size1) == 0) return kUpb_UnknownCompareResult_Equal;
+
+  upb_UnknownField_Context ctx = {
+    .arena = upb_arena_new(),
+    .depth = max_depth,
+  };
+  if (!ctx.arena) return kUpb_UnknownCompareResult_OutOfMemory;
+
+  upb_UnknownFields *uf1 = upb_UnknownFields_Build(&ctx, buf1, size1);
+  upb_UnknownFields *uf2 = upb_UnknownFields_Build(&ctx, buf2, size2);
+  bool ret = upb_UnknownFields_IsEqual(uf1, uf2);
+  upb_arena_free(ctx.arena);
+  return ret ? kUpb_UnknownCompareResult_Equal
+             : kUpb_UnknownCompareResult_NotEqual;
+}

--- a/upb/util/compare.h
+++ b/upb/util/compare.h
@@ -37,8 +37,8 @@ extern "C" {
 // Returns true if unknown fields from the two messages are equal when sorted
 // and varints are made canonical.
 //
-// This operation should be considered best effort; the comparison is inherently
-// lossy without schema data:
+// This function is discouraged, as the comparison is inherently lossy without
+// schema data:
 //
 //  1. We don't know whether delimited fields are sub-messages. Unknown
 //     sub-messages will therefore not have their fields sorted and varints

--- a/upb/util/compare.h
+++ b/upb/util/compare.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2009-2021, Google LLC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Google LLC nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL Google LLC BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef UPB_UTIL_COMPARE_H_
+#define UPB_UTIL_COMPARE_H_
+
+#include "upb/def.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Returns true if unknown fields from the two messages are equal when sorted
+// and varints are made canonical.
+//
+// These semantics are unfortunate, as the comparison is lossy without schema
+// data:
+//  1. We don't know whether delimited fields are sub-messages. Unknown
+//     sub-messages will therefore not have their fields sorted and varints
+//     canonicalized.
+//  2. We don't know about oneof/non-repeated fields, which should semantically
+//     discard every value except the last.
+typedef enum {
+    kUpb_UnknownCompareResult_Equal = 0,
+    kUpb_UnknownCompareResult_NotEqual = 1,
+    kUpb_UnknownCompareResult_OutOfMemory = 2,
+    kUpb_UnknownCompareResult_MaxDepthExceeded = 3,
+} upb_UnknownCompareResult;
+upb_UnknownCompareResult upb_Message_UnknownFieldsAreEqual(const upb_msg *msg1,
+                                                           const upb_msg *msg2,
+                                                           int max_depth);
+
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif
+
+#endif  /* UPB_UTIL_COMPARE_H_ */

--- a/upb/util/compare.h
+++ b/upb/util/compare.h
@@ -37,21 +37,26 @@ extern "C" {
 // Returns true if unknown fields from the two messages are equal when sorted
 // and varints are made canonical.
 //
-// These semantics are unfortunate, as the comparison is lossy without schema
-// data:
+// This operation should be considered best effort; the comparison is inherently
+// lossy without schema data:
+//
 //  1. We don't know whether delimited fields are sub-messages. Unknown
 //     sub-messages will therefore not have their fields sorted and varints
 //     canonicalized.
 //  2. We don't know about oneof/non-repeated fields, which should semantically
 //     discard every value except the last.
+
 typedef enum {
     kUpb_UnknownCompareResult_Equal = 0,
     kUpb_UnknownCompareResult_NotEqual = 1,
     kUpb_UnknownCompareResult_OutOfMemory = 2,
     kUpb_UnknownCompareResult_MaxDepthExceeded = 3,
 } upb_UnknownCompareResult;
-upb_UnknownCompareResult upb_Message_UnknownFieldsAreEqual(const upb_msg *msg1,
-                                                           const upb_msg *msg2,
+
+upb_UnknownCompareResult upb_Message_UnknownFieldsAreEqual(const char *buf1,
+                                                           size_t size1,
+                                                           const char *buf2,
+                                                           size_t size2,
                                                            int max_depth);
 
 #ifdef __cplusplus

--- a/upb/util/compare_test.cc
+++ b/upb/util/compare_test.cc
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2009-2021, Google LLC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Google LLC nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL Google LLC BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "upb/util/compare.h"
+
+#include "absl/strings/string_view.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include <stdint.h>
+#include <vector>
+#include <string_view>
+
+struct UnknownField;
+
+using UnknownFields = std::vector<UnknownField>;
+
+enum class UnknownFieldType {
+  kVarint,
+  kLongVarint,  // Over-encoded to have distinct wire format.
+  kDelimited,
+  kFixed64,
+  kFixed32,
+  kGroup,
+};
+
+union UnknownFieldValue {
+    uint64_t varint;
+    uint64_t fixed64;
+    uint32_t fixed32;
+    // NULL-terminated (strings must not have embedded NULL).
+    const char* delimited;
+    UnknownFields* group;
+};
+
+struct TypeAndValue {
+  UnknownFieldType type;
+  UnknownFieldValue value;
+};
+
+struct UnknownField {
+  uint32_t field_number;
+  TypeAndValue value;
+};
+
+
+TypeAndValue Varint(uint64_t val) {
+  TypeAndValue ret{UnknownFieldType::kVarint};
+  ret.value.varint = val;
+  return ret;
+}
+
+TypeAndValue LongVarint(uint64_t val) {
+  TypeAndValue ret{UnknownFieldType::kLongVarint};
+  ret.value.varint = val;
+  return ret;
+}
+
+TypeAndValue Fixed64(uint64_t val) {
+  TypeAndValue ret{UnknownFieldType::kFixed64};
+  ret.value.fixed64 = val;
+  return ret;
+}
+
+TypeAndValue Fixed32(uint32_t val) {
+  TypeAndValue ret{UnknownFieldType::kFixed32};
+  ret.value.fixed32 = val;
+  return ret;
+}
+
+TypeAndValue Delimited(const char* val) {
+  TypeAndValue ret{UnknownFieldType::kDelimited};
+  ret.value.delimited = val;
+  return ret;
+}
+
+TypeAndValue Group(UnknownFields nested) {
+  TypeAndValue ret{UnknownFieldType::kGroup};
+  ret.value.group = &nested;
+  return ret;
+}
+
+void f() {
+    auto fields = UnknownFields{
+        {1, Varint(1)},
+        {2, Fixed64(2)},
+    };
+
+    auto fields2 = UnknownFields{
+      {1, Group({
+        {2, Group({
+          {3, Varint(1)},
+        })},
+      })},
+    };
+}
+
+void EncodeVarint(uint64_t val, std::string* str) {
+  do {
+    char byte = val & 0x7fU;
+    val >>= 7;
+    if (val) byte |= 0x80U;
+    str->push_back(byte);
+  } while (val);
+}
+
+std::string ToBinaryPayload(const UnknownFields& fields) {
+  static const upb_wiretype_t wire_types[] = {
+    UPB_WIRE_TYPE_VARINT,
+    UPB_WIRE_TYPE_VARINT,
+    UPB_WIRE_TYPE_DELIMITED,
+    UPB_WIRE_TYPE_64BIT,
+    UPB_WIRE_TYPE_32BIT,
+    UPB_WIRE_TYPE_START_GROUP,
+  };
+  std::string ret;
+
+  for (const auto& field : fields) {
+    uint32_t tag = field.field_number << 3 |
+                   (wire_types[static_cast<int>(field.value.type)]);
+    EncodeVarint(tag, &ret);
+    switch (field.value.type) {
+      case UnknownFieldType::kVarint:
+        EncodeVarint(field.value.value.varint, &ret);
+        break;
+      case UnknownFieldType::kLongVarint:
+        EncodeVarint(field.value.value.varint, &ret);
+        ret.back() |= 0x80;
+        ret.push_back(0);
+        break;
+      case UnknownFieldType::kDelimited:
+        EncodeVarint(strlen(field.value.value.delimited), &ret);
+        ret.append(field.value.value.delimited);
+        break;
+      case UnknownFieldType::kFixed64: {
+        uint64_t val = _upb_be_swap64(field.value.value.fixed64);
+        ret.append(reinterpret_cast<const char*>(&val), sizeof(val));
+        break;
+      }
+      case UnknownFieldType::kFixed32: {
+        uint32_t val = _upb_be_swap32(field.value.value.fixed32);
+        ret.append(reinterpret_cast<const char*>(&val), sizeof(val));
+        break;
+      }
+      case UnknownFieldType::kGroup: {
+        uint32_t end_tag = field.field_number << 3 | UPB_WIRE_TYPE_END_GROUP;
+        ret.append(ToBinaryPayload(*field.value.value.group));
+        EncodeVarint(end_tag, &ret);
+        break;
+      }
+    }
+  }
+
+  return ret;
+}
+
+upb_UnknownCompareResult CompareUnknownWithMaxDepth(UnknownFields uf1,
+                                                    UnknownFields uf2,
+                                                    int max_depth) {
+  std::string buf1 = ToBinaryPayload(uf1);
+  std::string buf2 = ToBinaryPayload(uf2);
+  return upb_Message_UnknownFieldsAreEqual(buf1.data(), buf1.size(),
+                                           buf2.data(), buf2.size(), max_depth);
+}
+
+upb_UnknownCompareResult CompareUnknown(UnknownFields uf1, UnknownFields uf2) {
+  return CompareUnknownWithMaxDepth(uf1, uf2, 64);
+}
+
+TEST(CompareTest, UnknownFieldsReflexive) {
+  EXPECT_EQ(kUpb_UnknownCompareResult_Equal, CompareUnknown({}, {}));
+  EXPECT_EQ(kUpb_UnknownCompareResult_Equal,
+            CompareUnknown({{1, Varint(123)}, {2, Fixed32(456)}},
+                           {{1, Varint(123)}, {2, Fixed32(456)}}));
+  EXPECT_EQ(
+      kUpb_UnknownCompareResult_Equal,
+      CompareUnknown(
+          {{1, Group({{2, Group({{3, Fixed32(456)}, {4, Fixed64(123)}})}})}},
+          {{1, Group({{2, Group({{3, Fixed32(456)}, {4, Fixed64(123)}})}})}}));
+}
+
+TEST(CompareTest, UnknownFieldsOrdering) {
+  EXPECT_EQ(kUpb_UnknownCompareResult_Equal,
+            CompareUnknown({{1, Varint(111)},
+                            {2, Delimited("ABC")},
+                            {3, Fixed32(456)},
+                            {4, Fixed64(123)},
+                            {5, Group({})}},
+                           {{5, Group({})},
+                            {4, Fixed64(123)},
+                            {3, Fixed32(456)},
+                            {2, Delimited("ABC")},
+                            {1, Varint(111)}}));
+  EXPECT_EQ(kUpb_UnknownCompareResult_NotEqual,
+            CompareUnknown({{1, Varint(111)},
+                            {2, Delimited("ABC")},
+                            {3, Fixed32(456)},
+                            {4, Fixed64(123)},
+                            {5, Group({})}},
+                           {{5, Group({})},
+                            {4, Fixed64(123)},
+                            {3, Fixed32(455)},  // Small difference.
+                            {2, Delimited("ABC")},
+                            {1, Varint(111)}}));
+  EXPECT_EQ(kUpb_UnknownCompareResult_Equal,
+            CompareUnknown({{3, Fixed32(456)}, {4, Fixed64(123)}},
+                           {{4, Fixed64(123)}, {3, Fixed32(456)}}));
+  EXPECT_EQ(
+      kUpb_UnknownCompareResult_Equal,
+      CompareUnknown(
+          {{1, Group({{2, Group({{3, Fixed32(456)}, {4, Fixed64(123)}})}})}},
+          {{1, Group({{2, Group({{4, Fixed64(123)}, {3, Fixed32(456)}})}})}}));
+}
+
+TEST(CompareTest, LongVarint) {
+  EXPECT_EQ(kUpb_UnknownCompareResult_Equal,
+            CompareUnknown({{1, LongVarint(123)}, {2, LongVarint(456)}},
+                           {{1, Varint(123)}, {2, Varint(456)}}));
+  EXPECT_EQ(kUpb_UnknownCompareResult_Equal,
+            CompareUnknown({{2, LongVarint(456)}, {1, LongVarint(123)}},
+                           {{1, Varint(123)}, {2, Varint(456)}}));
+}
+
+TEST(CompareTest, MaxDepth) {
+  EXPECT_EQ(
+      kUpb_UnknownCompareResult_MaxDepthExceeded,
+      CompareUnknownWithMaxDepth(
+          {{1, Group({{2, Group({{3, Fixed32(456)}, {4, Fixed64(123)}})}})}},
+          {{1, Group({{2, Group({{4, Fixed64(123)}, {3, Fixed32(456)}})}})}},
+          2));
+}

--- a/upb/util/compare_test.cc
+++ b/upb/util/compare_test.cc
@@ -67,7 +67,6 @@ struct UnknownField {
   TypeAndValue value;
 };
 
-
 TypeAndValue Varint(uint64_t val) {
   TypeAndValue ret{UnknownFieldType::kVarint};
   ret.value.varint = val;
@@ -102,21 +101,6 @@ TypeAndValue Group(UnknownFields nested) {
   TypeAndValue ret{UnknownFieldType::kGroup};
   ret.value.group = &nested;
   return ret;
-}
-
-void f() {
-    auto fields = UnknownFields{
-        {1, Varint(1)},
-        {2, Fixed64(2)},
-    };
-
-    auto fields2 = UnknownFields{
-      {1, Group({
-        {2, Group({
-          {3, Varint(1)},
-        })},
-      })},
-    };
 }
 
 void EncodeVarint(uint64_t val, std::string* str) {


### PR DESCRIPTION
The functions in `python/convert.*` are state-less conversions between Python and upb data types.

These files also contain equality comparison for a few kinds of upb types.