### PR TITLE
Removed the explicit define of __SANITIZE_ADDRESS__.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,7 +6,7 @@ build --extra_toolchains=@system_python//:python_toolchain
 # Use our custom-configured c++ toolchain.
 
 build:m32 --copt=-m32 --linkopt=-m32
-build:asan --copt=-fsanitize=address --linkopt=-fsanitize=address --copt=-D__SANITIZE_ADDRESS__=1
+build:asan --copt=-fsanitize=address --linkopt=-fsanitize=address
 
 # For Valgrind, we have to disable checks of "possible" leaks because the Python
 # interpreter does the sorts of things that flag Valgrind "possible" leak checks.


### PR DESCRIPTION
This should always be set when `-fsanitize=address` is true, but for
some reason this doesn't appear to be happening.

This fixes link errors in CI like:

```
INFO: From Linking tests/conformance_upb:
/usr/bin/ld.gold: warning: Cannot export local symbol '__asan_extra_spill_area'
/usr/bin/ld.gold: warning: Cannot export local symbol '__lsan_current_stage'
```