### PR TITLE
Avoid NULL + 0 when adding a list of 0 extensions.

### DIFF
--- a/upb/def.c
+++ b/upb/def.c
@@ -2943,8 +2943,10 @@ static void build_filedef(
     resolve_msgdef(ctx, (upb_msgdef*)&file->top_lvl_msgs[i]);
   }
 
-  CHK_OOM(
-      _upb_extreg_add(ctx->symtab->extreg, file->ext_layouts, file->ext_count));
+  if (file->ext_count) {
+    CHK_OOM(_upb_extreg_add(ctx->symtab->extreg, file->ext_layouts,
+                            file->ext_count));
+  }
 }
 
 static void remove_filedef(upb_symtab *s, upb_filedef *file) {

--- a/upb/msg.c
+++ b/upb/msg.c
@@ -376,7 +376,7 @@ upb_extreg *upb_extreg_new(upb_arena *arena) {
 bool _upb_extreg_add(upb_extreg *r, const upb_msglayout_ext **e, size_t count) {
   char buf[EXTREG_KEY_SIZE];
   const upb_msglayout_ext **start = e;
-  const upb_msglayout_ext **end = e + count;
+  const upb_msglayout_ext **end = UPB_PTRADD(e, count);
   for (; e < end; e++) {
     const upb_msglayout_ext *ext = *e;
     extreg_key(buf, ext->extendee, ext->field.number);


### PR DESCRIPTION
Fixes: https://github.com/protocolbuffers/upb/issues/452