### PR TITLE
Fixed FieldDescriptor test

### DIFF
--- a/python/descriptor.c
+++ b/python/descriptor.c
@@ -1636,29 +1636,27 @@ bool PyUpb_InitDescriptor(PyObject* m) {
   }
 
   PyObject* field_desc = (PyObject*)s->descriptor_types[kPyUpb_FieldDescriptor];
-  bool ok =
-      PyUpb_SetIntAttr(field_desc, "TYPE_DOUBLE", upb_FieldType_Double) &&
-      PyUpb_SetIntAttr(field_desc, "TYPE_FLOAT", upb_FieldType_Float) &&
-      PyUpb_SetIntAttr(field_desc, "TYPE_INT64", upb_FieldType_Int64) &&
-      PyUpb_SetIntAttr(field_desc, "TYPE_UINT64", upb_FieldType_UInt64) &&
-      PyUpb_SetIntAttr(field_desc, "TYPE_INT32", upb_FieldType_Int32) &&
-      PyUpb_SetIntAttr(field_desc, "TYPE_FIXED64", upb_FieldType_Fixed64) &&
-      PyUpb_SetIntAttr(field_desc, "TYPE_FIXED32", upb_FieldType_Fixed32) &&
-      PyUpb_SetIntAttr(field_desc, "TYPE_BOOL", upb_FieldType_Bool) &&
-      PyUpb_SetIntAttr(field_desc, "TYPE_STRING", upb_FieldType_String) &&
-      PyUpb_SetIntAttr(field_desc, "TYPE_GROUP", upb_FieldType_Group) &&
-      PyUpb_SetIntAttr(field_desc, "TYPE_MESSAGE", upb_FieldType_Message) &&
-      PyUpb_SetIntAttr(field_desc, "TYPE_BYTES", upb_FieldType_Bytes) &&
-      PyUpb_SetIntAttr(field_desc, "TYPE_UINT32", upb_FieldType_UInt32) &&
-      PyUpb_SetIntAttr(field_desc, "TYPE_ENUM", upb_FieldType_Enum) &&
-      PyUpb_SetIntAttr(field_desc, "TYPE_SFIXED32", upb_FieldType_SFixed32) &&
-      PyUpb_SetIntAttr(field_desc, "TYPE_SFIXED64", upb_FieldType_SFixed64) &&
-      PyUpb_SetIntAttr(field_desc, "TYPE_SINT32", upb_FieldType_SInt32) &&
-      PyUpb_SetIntAttr(field_desc, "TYPE_SINT64", upb_FieldType_SInt64) &&
-      PyUpb_SetIntAttr(field_desc, "LABEL_OPTIONAL", kUpb_Label_Optional) &&
-      PyUpb_SetIntAttr(field_desc, "LABEL_REQUIRED", kUpb_Label_Required) &&
-      PyUpb_SetIntAttr(field_desc, "LABEL_REPEATED", kUpb_Label_Repeated);
-  if (!ok) return false;
-
-  return true;
+  return PyUpb_SetIntAttr(field_desc, "LABEL_OPTIONAL", kUpb_Label_Optional) &&
+         PyUpb_SetIntAttr(field_desc, "LABEL_REPEATED", kUpb_Label_Repeated) &&
+         PyUpb_SetIntAttr(field_desc, "LABEL_REQUIRED", kUpb_Label_Required) &&
+         PyUpb_SetIntAttr(field_desc, "TYPE_BOOL", upb_FieldType_Bool) &&
+         PyUpb_SetIntAttr(field_desc, "TYPE_BYTES", upb_FieldType_Bytes) &&
+         PyUpb_SetIntAttr(field_desc, "TYPE_DOUBLE", upb_FieldType_Double) &&
+         PyUpb_SetIntAttr(field_desc, "TYPE_ENUM", upb_FieldType_Enum) &&
+         PyUpb_SetIntAttr(field_desc, "TYPE_FIXED32", upb_FieldType_Fixed32) &&
+         PyUpb_SetIntAttr(field_desc, "TYPE_FIXED64", upb_FieldType_Fixed64) &&
+         PyUpb_SetIntAttr(field_desc, "TYPE_FLOAT", upb_FieldType_Float) &&
+         PyUpb_SetIntAttr(field_desc, "TYPE_GROUP", upb_FieldType_Group) &&
+         PyUpb_SetIntAttr(field_desc, "TYPE_INT32", upb_FieldType_Int32) &&
+         PyUpb_SetIntAttr(field_desc, "TYPE_INT64", upb_FieldType_Int64) &&
+         PyUpb_SetIntAttr(field_desc, "TYPE_MESSAGE", upb_FieldType_Message) &&
+         PyUpb_SetIntAttr(field_desc, "TYPE_SFIXED32",
+                          upb_FieldType_SFixed32) &&
+         PyUpb_SetIntAttr(field_desc, "TYPE_SFIXED64",
+                          upb_FieldType_SFixed64) &&
+         PyUpb_SetIntAttr(field_desc, "TYPE_SINT32", upb_FieldType_SInt32) &&
+         PyUpb_SetIntAttr(field_desc, "TYPE_SINT64", upb_FieldType_SInt64) &&
+         PyUpb_SetIntAttr(field_desc, "TYPE_STRING", upb_FieldType_String) &&
+         PyUpb_SetIntAttr(field_desc, "TYPE_UINT32", upb_FieldType_UInt32) &&
+         PyUpb_SetIntAttr(field_desc, "TYPE_UINT64", upb_FieldType_UInt64);
 }

--- a/python/descriptor.c
+++ b/python/descriptor.c
@@ -1609,6 +1609,14 @@ static PyType_Spec PyUpb_ServiceDescriptor_Spec = {
 // Top Level
 // -----------------------------------------------------------------------------
 
+static bool PyUpb_SetIntAttr(PyObject* obj, const char* name, int val) {
+  PyObject* num = PyLong_FromLong(val);
+  if (!num) return false;
+  int status = PyObject_SetAttrString(obj, name, num);
+  Py_DECREF(num);
+  return status >= 0;
+}
+
 // These must be in the same order as PyUpb_DescriptorType in the header.
 static PyType_Spec* desc_specs[] = {
     &PyUpb_Descriptor_Spec,          &PyUpb_EnumDescriptor_Spec,
@@ -1626,6 +1634,31 @@ bool PyUpb_InitDescriptor(PyObject* m) {
       return false;
     }
   }
+
+  PyObject* field_desc = (PyObject*)s->descriptor_types[kPyUpb_FieldDescriptor];
+  bool ok =
+      PyUpb_SetIntAttr(field_desc, "TYPE_DOUBLE", upb_FieldType_Double) &&
+      PyUpb_SetIntAttr(field_desc, "TYPE_FLOAT", upb_FieldType_Float) &&
+      PyUpb_SetIntAttr(field_desc, "TYPE_INT64", upb_FieldType_Int64) &&
+      PyUpb_SetIntAttr(field_desc, "TYPE_UINT64", upb_FieldType_UInt64) &&
+      PyUpb_SetIntAttr(field_desc, "TYPE_INT32", upb_FieldType_Int32) &&
+      PyUpb_SetIntAttr(field_desc, "TYPE_FIXED64", upb_FieldType_Fixed64) &&
+      PyUpb_SetIntAttr(field_desc, "TYPE_FIXED32", upb_FieldType_Fixed32) &&
+      PyUpb_SetIntAttr(field_desc, "TYPE_BOOL", upb_FieldType_Bool) &&
+      PyUpb_SetIntAttr(field_desc, "TYPE_STRING", upb_FieldType_String) &&
+      PyUpb_SetIntAttr(field_desc, "TYPE_GROUP", upb_FieldType_Group) &&
+      PyUpb_SetIntAttr(field_desc, "TYPE_MESSAGE", upb_FieldType_Message) &&
+      PyUpb_SetIntAttr(field_desc, "TYPE_BYTES", upb_FieldType_Bytes) &&
+      PyUpb_SetIntAttr(field_desc, "TYPE_UINT32", upb_FieldType_UInt32) &&
+      PyUpb_SetIntAttr(field_desc, "TYPE_ENUM", upb_FieldType_Enum) &&
+      PyUpb_SetIntAttr(field_desc, "TYPE_SFIXED32", upb_FieldType_SFixed32) &&
+      PyUpb_SetIntAttr(field_desc, "TYPE_SFIXED64", upb_FieldType_SFixed64) &&
+      PyUpb_SetIntAttr(field_desc, "TYPE_SINT32", upb_FieldType_SInt32) &&
+      PyUpb_SetIntAttr(field_desc, "TYPE_SINT64", upb_FieldType_SInt64) &&
+      PyUpb_SetIntAttr(field_desc, "LABEL_OPTIONAL", kUpb_Label_Optional) &&
+      PyUpb_SetIntAttr(field_desc, "LABEL_REQUIRED", kUpb_Label_Required) &&
+      PyUpb_SetIntAttr(field_desc, "LABEL_REPEATED", kUpb_Label_Repeated);
+  if (!ok) return false;
 
   return true;
 }

--- a/python/descriptor_pool.c
+++ b/python/descriptor_pool.c
@@ -406,6 +406,11 @@ static PyObject* PyUpb_DescriptorPool_FindFieldByName(PyObject* _self,
   if (child) {
     const upb_MessageDef* parent =
         upb_DefPool_FindMessageByNameWithSize(self->symtab, name, parent_size);
+    if (parent == NULL && self->db) {
+      if (!PyUpb_DescriptorPool_TryLoadSymbol(self, arg)) return NULL;
+      parent = upb_DefPool_FindMessageByNameWithSize(self->symtab, name,
+                                                     parent_size);
+    }
     if (parent) {
       f = upb_MessageDef_FindFieldByName(parent, child);
     }

--- a/python/pb_unit_tests/descriptor_pool_test_wrapper.py
+++ b/python/pb_unit_tests/descriptor_pool_test_wrapper.py
@@ -27,12 +27,11 @@ from google.protobuf.internal import descriptor_pool_test
 import unittest
 import copy
 
+# This is testing that certain methods unconditionally throw TypeError.
+# In the new extension we simply don't define them at all.
 descriptor_pool_test.AddDescriptorTest.testAddTypeError.__unittest_expecting_failure__ = True
-descriptor_pool_test.AddDescriptorTest.testEnum.__unittest_expecting_failure__ = True
-descriptor_pool_test.AddDescriptorTest.testFile.__unittest_expecting_failure__ = True
-descriptor_pool_test.AddDescriptorTest.testMessage.__unittest_expecting_failure__ = True
-descriptor_pool_test.AddDescriptorTest.testService.__unittest_expecting_failure__ = True
-descriptor_pool_test.CreateDescriptorPoolTest.testFindFieldByName.__unittest_expecting_failure__ = True
+
+#descriptor_pool_test.CreateDescriptorPoolTest.testFindFieldByName.__unittest_expecting_failure__ = True
 descriptor_pool_test.CreateDescriptorPoolTest.testFindService.__unittest_expecting_failure__ = True
 descriptor_pool_test.CreateDescriptorPoolTest.testFindTypeErrors.__unittest_expecting_failure__ = True
 descriptor_pool_test.SecondaryDescriptorFromDescriptorDB.testErrorCollector.__unittest_expecting_failure__ = True


### PR DESCRIPTION
Added `TYPE_*` and `LABEL_*` constants to `FieldDescriptor. However we omit the previously-available `CPPTYPE_*` constants, as these are specific to the C++ implementation.

Also added support for finding field descriptors from a fallback database.