### PR TITLE
Added fuzzing of symtab build, and fixed a handful of minor bugs.

### DIFF
--- a/upb/def.c
+++ b/upb/def.c
@@ -2958,7 +2958,7 @@ static void build_filedef(
   int32_t* mutable_weak_deps = (int32_t*)file->weak_deps;
   for (i = 0; i < n; i++) {
     if (weak_deps[i] >= file->dep_count) {
-      symtab_errf(ctx, "public_dep %d is out of range", (int)weak_deps[i]);
+      symtab_errf(ctx, "weak_dep %d is out of range", (int)weak_deps[i]);
     }
     mutable_weak_deps[i] = weak_deps[i];
   }

--- a/upb/fuzz/BUILD
+++ b/upb/fuzz/BUILD
@@ -7,6 +7,7 @@ cc_fuzz_test(
     srcs = ["file_descriptor_parsenew_fuzzer.cc"],
     deps = [
         "//:descriptor_upb_proto",
+        "//:reflection",
         "//:upb",
     ],
 )

--- a/upb/fuzz/file_descriptor_parsenew_fuzzer.cc
+++ b/upb/fuzz/file_descriptor_parsenew_fuzzer.cc
@@ -26,8 +26,8 @@
 #include <cstdint>
 
 #include "google/protobuf/descriptor.upb.h"
-#include "upb/upb.hpp"
 #include "upb/def.hpp"
+#include "upb/upb.hpp"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   upb::Arena arena;

--- a/upb/fuzz/file_descriptor_parsenew_fuzzer.cc
+++ b/upb/fuzz/file_descriptor_parsenew_fuzzer.cc
@@ -27,10 +27,17 @@
 
 #include "google/protobuf/descriptor.upb.h"
 #include "upb/upb.hpp"
+#include "upb/def.hpp"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   upb::Arena arena;
-  google_protobuf_FileDescriptorProto_parse(reinterpret_cast<const char*>(data),
-                                            size, arena.ptr());
+  google_protobuf_FileDescriptorProto* proto =
+      google_protobuf_FileDescriptorProto_parse(
+          reinterpret_cast<const char*>(data), size, arena.ptr());
+  if (proto) {
+    upb::SymbolTable symtab;
+    upb::Status status;
+    symtab.AddFile(proto, &status);
+  }
   return 0;
 }


### PR DESCRIPTION
This extends our existing fuzz test to cover not only the parser, but the code that loads a descriptor into a `upb_DefPool`.

I expect this would have caught https://github.com/protocolbuffers/upb/pull/525