### PR TITLE
Fixed two bugs with proto2 enums

### DIFF
--- a/upb/def.c
+++ b/upb/def.c
@@ -2402,7 +2402,7 @@ static int count_bits_debug(uint64_t x) {
 static int compare_int32(const void* a_ptr, const void* b_ptr) {
   int32_t a = *(int32_t*)a_ptr;
   int32_t b = *(int32_t*)b_ptr;
-  return ((a) < (b) ? -1 : ((a) == (b) ? 0 : 1));
+  return (a) < (b) ? -1 : ((a) == (b) ? 0 : 1);
 }
 
 upb_MiniTable_Enum* create_enumlayout(symtab_addctx* ctx,

--- a/upb/def.c
+++ b/upb/def.c
@@ -2403,7 +2403,7 @@ static int count_bits_debug(uint64_t x) {
 static int compare_int32(const void* a_ptr, const void* b_ptr) {
   int32_t a = *(int32_t*)a_ptr;
   int32_t b = *(int32_t*)b_ptr;
-  return (a) < (b) ? -1 : ((a) == (b) ? 0 : 1);
+  return a < b ? -1 : (a == b ? 0 : 1);
 }
 
 upb_MiniTable_Enum* create_enumlayout(symtab_addctx* ctx,

--- a/upb/def.c
+++ b/upb/def.c
@@ -1623,7 +1623,9 @@ static void make_layout(symtab_addctx* ctx, const upb_MessageDef* m) {
   l->size = UPB_ALIGN_UP(l->size, 8);
 
   /* Sort fields by number. */
-  qsort(fields, upb_MessageDef_numfields(m), sizeof(*fields), field_number_cmp);
+  if (fields) {
+    qsort(fields, upb_MessageDef_numfields(m), sizeof(*fields), field_number_cmp);
+  }
   assign_layout_indices(m, l, fields);
 }
 
@@ -2434,7 +2436,7 @@ upb_MiniTable_Enum* create_enumlayout(symtab_addctx* ctx,
   }
 
   // Enums can have duplicate values; we must sort+uniq them.
-  qsort(values, n, sizeof(*values), &compare_int32);
+  if (values) qsort(values, n, sizeof(*values), &compare_int32);
 
   int dst = 0;
   for (int i = 0; i < n; dst++) {

--- a/upb/def.c
+++ b/upb/def.c
@@ -1624,7 +1624,8 @@ static void make_layout(symtab_addctx* ctx, const upb_MessageDef* m) {
 
   /* Sort fields by number. */
   if (fields) {
-    qsort(fields, upb_MessageDef_numfields(m), sizeof(*fields), field_number_cmp);
+    qsort(fields, upb_MessageDef_numfields(m), sizeof(*fields),
+          field_number_cmp);
   }
   assign_layout_indices(m, l, fields);
 }

--- a/upb/def.h
+++ b/upb/def.h
@@ -389,7 +389,7 @@ typedef struct _upb_DefPool_Init {
   upb_StringView descriptor; /* Serialized descriptor. */
 } _upb_DefPool_Init;
 
-// Should only be directly called by tests.  This varant lets us suppress
+// Should only be directly called by tests.  This variant lets us suppress
 // the use of compiled-in tables, forcing a rebuild of the tables at runtime.
 bool _upb_DefPool_LoadDefInitEx(upb_DefPool* s, const _upb_DefPool_Init* init,
                                 bool rebuild_minitable);

--- a/upb/def.h
+++ b/upb/def.h
@@ -389,7 +389,15 @@ typedef struct _upb_DefPool_Init {
   upb_StringView descriptor; /* Serialized descriptor. */
 } _upb_DefPool_Init;
 
-bool _upb_DefPool_LoadDefInit(upb_DefPool* s, const _upb_DefPool_Init* init);
+// Should only be directly called by tests.  This varant lets us suppress
+// the use of compiled-in tables, forcing a rebuild of the tables at runtime.
+bool _upb_DefPool_LoadDefInitEx(upb_DefPool* s, const _upb_DefPool_Init* init,
+                                bool rebuild_minitable);
+
+UPB_INLINE bool _upb_DefPool_LoadDefInit(upb_DefPool* s,
+                                         const _upb_DefPool_Init* init) {
+  return _upb_DefPool_LoadDefInitEx(s, init, false);
+}
 
 #include "upb/port_undef.inc"
 

--- a/upb/util/def_to_proto_test.cc
+++ b/upb/util/def_to_proto_test.cc
@@ -125,3 +125,19 @@ TEST(DefToProto, Test) {
   upb::FileDefPtr file = msgdef.file();
   CheckFile(file, file_desc);
 }
+
+// Like the previous test, but uses a message layout built at runtime.
+TEST(DefToProto, TestRuntimeReflection) {
+  upb::Arena arena;
+  upb::SymbolTable symtab;
+  upb_StringView test_file_desc =
+      upb_util_def_to_proto_test_proto_upbdefinit.descriptor;
+  const auto* file_desc = google_protobuf_FileDescriptorProto_parse(
+      test_file_desc.data, test_file_desc.size, arena.ptr());
+
+  _upb_DefPool_LoadDefInitEx(
+      symtab.ptr(), &upb_util_def_to_proto_test_proto_upbdefinit, true);
+  upb::FileDefPtr file = symtab.FindFileByName(
+      upb_util_def_to_proto_test_proto_upbdefinit.filename);
+  CheckFile(file, file_desc);
+}

--- a/upb/util/def_to_proto_test.proto
+++ b/upb/util/def_to_proto_test.proto
@@ -69,6 +69,26 @@ enum Enum {
   NEGATIVE_ONE = -1;
 }
 
+enum EnumUpper32Value {
+  UPPER32_VALUE = 40;
+}
+
+enum HasDuplicateValues {
+  option allow_alias = true;
+  A = 0;
+  B = 1;
+  C = 120;
+  D = 130;
+
+  G = 120;
+  F = 1;
+  E = 0;
+  H = 121;
+  I = 121;
+  J = 121;
+  K = 121;
+}
+
 service Service {
   rpc Bar(Message) returns (Message);
 }

--- a/upb/util/def_to_proto_test.proto
+++ b/upb/util/def_to_proto_test.proto
@@ -97,6 +97,10 @@ extend Message {
   optional int32 ext = 1001;
 }
 
+enum Has31 {
+  VALUE_31 = 31;
+}
+
 message PretendMessageSet {
   option message_set_wire_format = true;
   // Since this is message_set_wire_format, "max" here means INT32_MAX.

--- a/upbc/protoc-gen-upb.cc
+++ b/upbc/protoc-gen-upb.cc
@@ -1324,7 +1324,7 @@ int WriteEnums(const protobuf::FileDescriptor* file, Output& output) {
     if (!values.empty()) {
       values_init = EnumInit(e) + "_values";
       output("static const int32_t $0[$1] = {\n", values_init, values.size());
-      for (auto value : values) {
+      for (int32_t value : values) {
         output("  $0,\n", value);
       }
       output("};\n\n");

--- a/upbc/protoc-gen-upb.cc
+++ b/upbc/protoc-gen-upb.cc
@@ -1323,8 +1323,7 @@ int WriteEnums(const protobuf::FileDescriptor* file, Output& output) {
 
     if (!values.empty()) {
       values_init = EnumInit(e) + "_values";
-      output("static const int32_t $0[$1] = {\n", values_init,
-             values.size());
+      output("static const int32_t $0[$1] = {\n", values_init, values.size());
       for (auto value : values) {
         output("  $0,\n", value);
       }

--- a/upbc/protoc-gen-upb.cc
+++ b/upbc/protoc-gen-upb.cc
@@ -1314,7 +1314,7 @@ int WriteEnums(const protobuf::FileDescriptor* file, Output& output) {
     absl::flat_hash_set<int32_t> values;
     for (auto number : SortedUniqueEnumNumbers(e)) {
       if (static_cast<uint32_t>(number) < 64) {
-        mask |= 1 << number;
+        mask |= 1ULL << number;
       } else {
         values.insert(number);
       }

--- a/upbc/protoc-gen-upb.cc
+++ b/upbc/protoc-gen-upb.cc
@@ -95,6 +95,17 @@ std::vector<const protobuf::EnumDescriptor*> SortedEnums(
   return enums;
 }
 
+std::vector<int32_t> SortedUniqueEnumNumbers(
+    const protobuf::EnumDescriptor* e) {
+  std::vector<int32_t> values;
+  for (int i = 0; i < e->value_count(); i++) {
+    values.push_back(e->value(i)->number());
+  }
+  std::sort(values.begin(), values.end());
+  std::unique(values.begin(), values.end());
+  return values;
+}
+
 void AddMessages(const protobuf::Descriptor* message,
                  std::vector<const protobuf::Descriptor*>* messages) {
   messages->push_back(message);
@@ -1301,8 +1312,7 @@ int WriteEnums(const protobuf::FileDescriptor* file, Output& output) {
   for (const auto* e : this_file_enums) {
     uint64_t mask = 0;
     absl::flat_hash_set<int32_t> values;
-    for (int i = 0; i < e->value_count(); i++) {
-      int32_t number = e->value(i)->number();
+    for (auto number : SortedUniqueEnumNumbers(e)) {
       if (static_cast<uint32_t>(number) < 64) {
         mask |= 1 << number;
       } else {


### PR DESCRIPTION
1. The mask was getting improperly truncated for values 32-63.
2. We were not handling duplicated enum values.

In both cases asserts would catch the error. However in no-asserts builds, this bug could cause values parsed from the wire to be inappropriate placed into the unknown field set.