### PR TITLE
Update to new protobuf version

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,26 +1,13 @@
 workspace(name = "upb")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("//bazel:workspace_defs.bzl", "system_python")
-
-git_repository(
-    name = "com_google_protobuf",
-    commit = "2f91da585e96a7efe43505f714f03c7716a94ecb",
-    remote = "https://github.com/protocolbuffers/protobuf.git",
-    #strip_prefix = "protobuf-3.19.1",
-    patches = [
-        "//bazel:protobuf.patch",
-    ],
-    patch_cmds = [
-        "rm python/google/protobuf/__init__.py",
-        "rm python/google/protobuf/pyext/__init__.py",
-        "rm python/google/protobuf/internal/__init__.py",
-    ]
-)
 
 load("//bazel:workspace_deps.bzl", "upb_deps")
 upb_deps()
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+protobuf_deps()
 
 http_archive(
     name = "lua",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,9 +1,9 @@
 workspace(name = "upb")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("//bazel:workspace_deps.bzl", "upb_deps")
 load("//bazel:workspace_defs.bzl", "system_python")
 
-load("//bazel:workspace_deps.bzl", "upb_deps")
 upb_deps()
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,9 +1,25 @@
 workspace(name = "upb")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("//bazel:workspace_deps.bzl", "upb_deps")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("//bazel:workspace_defs.bzl", "system_python")
 
+git_repository(
+    name = "com_google_protobuf",
+    commit = "2f91da585e96a7efe43505f714f03c7716a94ecb",
+    remote = "https://github.com/protocolbuffers/protobuf.git",
+    #strip_prefix = "protobuf-3.19.1",
+    patches = [
+        "//bazel:protobuf.patch",
+    ],
+    patch_cmds = [
+        "rm python/google/protobuf/__init__.py",
+        "rm python/google/protobuf/pyext/__init__.py",
+        "rm python/google/protobuf/internal/__init__.py",
+    ]
+)
+
+load("//bazel:workspace_deps.bzl", "upb_deps")
 upb_deps()
 
 http_archive(

--- a/bazel/workspace_deps.bzl
+++ b/bazel/workspace_deps.bzl
@@ -1,9 +1,6 @@
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-
-# Any users of upb must define the protobuf repo must depend explicitly on
-# protobuf prior to loading and calling upb_deps().
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 def upb_deps():
     maybe(
@@ -12,6 +9,21 @@ def upb_deps():
         url = "https://github.com/abseil/abseil-cpp/archive/b9b925341f9e90f5e7aa0cf23f036c29c7e454eb.zip",
         strip_prefix = "abseil-cpp-b9b925341f9e90f5e7aa0cf23f036c29c7e454eb",
         sha256 = "bb2a0b57c92b6666e8acb00f4cbbfce6ddb87e83625fb851b0e78db581340617",
+    )
+
+    maybe(
+        git_repository,
+        name = "com_google_protobuf",
+        commit = "2f91da585e96a7efe43505f714f03c7716a94ecb",
+        remote = "https://github.com/protocolbuffers/protobuf.git",
+        patches = [
+            "//bazel:protobuf.patch",
+        ],
+        patch_cmds = [
+            "rm python/google/protobuf/__init__.py",
+            "rm python/google/protobuf/pyext/__init__.py",
+            "rm python/google/protobuf/internal/__init__.py",
+        ]
     )
 
     rules_python_version = "740825b7f74930c62f44af95c9a4c1bd428d2c53" # Latest @ 2021-06-23
@@ -30,5 +42,3 @@ def upb_deps():
         strip_prefix = "bazel-skylib-main",
         urls = ["https://github.com/bazelbuild/bazel-skylib/archive/main.tar.gz"],
     )
-
-    protobuf_deps()

--- a/bazel/workspace_deps.bzl
+++ b/bazel/workspace_deps.bzl
@@ -1,5 +1,8 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+# Any users of upb must define the protobuf repo must depend explicitly on
+# protobuf prior to loading and calling upb_deps().
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 def upb_deps():

--- a/bazel/workspace_deps.bzl
+++ b/bazel/workspace_deps.bzl
@@ -1,5 +1,6 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 def upb_deps():
     maybe(
@@ -8,25 +9,6 @@ def upb_deps():
         url = "https://github.com/abseil/abseil-cpp/archive/b9b925341f9e90f5e7aa0cf23f036c29c7e454eb.zip",
         strip_prefix = "abseil-cpp-b9b925341f9e90f5e7aa0cf23f036c29c7e454eb",
         sha256 = "bb2a0b57c92b6666e8acb00f4cbbfce6ddb87e83625fb851b0e78db581340617",
-    )
-
-    maybe(
-        http_archive,
-        name = "com_google_protobuf",
-        sha256 = "87407cd28e7a9c95d9f61a098a53cf031109d451a7763e7dd1253abf8b4df422",
-        strip_prefix = "protobuf-3.19.1",
-        urls = [
-            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v3.19.1.tar.gz",
-            "https://github.com/protocolbuffers/protobuf/archive/v3.19.1.tar.gz",
-        ],
-        patches = [
-            "//bazel:protobuf.patch",
-        ],
-        patch_cmds = [
-            "rm python/google/protobuf/__init__.py",
-            "rm python/google/protobuf/pyext/__init__.py",
-            "rm python/google/protobuf/internal/__init__.py",
-        ]
     )
 
     rules_python_version = "740825b7f74930c62f44af95c9a4c1bd428d2c53" # Latest @ 2021-06-23
@@ -46,11 +28,4 @@ def upb_deps():
         urls = ["https://github.com/bazelbuild/bazel-skylib/archive/main.tar.gz"],
     )
 
-    maybe(
-        http_archive,
-        name = "zlib",
-        build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
-        sha256 = "629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff",
-        strip_prefix = "zlib-1.2.11",
-        url = "https://github.com/madler/zlib/archive/v1.2.11.tar.gz",
-    )
+    protobuf_deps()

--- a/cmake/google/protobuf/descriptor.upb.c
+++ b/cmake/google/protobuf/descriptor.upb.c
@@ -309,20 +309,21 @@ static const upb_MiniTable_Sub google_protobuf_FieldOptions_submsgs[3] = {
   {.subenum = &google_protobuf_FieldOptions_JSType_enuminit},
 };
 
-static const upb_MiniTable_Field google_protobuf_FieldOptions__fields[7] = {
+static const upb_MiniTable_Field google_protobuf_FieldOptions__fields[8] = {
   {1, UPB_SIZE(4, 4), 1, 1, 14, kUpb_FieldMode_Scalar | (upb_FieldRep_4Byte << upb_FieldRep_Shift)},
   {2, UPB_SIZE(12, 12), 2, 0, 8, kUpb_FieldMode_Scalar | (upb_FieldRep_1Byte << upb_FieldRep_Shift)},
   {3, UPB_SIZE(13, 13), 3, 0, 8, kUpb_FieldMode_Scalar | (upb_FieldRep_1Byte << upb_FieldRep_Shift)},
   {5, UPB_SIZE(14, 14), 4, 0, 8, kUpb_FieldMode_Scalar | (upb_FieldRep_1Byte << upb_FieldRep_Shift)},
   {6, UPB_SIZE(8, 8), 5, 2, 14, kUpb_FieldMode_Scalar | (upb_FieldRep_4Byte << upb_FieldRep_Shift)},
   {10, UPB_SIZE(15, 15), 6, 0, 8, kUpb_FieldMode_Scalar | (upb_FieldRep_1Byte << upb_FieldRep_Shift)},
-  {999, UPB_SIZE(16, 16), 0, 0, 11, kUpb_FieldMode_Array | (upb_FieldRep_Pointer << upb_FieldRep_Shift)},
+  {15, UPB_SIZE(16, 16), 7, 0, 8, kUpb_FieldMode_Scalar | (upb_FieldRep_1Byte << upb_FieldRep_Shift)},
+  {999, UPB_SIZE(20, 24), 0, 0, 11, kUpb_FieldMode_Array | (upb_FieldRep_Pointer << upb_FieldRep_Shift)},
 };
 
 const upb_MiniTable google_protobuf_FieldOptions_msginit = {
   &google_protobuf_FieldOptions_submsgs[0],
   &google_protobuf_FieldOptions__fields[0],
-  UPB_SIZE(24, 24), 7, upb_ExtMode_Extendable, 3, 255, 0,
+  UPB_SIZE(24, 32), 8, upb_ExtMode_Extendable, 3, 255, 0,
 };
 
 static const upb_MiniTable_Sub google_protobuf_OneofOptions_submsgs[1] = {

--- a/cmake/google/protobuf/descriptor.upb.h
+++ b/cmake/google/protobuf/descriptor.upb.h
@@ -1638,8 +1638,12 @@ UPB_INLINE bool google_protobuf_FieldOptions_has_weak(const google_protobuf_Fiel
 UPB_INLINE bool google_protobuf_FieldOptions_weak(const google_protobuf_FieldOptions* msg) {
   return *UPB_PTR_AT(msg, UPB_SIZE(15, 15), bool);
 }
-UPB_INLINE bool google_protobuf_FieldOptions_has_uninterpreted_option(const google_protobuf_FieldOptions *msg) { return _upb_has_submsg_nohasbit(msg, UPB_SIZE(16, 16)); }
-UPB_INLINE const google_protobuf_UninterpretedOption* const* google_protobuf_FieldOptions_uninterpreted_option(const google_protobuf_FieldOptions *msg, size_t *len) { return (const google_protobuf_UninterpretedOption* const*)_upb_array_accessor(msg, UPB_SIZE(16, 16), len); }
+UPB_INLINE bool google_protobuf_FieldOptions_has_unverified_lazy(const google_protobuf_FieldOptions *msg) { return _upb_hasbit(msg, 7); }
+UPB_INLINE bool google_protobuf_FieldOptions_unverified_lazy(const google_protobuf_FieldOptions* msg) {
+  return *UPB_PTR_AT(msg, UPB_SIZE(16, 16), bool);
+}
+UPB_INLINE bool google_protobuf_FieldOptions_has_uninterpreted_option(const google_protobuf_FieldOptions *msg) { return _upb_has_submsg_nohasbit(msg, UPB_SIZE(20, 24)); }
+UPB_INLINE const google_protobuf_UninterpretedOption* const* google_protobuf_FieldOptions_uninterpreted_option(const google_protobuf_FieldOptions *msg, size_t *len) { return (const google_protobuf_UninterpretedOption* const*)_upb_array_accessor(msg, UPB_SIZE(20, 24), len); }
 
 UPB_INLINE void google_protobuf_FieldOptions_set_ctype(google_protobuf_FieldOptions *msg, int32_t value) {
   _upb_sethas(msg, 1);
@@ -1665,16 +1669,20 @@ UPB_INLINE void google_protobuf_FieldOptions_set_weak(google_protobuf_FieldOptio
   _upb_sethas(msg, 6);
   *UPB_PTR_AT(msg, UPB_SIZE(15, 15), bool) = value;
 }
+UPB_INLINE void google_protobuf_FieldOptions_set_unverified_lazy(google_protobuf_FieldOptions *msg, bool value) {
+  _upb_sethas(msg, 7);
+  *UPB_PTR_AT(msg, UPB_SIZE(16, 16), bool) = value;
+}
 UPB_INLINE google_protobuf_UninterpretedOption** google_protobuf_FieldOptions_mutable_uninterpreted_option(google_protobuf_FieldOptions *msg, size_t *len) {
-  return (google_protobuf_UninterpretedOption**)_upb_array_mutable_accessor(msg, UPB_SIZE(16, 16), len);
+  return (google_protobuf_UninterpretedOption**)_upb_array_mutable_accessor(msg, UPB_SIZE(20, 24), len);
 }
 UPB_INLINE google_protobuf_UninterpretedOption** google_protobuf_FieldOptions_resize_uninterpreted_option(google_protobuf_FieldOptions *msg, size_t len, upb_Arena *arena) {
-  return (google_protobuf_UninterpretedOption**)_upb_Array_Resize_accessor2(msg, UPB_SIZE(16, 16), len, UPB_SIZE(2, 3), arena);
+  return (google_protobuf_UninterpretedOption**)_upb_Array_Resize_accessor2(msg, UPB_SIZE(20, 24), len, UPB_SIZE(2, 3), arena);
 }
 UPB_INLINE struct google_protobuf_UninterpretedOption* google_protobuf_FieldOptions_add_uninterpreted_option(google_protobuf_FieldOptions *msg, upb_Arena *arena) {
   struct google_protobuf_UninterpretedOption* sub = (struct google_protobuf_UninterpretedOption*)_upb_Message_New(&google_protobuf_UninterpretedOption_msginit, arena);
   bool ok = _upb_Array_Append_accessor2(
-      msg, UPB_SIZE(16, 16), UPB_SIZE(2, 3), &sub, arena);
+      msg, UPB_SIZE(20, 24), UPB_SIZE(2, 3), &sub, arena);
   if (!ok) return NULL;
   return sub;
 }

--- a/cmake/make_cmakelists.py
+++ b/cmake/make_cmakelists.py
@@ -217,6 +217,9 @@ class WorkspaceFileFunctions(object):
   def upb_deps(self):
     pass
 
+  def protobuf_deps(self):
+    pass
+
   def rules_fuzzing_dependencies(self):
     pass
 

--- a/python/pb_unit_tests/descriptor_test_wrapper.py
+++ b/python/pb_unit_tests/descriptor_test_wrapper.py
@@ -40,5 +40,7 @@ descriptor_test.MakeDescriptorTest.testJsonName.__unittest_expecting_failure__ =
 # Our error message is better.
 descriptor_test.NewDescriptorTest.testImmutableCppDescriptor.__unittest_expecting_failure__ = True
 
+descriptor_test.DescriptorTest.testGetDebugString.__unittest_expecting_failure__ = True
+
 if __name__ == '__main__':
   unittest.main(module=descriptor_test, verbosity=2)

--- a/python/pb_unit_tests/message_test_wrapper.py
+++ b/python/pb_unit_tests/message_test_wrapper.py
@@ -46,8 +46,12 @@ message_test.MessageTest.testFloatPrinting_proto3.__unittest_expecting_failure__
 message_test.Proto3Test.testCopyFromBadType.__unittest_expecting_failure__ = True
 message_test.Proto3Test.testMergeFromBadType.__unittest_expecting_failure__ = True
 
+message_test.MessageTest.testPickleRepeatedScalarContainer_proto2.__unittest_expecting_failure__ = True
+message_test.MessageTest.testPickleRepeatedScalarContainer_proto3.__unittest_expecting_failure__ = True
 message_test.Proto2Test.testPythonicInit.__unittest_expecting_failure__ = True
 message_test.Proto2Test.test_documentation.__unittest_expecting_failure__ = True
+message_test.Proto3Test.testModifyMapEntryWhileIterating.__unittest_expecting_failure__ = True
+message_test.Proto3Test.testProto3Optional.__unittest_expecting_failure__ = True
 
 if __name__ == '__main__':
   unittest.main(module=message_test, verbosity=2)


### PR DESCRIPTION
Motivation: this will allow us to use the toolchain support for manylinux, to move us closer to building packages.

This incidentally brings in a few new Python tests that are failing, and must be added to the failure list.

Small fix: removed our explicit zlib dependency in favor of calling `protobuf_deps()`.