### PR TITLE
Fix amalgamate script to include third_party stuff

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -270,6 +270,7 @@ upb_amalgamation(
         ":descriptor_upb_proto",
         ":reflection",
         ":port",
+        "//third_party/utf8_range",
     ],
 )
 

--- a/bazel/amalgamate.py
+++ b/bazel/amalgamate.py
@@ -30,6 +30,7 @@ import re
 import os
 
 INCLUDE_RE = re.compile('^#include "([^"]*)"$')
+VALID_HDR_PREFIXES = ["upb", "google", "third_party"]
 
 def parse_include(line):
   match = INCLUDE_RE.match(line)
@@ -86,7 +87,7 @@ class Amalgamator:
     include = parse_include(line)
     if not include:
       return False
-    if not (include.startswith("upb") or include.startswith("google")):
+    if not any([include.startswith(prefix) for prefix in VALID_HDR_PREFIXES]):
       return False
     if include.endswith("hpp"):
       # Skip, we don't support the amalgamation from C++.


### PR DESCRIPTION
The PR https://github.com/protocolbuffers/upb/pull/429 added the utf8_range library in the third_party directory for some utf8 verification routines. However, the amalgamate script does not look there for things to squash into the amalgamation header files.

Fix this by:
    * Adding utf8_range as a lib dep for the amalgamate target in Bazel, so that build_defs.bzl will include the .c file in the amalgamation
    * Including third_party as a valid header path to squash out in the amalgamate script itself

Side note: For a bit more context, what I'm doing is embedding upb.c/h in a Ruby C extension, to generate pprof protobufs (https://github.com/google/pprof/blob/master/proto/profile.proto) as part of a performance monitoring tool I'm working on. So, after fixing this, the next thing I wanted to do was use `protoc-gen-upb` to compile the profile.proto file. 

This mostly worked, except for two things:
    * `protoc-gen-upb` puts includes in the generated files like `#include "upb/msg_internal.h"` (i.e. with `upb/` in the path), but of course after amalgamation all we have is `upb.h`.
    * `upb.h` includes `ports_def.inc` at the top, and `ports_undef.inc` at the bottom; this means that it does not actually export macros like `UPB_INLINE`, which are used by the generated `.upb.c` files.

I "fixed" this by postprocessing the generated protobufs with this piece of hackery, which seemed to work well enough:
```ruby
  port_def = File.read("#{upb_dir}/upb/port_def.inc")
  Dir["ext/ruby_memprofiler_pprof/*.upb.{c,h}"].each do |f|
    old_content = File.read(f)
    old_content.gsub!(/^\s*#include\s+["<]upb\/port_def\.inc.*$/, port_def)
    old_content.gsub!(/^\s*#include\s+["<]upb\/.*$/, '#include "upb.h"')
    File.write(f, old_content)
  end
```

If I submitted a patch to give `protoc-gen-upb` an option to generate output that plays nicely with the amalgamation, would that be of interest? How would you suggest I go about doing that?

PS: Love your comment in CONTRIBUTING.md about "if it's > 30 mins, reach out". This patch was definitely < 30 mins, but hacking on protoc-gen-upb is most certainly > 30 minutes :)