### PR TITLE
Fix negative hours when encode to JSON

### DIFF
--- a/tests/BUILD
+++ b/tests/BUILD
@@ -83,6 +83,7 @@ proto_library(
     srcs = [
         "test_cpp.proto",
     ],
+    deps = ["@com_google_protobuf//:timestamp_proto"]
 )
 
 upb_proto_library(

--- a/tests/test_cpp.cc
+++ b/tests/test_cpp.cc
@@ -171,7 +171,7 @@ TEST(Cpp, TimestampEncoder) {
   for(long timestamp: timestamps) {
     google_protobuf_Timestamp_set_seconds(timestamp_upb, timestamp);
 
-    char* json = new char[23];
+    char json[23];
     size_t size = upb_JsonEncode(timestamp_upb, md.ptr(), NULL, 0, json, 23, NULL);
     bool result = upb_JsonDecode(json, size, timestamp_upb_decoded, md.ptr(), NULL, 0, arena.ptr(), NULL);
     const long timestamp_decoded = google_protobuf_Timestamp_seconds(timestamp_upb_decoded); 

--- a/tests/test_cpp.cc
+++ b/tests/test_cpp.cc
@@ -171,8 +171,8 @@ TEST(Cpp, TimestampEncoder) {
   for(long timestamp: timestamps) {
     google_protobuf_Timestamp_set_seconds(timestamp_upb, timestamp);
 
-    char json[23];
-    size_t size = upb_JsonEncode(timestamp_upb, md.ptr(), NULL, 0, json, 23, NULL);
+    char json[128];
+    size_t size = upb_JsonEncode(timestamp_upb, md.ptr(), NULL, 0, json, sizeof(json), NULL);
     bool result = upb_JsonDecode(json, size, timestamp_upb_decoded, md.ptr(), NULL, 0, arena.ptr(), NULL);
     const long timestamp_decoded = google_protobuf_Timestamp_seconds(timestamp_upb_decoded); 
 

--- a/tests/test_cpp.cc
+++ b/tests/test_cpp.cc
@@ -171,8 +171,8 @@ TEST(Cpp, TimestampEncoder) {
   for(long timestamp: timestamps) {
     google_protobuf_Timestamp_set_seconds(timestamp_upb, timestamp);
 
-    char* json = new char[300];
-    size_t size = upb_JsonEncode(timestamp_upb, md.ptr(), NULL, 0, json, 300, NULL);
+    char* json = new char[23];
+    size_t size = upb_JsonEncode(timestamp_upb, md.ptr(), NULL, 0, json, 23, NULL);
     bool result = upb_JsonDecode(json, size, timestamp_upb_decoded, md.ptr(), NULL, 0, arena.ptr(), NULL);
     const long timestamp_decoded = google_protobuf_Timestamp_seconds(timestamp_upb_decoded); 
 

--- a/upb/json_encode.c
+++ b/upb/json_encode.c
@@ -139,10 +139,6 @@ static void jsonenc_nanos(jsonenc* e, int32_t nanos) {
   jsonenc_printf(e, ".%.*" PRId32, digits, nanos);
 }
 
-static int64_t safe_mod(int64_t value, int64_t divisor) {
-  return (value%divisor + divisor)%divisor;
-}	
-
 static void jsonenc_timestamp(jsonenc* e, const upb_Message* msg,
                               const upb_MessageDef* m) {
   const upb_FieldDef* seconds_f =
@@ -166,21 +162,21 @@ static void jsonenc_timestamp(jsonenc* e, const upb_Message* msg,
    * Fliegel, H. F., and Van Flandern, T. C., "A Machine Algorithm for
    *   Processing Calendar Dates," Communications of the Association of
    *   Computing Machines, vol. 11 (1968), p. 657.  */
-  L = seconds / 86400.0 + 68569 + 2440588;
+  seconds += 62135596800; // Ensure seconds is positive. 
+  L = seconds / 86400 - 719162 + 68569 + 2440588
   N = 4 * L / 146097;
   L = L - (146097 * N + 3) / 4;
   I = 4000 * (L + 1) / 1461001;
   L = L - 1461 * I / 4 + 31;
   J = 80 * L / 2447;
   K = L - 2447 * J / 80;
-
   L = J / 11;
   J = J + 2 - 12 * L;
   I = 100 * (N - 49) + I + L;
 
-  sec = safe_mod(seconds, 60);
-  min = safe_mod((seconds / 60), 60);
-  hour = safe_mod((seconds / 3600), 24);
+  sec = seconds % 60;
+  min = (seconds / 60) % 60;
+  hour = (seconds / 3600) % 24;
 
   jsonenc_printf(e, "\"%04d-%02d-%02dT%02d:%02d:%02d", I, J, K, hour, min, sec);
   jsonenc_nanos(e, nanos);

--- a/upb/json_encode.c
+++ b/upb/json_encode.c
@@ -163,7 +163,7 @@ static void jsonenc_timestamp(jsonenc* e, const upb_Message* msg,
    *   Processing Calendar Dates," Communications of the Association of
    *   Computing Machines, vol. 11 (1968), p. 657.  */
   seconds += 62135596800; // Ensure seconds is positive. 
-  L = seconds / 86400 - 719162 + 68569 + 2440588
+  L = (int)(seconds / 86400) - 719162 + 68569 + 2440588;
   N = 4 * L / 146097;
   L = L - (146097 * N + 3) / 4;
   I = 4000 * (L + 1) / 1461001;


### PR DESCRIPTION
This PR solved the problem around encoding data less than 1970, related in [this issue](https://github.com/protocolbuffers/protobuf/issues/9424).

The problem subdivides into two problems. The first problem is about how to use the modulus operator, the native module C is not safe for negative operations, producing the negative hours. The second problem is about precision int that introduces more 1 day when the day is less than 1970 with 3 hours. 