### PR TITLE
Remaining fixes to make Python tests pass in google3

### DIFF
--- a/python/descriptor.c
+++ b/python/descriptor.c
@@ -1338,6 +1338,12 @@ static PyObject* PyUpb_MethodDescriptor_GetFullName(PyObject* self,
   return PyUnicode_FromString(upb_MethodDef_FullName(m));
 }
 
+static PyObject* PyUpb_MethodDescriptor_GetIndex(PyObject* self,
+                                                 void* closure) {
+  const upb_MethodDef* oneof = PyUpb_MethodDescriptor_GetDef(self);
+  return PyLong_FromLong(upb_MethodDef_Index(oneof));
+}
+
 static PyObject* PyUpb_MethodDescriptor_GetContainingService(PyObject* self,
                                                              void* closure) {
   const upb_MethodDef* m = PyUpb_MethodDescriptor_GetDef(self);
@@ -1375,8 +1381,7 @@ static PyObject* PyUpb_MethodDescriptor_CopyToProto(PyObject* _self,
 static PyGetSetDef PyUpb_MethodDescriptor_Getters[] = {
     {"name", PyUpb_MethodDescriptor_GetName, NULL, "Name", NULL},
     {"full_name", PyUpb_MethodDescriptor_GetFullName, NULL, "Full name", NULL},
-    // TODO(https://github.com/protocolbuffers/upb/issues/459)
-    //{ "index", PyUpb_MethodDescriptor_GetIndex, NULL, "Index", NULL},
+    {"index", PyUpb_MethodDescriptor_GetIndex, NULL, "Index", NULL},
     {"containing_service", PyUpb_MethodDescriptor_GetContainingService, NULL,
      "Containing service", NULL},
     {"input_type", PyUpb_MethodDescriptor_GetInputType, NULL, "Input type",

--- a/python/extension_dict.c
+++ b/python/extension_dict.c
@@ -88,6 +88,23 @@ static void PyUpb_ExtensionDict_Dealloc(PyUpb_ExtensionDict* self) {
   PyUpb_Dealloc(self);
 }
 
+static PyObject* PyUpb_ExtensionDict_RichCompare(PyObject* _self,
+                                                 PyObject* _other, int opid) {
+  // Only equality comparisons are implemented.
+  if (opid != Py_EQ && opid != Py_NE) {
+    Py_INCREF(Py_NotImplemented);
+    return Py_NotImplemented;
+  }
+  PyUpb_ExtensionDict* self = (PyUpb_ExtensionDict*)_self;
+  bool equals = false;
+  if (PyObject_TypeCheck(_other, Py_TYPE(_self))) {
+    PyUpb_ExtensionDict* other = (PyUpb_ExtensionDict*)_other;
+    equals = self->msg == other->msg;
+  }
+  bool ret = opid == Py_EQ ? equals : !equals;
+  return PyBool_FromLong(ret);
+}
+
 static int PyUpb_ExtensionDict_Contains(PyObject* _self, PyObject* key) {
   PyUpb_ExtensionDict* self = (PyUpb_ExtensionDict*)_self;
   const upb_FieldDef* f = PyUpb_CMessage_GetExtensionDef(self->msg, key);
@@ -143,7 +160,7 @@ static PyType_Slot PyUpb_ExtensionDict_Slots[] = {
     {Py_tp_methods, PyUpb_ExtensionDict_Methods},
     //{Py_tp_getset, PyUpb_ExtensionDict_Getters},
     //{Py_tp_hash, PyObject_HashNotImplemented},
-    //{Py_tp_richcompare, PyUpb_ExtensionDict_RichCompare},
+    {Py_tp_richcompare, PyUpb_ExtensionDict_RichCompare},
     {Py_tp_iter, PyUpb_ExtensionIterator_New},
     {Py_sq_contains, PyUpb_ExtensionDict_Contains},
     {Py_sq_length, PyUpb_ExtensionDict_Length},

--- a/python/message.c
+++ b/python/message.c
@@ -1482,6 +1482,7 @@ static PyObject* PyUpb_CMessage_GetExtensionDict(PyObject* _self,
                                                  void* closure) {
   PyUpb_CMessage* self = (void*)_self;
   if (self->ext_dict) {
+    Py_INCREF(self->ext_dict);
     return self->ext_dict;
   }
 

--- a/python/pb_unit_tests/descriptor_pool_test_wrapper.py
+++ b/python/pb_unit_tests/descriptor_pool_test_wrapper.py
@@ -27,6 +27,10 @@ from google.protobuf.internal import descriptor_pool_test
 import unittest
 import copy
 
+# copybara:insert_for_google3_begin
+# from google3.testing.pybase import googletest
+# copybara:insert_end
+
 # This is testing that certain methods unconditionally throw TypeError.
 # In the new extension we simply don't define them at all.
 descriptor_pool_test.AddDescriptorTest.testAddTypeError.__unittest_expecting_failure__ = True
@@ -34,4 +38,8 @@ descriptor_pool_test.AddDescriptorTest.testAddTypeError.__unittest_expecting_fai
 descriptor_pool_test.SecondaryDescriptorFromDescriptorDB.testErrorCollector.__unittest_expecting_failure__ = True
 
 if __name__ == '__main__':
+  # copybara:strip_for_google3_begin
   unittest.main(module=descriptor_pool_test, verbosity=2)
+  # copybara:replace_for_google3_begin
+  # googletest.main()
+  # copybara:replace_for_google3_end

--- a/python/pb_unit_tests/text_format_test_wrapper.py
+++ b/python/pb_unit_tests/text_format_test_wrapper.py
@@ -25,14 +25,16 @@
 
 from google.protobuf.internal import text_format_test
 import unittest
-from google.protobuf.internal import _parameterized
-
-sep = _parameterized._SEPARATOR
 
 # These rely on the UnknownFields accessor, which we are trying to deprecate.
 text_format_test.OnlyWorksWithProto2RightNowTests.testPrintUnknownFields.__unittest_expecting_failure__ = True
+
+# copybara:strip_for_google3_begin
+from google.protobuf.internal import _parameterized  # copybara:strip_for_google3
+sep = _parameterized._SEPARATOR
 getattr(text_format_test.TextFormatMessageToStringTests, "testPrintUnknownFieldsEmbeddedMessageInBytes" + sep + "0").__unittest_expecting_failure__ = True
 getattr(text_format_test.TextFormatMessageToStringTests, "testPrintUnknownFieldsEmbeddedMessageInBytes" + sep + "1").__unittest_expecting_failure__ = True
+# copybara:strip_end
 
 if __name__ == '__main__':
   unittest.main(module=text_format_test, verbosity=2)


### PR DESCRIPTION
1. Implemented `MethodDescriptor.index`.
2. Implemented comparison on `ExtensionDict`.
3. Fixed a reference bug: when we return a cached `ExtensionDict`, we need to incref it.
4. Patch a few differences in the tests to accommodate for differences in the google environment.