### PR TITLE
Fixed or accounted for nearly all errors in message_test

### DIFF
--- a/python/message.c
+++ b/python/message.c
@@ -989,9 +989,8 @@ PyObject* PyUpb_CMessage_MergeFromString(PyObject* _self, PyObject* arg) {
   const upb_extreg* extreg = upb_symtab_extreg(upb_filedef_symtab(file));
   const upb_msglayout* layout = upb_msgdef_layout(msgdef);
   upb_arena* arena = PyUpb_Arena_Get(self->arena);
-  int options = 0;
   PyUpb_ModuleState* state = PyUpb_ModuleState_Get();
-  options |=
+  int options =
       UPB_DECODE_MAXDEPTH(state->allow_oversize_protos ? UINT32_MAX : 100);
   upb_DecodeStatus status =
       _upb_decode(buf, size, self->ptr.msg, layout, extreg, options, arena);
@@ -1186,11 +1185,10 @@ PyObject* PyUpb_CMessage_SerializeInternal(PyObject* _self, PyObject* args,
   const upb_msgdef* msgdef = _PyUpb_CMessage_GetMsgdef(self);
   const upb_msglayout* layout = upb_msgdef_layout(msgdef);
   size_t size = 0;
-  int options = 0;
+  int options = UPB_ENCODE_MAXDEPTH(UINT32_MAX);
   if (check_required) options |= UPB_ENCODE_CHECKREQUIRED;
   if (deterministic) options |= UPB_ENCODE_DETERMINISTIC;
   // Python does not currently have any effective limit on serialization depth.
-  options |= UPB_ENCODE_MAXDEPTH(UINT32_MAX);
   char* pb = upb_encode_ex(self->ptr.msg, layout, options, arena, &size);
   PyObject* ret = NULL;
 

--- a/python/pb_unit_tests/message_test_wrapper.py
+++ b/python/pb_unit_tests/message_test_wrapper.py
@@ -26,28 +26,29 @@
 from google.protobuf.internal import message_test
 import unittest
 
-message_test.MessageTest.testBadUtf8String_proto2.__unittest_expecting_failure__ = True
-message_test.MessageTest.testBadUtf8String_proto3.__unittest_expecting_failure__ = True
+# We don't want to support extending repeated fields with nothing; this behavior
+# is marked for deprecation in the existing library.
 message_test.MessageTest.testExtendFloatWithNothing_proto2.__unittest_expecting_failure__ = True
 message_test.MessageTest.testExtendFloatWithNothing_proto3.__unittest_expecting_failure__ = True
 message_test.MessageTest.testExtendInt32WithNothing_proto2.__unittest_expecting_failure__ = True
 message_test.MessageTest.testExtendInt32WithNothing_proto3.__unittest_expecting_failure__ = True
 message_test.MessageTest.testExtendStringWithNothing_proto2.__unittest_expecting_failure__ = True
 message_test.MessageTest.testExtendStringWithNothing_proto3.__unittest_expecting_failure__ = True
+
+# Our float printing suffers from not having dtoa().
 message_test.MessageTest.testFloatPrinting_proto2.__unittest_expecting_failure__ = True
 message_test.MessageTest.testFloatPrinting_proto3.__unittest_expecting_failure__ = True
 message_test.MessageTest.testHighPrecisionDoublePrinting_proto2.__unittest_expecting_failure__ = True
 message_test.MessageTest.testHighPrecisionDoublePrinting_proto3.__unittest_expecting_failure__ = True
-message_test.MessageTest.testInsertRepeatedCompositeField_proto2.__unittest_expecting_failure__ = True
-message_test.MessageTest.testInsertRepeatedCompositeField_proto3.__unittest_expecting_failure__ = True
-message_test.Proto2Test.testExtensionsErrors.__unittest_expecting_failure__ = True
+
+# For these tests we are throwing the correct error, only the text of the error
+# message is a mismatch.  For technical reasons around the limited API, matching
+# the existing error message exactly is not feasible.
+message_test.Proto3Test.testCopyFromBadType.__unittest_expecting_failure__ = True
+message_test.Proto3Test.testMergeFromBadType.__unittest_expecting_failure__ = True
+
 message_test.Proto2Test.testPythonicInit.__unittest_expecting_failure__ = True
 message_test.Proto2Test.test_documentation.__unittest_expecting_failure__ = True
-message_test.Proto3Test.testCopyFromBadType.__unittest_expecting_failure__ = True
-message_test.Proto3Test.testMapDeterministicSerialization.__unittest_expecting_failure__ = True
-message_test.Proto3Test.testMergeFromBadType.__unittest_expecting_failure__ = True
-message_test.OversizeProtosTest.testAssertOversizeProto.__unittest_expecting_failure__ = True
-message_test.OversizeProtosTest.testSucceedOversizeProto.__unittest_expecting_failure__ = True
 
 if __name__ == '__main__':
   unittest.main(module=message_test, verbosity=2)

--- a/python/pb_unit_tests/well_known_types_test_wrapper.py
+++ b/python/pb_unit_tests/well_known_types_test_wrapper.py
@@ -26,7 +26,5 @@
 from google.protobuf.internal import well_known_types_test
 import unittest
 
-well_known_types_test.AnyTest.testPackDeterministic.__unittest_expecting_failure__ = True
-
 if __name__ == '__main__':
   unittest.main(module=well_known_types_test, verbosity=2)

--- a/python/protobuf.c
+++ b/python/protobuf.c
@@ -40,11 +40,28 @@ static void PyUpb_ModuleDealloc(void *module) {
   PyUpb_WeakMap_Free(s->obj_cache);
 }
 
+PyObject* PyUpb_SetAllowOversizeProtos(PyObject* m, PyObject* arg) {
+  if (!arg || !PyBool_Check(arg)) {
+    PyErr_SetString(PyExc_TypeError,
+                    "Argument to SetAllowOversizeProtos must be boolean");
+    return NULL;
+  }
+  PyUpb_ModuleState* state = PyUpb_ModuleState_Get();
+  state->allow_oversize_protos = PyObject_IsTrue(arg);
+  Py_INCREF(arg);
+  return arg;
+}
+
+static PyMethodDef PyUpb_ModuleMethods[] = {
+    {"SetAllowOversizeProtos", PyUpb_SetAllowOversizeProtos, METH_O,
+     "Enable/disable oversize proto parsing."},
+    {NULL, NULL}};
+
 static struct PyModuleDef module_def = {PyModuleDef_HEAD_INIT,
                                         PYUPB_MODULE_NAME,
                                         "Protobuf Module",
                                         sizeof(PyUpb_ModuleState),
-                                        NULL,  // m_methods
+                                        PyUpb_ModuleMethods,  // m_methods
                                         NULL,  // m_slots
                                         NULL,  // m_traverse
                                         NULL,  // m_clear
@@ -302,6 +319,7 @@ PyMODINIT_FUNC PyInit__message(void) {
 
   PyUpb_ModuleState *state = PyUpb_ModuleState_GetFromModule(m);
 
+  state->allow_oversize_protos = false;
   state->wkt_bases = NULL;
   state->obj_cache = PyUpb_WeakMap_New();
 

--- a/python/protobuf.h
+++ b/python/protobuf.h
@@ -83,6 +83,7 @@ typedef struct {
   PyTypeObject *message_meta_type;
 
   // From protobuf.c
+  bool allow_oversize_protos;
   PyObject *wkt_bases;
   PyTypeObject *arena_type;
   PyUpb_WeakMap *obj_cache;

--- a/upb/msg.c
+++ b/upb/msg.c
@@ -252,36 +252,36 @@ static void _upb_mapsorter_getkeys(const void *_a, const void *_b, void *a_key,
   _upb_map_fromkey(b_tabkey, b_key, size);
 }
 
-#define COMPARE_INTEGERS(a, b) ((a) < (b) ? -1 : ((a) == (b) ? 0 : 1))
+#define UPB_COMPARE_INTEGERS(a, b) ((a) < (b) ? -1 : ((a) == (b) ? 0 : 1))
 
 static int _upb_mapsorter_cmpi64(const void *_a, const void *_b) {
   int64_t a, b;
   _upb_mapsorter_getkeys(_a, _b, &a, &b, 8);
-  return COMPARE_INTEGERS(a, b);
+  return UPB_COMPARE_INTEGERS(a, b);
 }
 
 static int _upb_mapsorter_cmpu64(const void *_a, const void *_b) {
   uint64_t a, b;
   _upb_mapsorter_getkeys(_a, _b, &a, &b, 8);
-  return COMPARE_INTEGERS(a, b);
+  return UPB_COMPARE_INTEGERS(a, b);
 }
 
 static int _upb_mapsorter_cmpi32(const void *_a, const void *_b) {
   int32_t a, b;
   _upb_mapsorter_getkeys(_a, _b, &a, &b, 4);
-  return COMPARE_INTEGERS(a, b);
+  return UPB_COMPARE_INTEGERS(a, b);
 }
 
 static int _upb_mapsorter_cmpu32(const void *_a, const void *_b) {
   uint32_t a, b;
   _upb_mapsorter_getkeys(_a, _b, &a, &b, 4);
-  return COMPARE_INTEGERS(a, b);
+  return UPB_COMPARE_INTEGERS(a, b);
 }
 
 static int _upb_mapsorter_cmpbool(const void *_a, const void *_b) {
   bool a, b;
   _upb_mapsorter_getkeys(_a, _b, &a, &b, 1);
-  return COMPARE_INTEGERS(a, b);
+  return UPB_COMPARE_INTEGERS(a, b);
 }
 
 static int _upb_mapsorter_cmpstr(const void *_a, const void *_b) {
@@ -290,10 +290,10 @@ static int _upb_mapsorter_cmpstr(const void *_a, const void *_b) {
   size_t common_size = UPB_MIN(a.size, b.size);
   int cmp = memcmp(a.data, b.data, common_size);
   if (cmp) return -cmp;
-  return COMPARE_INTEGERS(a.size, b.size);
+  return UPB_COMPARE_INTEGERS(a.size, b.size);
 }
 
-#undef COMPARE_INTEGERS
+#undef UPB_COMPARE_INTEGERS
 
 bool _upb_mapsorter_pushmap(_upb_mapsorter *s, upb_descriptortype_t key_type,
                             const upb_map *map, _upb_sortedmap *sorted) {

--- a/upb/msg.c
+++ b/upb/msg.c
@@ -287,7 +287,7 @@ static int _upb_mapsorter_cmpstr(const void *_a, const void *_b) {
   _upb_mapsorter_getkeys(_a, _b, &a, &b, UPB_MAPTYPE_STRING);
   size_t common_size = UPB_MIN(a.size, b.size);
   int cmp = memcmp(a.data, b.data, common_size);
-  if (cmp) return cmp;
+  if (cmp) return -cmp;
   return a.size - b.size;
 }
 

--- a/upb/msg.c
+++ b/upb/msg.c
@@ -252,34 +252,36 @@ static void _upb_mapsorter_getkeys(const void *_a, const void *_b, void *a_key,
   _upb_map_fromkey(b_tabkey, b_key, size);
 }
 
+#define COMPARE_INTEGERS(a, b) ((a) < (b) ? -1 : ((a) == (b) ? 0 : 1))
+
 static int _upb_mapsorter_cmpi64(const void *_a, const void *_b) {
   int64_t a, b;
   _upb_mapsorter_getkeys(_a, _b, &a, &b, 8);
-  return a - b;
+  return COMPARE_INTEGERS(a, b);
 }
 
 static int _upb_mapsorter_cmpu64(const void *_a, const void *_b) {
   uint64_t a, b;
   _upb_mapsorter_getkeys(_a, _b, &a, &b, 8);
-  return a - b;
+  return COMPARE_INTEGERS(a, b);
 }
 
 static int _upb_mapsorter_cmpi32(const void *_a, const void *_b) {
   int32_t a, b;
   _upb_mapsorter_getkeys(_a, _b, &a, &b, 4);
-  return a - b;
+  return COMPARE_INTEGERS(a, b);
 }
 
 static int _upb_mapsorter_cmpu32(const void *_a, const void *_b) {
   uint32_t a, b;
   _upb_mapsorter_getkeys(_a, _b, &a, &b, 4);
-  return a - b;
+  return COMPARE_INTEGERS(a, b);
 }
 
 static int _upb_mapsorter_cmpbool(const void *_a, const void *_b) {
   bool a, b;
   _upb_mapsorter_getkeys(_a, _b, &a, &b, 1);
-  return a - b;
+  return COMPARE_INTEGERS(a, b);
 }
 
 static int _upb_mapsorter_cmpstr(const void *_a, const void *_b) {
@@ -288,8 +290,10 @@ static int _upb_mapsorter_cmpstr(const void *_a, const void *_b) {
   size_t common_size = UPB_MIN(a.size, b.size);
   int cmp = memcmp(a.data, b.data, common_size);
   if (cmp) return -cmp;
-  return a.size - b.size;
+  return COMPARE_INTEGERS(a.size, b.size);
 }
+
+#undef COMPARE_INTEGERS
 
 bool _upb_mapsorter_pushmap(_upb_mapsorter *s, upb_descriptortype_t key_type,
                             const upb_map *map, _upb_sortedmap *sorted) {


### PR DESCRIPTION
Fixed/added several things:

1. We now properly raise `AttributeError` if you ask for `msg.Extensions` on a non-extendable message.
2. We now properly support the `AllowOversizeProtos` function that acts as a safeguard against messages of excessive depth.
3. We now match the text format quirk where sub-messages are printed as `msg_field { /* ... */  }`, omitting the colon that normal fields would have (`scalar_field: 123`).

Also added comments explaining why we don't pass several of the other tests in message_test.