### PR TITLE
Ported protobuf's dtoa() function for text format and JSON.

### DIFF
--- a/python/minimal_test.py
+++ b/python/minimal_test.py
@@ -113,7 +113,10 @@ class TestMessageExtension(unittest.TestCase):
         int32_array.append(123)
         self.assertEqual(0, msg.ByteSize())
 
-#TestMessageExtension.test_descriptor_pool.__unittest_expecting_failure__ = True
+    def testFloatPrinting(self):
+        message = unittest_pb2.TestAllTypes()
+        message.optional_float = -0.0
+        self.assertEqual(str(message), 'optional_float: -0\n')
 
 class OversizeProtosTest(unittest.TestCase):
   def setUp(self):

--- a/python/pb_unit_tests/message_test_wrapper.py
+++ b/python/pb_unit_tests/message_test_wrapper.py
@@ -35,11 +35,10 @@ message_test.MessageTest.testExtendInt32WithNothing_proto3.__unittest_expecting_
 message_test.MessageTest.testExtendStringWithNothing_proto2.__unittest_expecting_failure__ = True
 message_test.MessageTest.testExtendStringWithNothing_proto3.__unittest_expecting_failure__ = True
 
-# Our float printing suffers from not having dtoa().
+# Python/C++ customizes the C++ TextFormat to always print trailing ".0" for
+# floats. upb doesn't do this, it matches C++ TextFormat.
 message_test.MessageTest.testFloatPrinting_proto2.__unittest_expecting_failure__ = True
 message_test.MessageTest.testFloatPrinting_proto3.__unittest_expecting_failure__ = True
-message_test.MessageTest.testHighPrecisionDoublePrinting_proto2.__unittest_expecting_failure__ = True
-message_test.MessageTest.testHighPrecisionDoublePrinting_proto3.__unittest_expecting_failure__ = True
 
 # For these tests we are throwing the correct error, only the text of the error
 # message is a mismatch.  For technical reasons around the limited API, matching

--- a/upb/text_encode.c
+++ b/upb/text_encode.c
@@ -35,6 +35,7 @@
 #include <string.h>
 
 #include "upb/reflection.h"
+#include "upb/upb_internal.h"
 
 // Must be last.
 #include "upb/port_def.inc"
@@ -177,12 +178,18 @@ static void txtenc_field(txtenc* e, upb_MessageValue val,
     case kUpb_CType_Bool:
       txtenc_putstr(e, val.bool_val ? "true" : "false");
       break;
-    case kUpb_CType_Float:
-      txtenc_printf(e, "%f", val.float_val);
+    case kUpb_CType_Float: {
+      char buf[32];
+      _upb_EncodeRoundTripFloat(val.float_val, buf, sizeof(buf));
+      txtenc_putstr(e, buf);
       break;
-    case kUpb_CType_Double:
-      txtenc_printf(e, "%f", val.double_val);
+    }
+    case kUpb_CType_Double: {
+      char buf[32];
+      _upb_EncodeRoundTripDouble(val.double_val, buf, sizeof(buf));
+      txtenc_putstr(e, buf);
       break;
+    }
     case kUpb_CType_Int32:
       txtenc_printf(e, "%" PRId32, val.int32_val);
       break;

--- a/upb/upb_internal.h
+++ b/upb/upb_internal.h
@@ -55,4 +55,16 @@ struct upb_Arena {
   mem_block *freelist, *freelist_tail;
 };
 
+// Encodes a float or double that is round-trippable, but as short as possible.
+// These routines are not fully optimal (not guaranteed to be shortest), but are
+// short-ish and match the implementation that has been used in protobuf since
+// the beginning.
+//
+// The given buffer size must be at least kUpb_RoundTripBufferSize.
+enum {
+  kUpb_RoundTripBufferSize = 32
+};
+void _upb_EncodeRoundTripDouble(double val, char* buf, size_t size);
+void _upb_EncodeRoundTripFloat(float val, char* buf, size_t size);
+
 #endif /* UPB_INT_H_ */


### PR DESCRIPTION
This PR changes the behavior of `str(FooMessage(abc: 2))` in Python from `abc 2.0` to `abc: 2`. The latter matches what C++ normally does.

If we go through with this, we may want to change the pure-Python implementation to drop the `.0` also, so Python+upb matches pure Python.

An alternative would be to add a flag to upb's text format encoder to always add `.0` to the end of float/double fields that would not otherwise have it.