### PR TITLE
Build tools in the exec configuration

### DIFF
--- a/bazel/build_defs.bzl
+++ b/bazel/build_defs.bzl
@@ -157,7 +157,7 @@ upb_amalgamation = rule(
     attrs = {
         "_amalgamator": attr.label(
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             default = "//bazel:amalgamate",
         ),
         "prefix": attr.string(

--- a/bazel/upb_proto_library.bzl
+++ b/bazel/upb_proto_library.bzl
@@ -272,7 +272,7 @@ def _maybe_add(d):
     if not _is_bazel:
         d["_grep_includes"] = attr.label(
             allow_single_file = True,
-            cfg = "host",
+            cfg = "exec",
             default = "//tools/cpp:grep-includes",
         )
     return d
@@ -286,12 +286,12 @@ _upb_proto_library_aspect = aspect(
         ),
         "_gen_upb": attr.label(
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             default = "//upbc:protoc-gen-upb",
         ),
         "_protoc": attr.label(
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             default = "@com_google_protobuf//:protoc",
         ),
         "_cc_toolchain": attr.label(
@@ -335,12 +335,12 @@ _upb_proto_reflection_library_aspect = aspect(
         ),
         "_gen_upbdefs": attr.label(
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             default = "//upbc:protoc-gen-upbdefs",
         ),
         "_protoc": attr.label(
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             default = "@com_google_protobuf//:protoc",
         ),
         "_cc_toolchain": attr.label(

--- a/upb/bindings/lua/lua_proto_library.bzl
+++ b/upb/bindings/lua/lua_proto_library.bzl
@@ -107,12 +107,12 @@ _lua_proto_library_aspect = aspect(
     attrs = {
         "_upbc": attr.label(
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             default = "//upb/bindings/lua:protoc-gen-lua",
         ),
         "_protoc": attr.label(
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             default = "@com_google_protobuf//:protoc",
         ),
     },


### PR DESCRIPTION
Bazel has deprecated the host configuration and replaced it with the
exec configuration, which has proper support for transitions and remote
build execution.