### PR TITLE
Upgrade Bazel workspace to use protobuf v3.19.1

### DIFF
--- a/bazel/workspace_deps.bzl
+++ b/bazel/workspace_deps.bzl
@@ -13,11 +13,11 @@ def upb_deps():
     maybe(
         http_archive,
         name = "com_google_protobuf",
-        sha256 = "b10bf4e2d1a7586f54e64a5d9e7837e5188fc75ae69e36f215eb01def4f9721b",
-        strip_prefix = "protobuf-3.15.3",
+        sha256 = "87407cd28e7a9c95d9f61a098a53cf031109d451a7763e7dd1253abf8b4df422",
+        strip_prefix = "protobuf-3.19.1",
         urls = [
-            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v3.15.3.tar.gz",
-            "https://github.com/protocolbuffers/protobuf/archive/v3.15.3.tar.gz",
+            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v3.19.1.tar.gz",
+            "https://github.com/protocolbuffers/protobuf/archive/v3.19.1.tar.gz",
         ],
     )
 


### PR DESCRIPTION
Builds were not working because the mirror URL for v3.15.3 no longer
exists.