### PR TITLE
Update BUILD to set visilbity on windows config to public

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -46,6 +46,7 @@ exports_files([
 config_setting(
     name = "windows",
     constraint_values = ["@bazel_tools//platforms:windows"],
+    visibility = ["//visibility:public"],
 )
 
 upb_fasttable_enabled(


### PR DESCRIPTION
Without visibility public on the windows config build fails with Bazel version 4.2.2