### PR TITLE
Added conformance test variant to exercise dynamic minitable building

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -436,6 +436,47 @@ sh_test(
     deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
+cc_binary(
+    name = "conformance_upb_dynamic_minitable",
+    testonly = 1,
+    srcs = ["upb/conformance_upb.c"],
+    copts = UPB_DEFAULT_COPTS + [
+        "-DREBUILD_MINITABLES"
+    ],
+    data = ["upb/conformance_upb_failures.txt"],
+    deps = [
+        ":conformance_proto_upb",
+        ":conformance_proto_upbdefs",
+        ":test_messages_proto2_upbdefs",
+        ":test_messages_proto3_upbdefs",
+        "//:json",
+        "//:port",
+        "//:reflection",
+        "//:textformat",
+        "//:upb",
+    ],
+)
+
+make_shell_script(
+    name = "gen_test_conformance_upb_dynamic_minitable",
+    out = "test_conformance_upb_dynamic_minitable.sh",
+    contents = "external/com_google_protobuf/conformance_test_runner " +
+               " --enforce_recommended " +
+               " --failure_list ./upb/conformance_upb_failures.txt" +
+               " ./conformance_upb_dynamic_minitable",
+)
+
+sh_test(
+    name = "test_conformance_upb_dynamic_minitable",
+    srcs = ["test_conformance_upb_dynamic_minitable.sh"],
+    data = [
+        "upb/conformance_upb_failures.txt",
+        ":conformance_upb_dynamic_minitable",
+        "@com_google_protobuf//:conformance_test_runner",
+    ],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)
+
 # Internal C/C++ libraries #####################################################
 
 cc_library(

--- a/upb/conformance_upb.c
+++ b/upb/conformance_upb.c
@@ -324,8 +324,10 @@ int main(void) {
   upb_DefPool* symtab = upb_DefPool_New();
 
 #ifdef REBUILD_MINITABLES
-  _upb_DefPool_LoadDefInitEx(symtab, &src_google_protobuf_test_messages_proto2_proto_upbdefinit, true);
-  _upb_DefPool_LoadDefInitEx(symtab, &src_google_protobuf_test_messages_proto3_proto_upbdefinit, true);
+  _upb_DefPool_LoadDefInitEx(
+      symtab, &src_google_protobuf_test_messages_proto2_proto_upbdefinit, true);
+  _upb_DefPool_LoadDefInitEx(
+      symtab, &src_google_protobuf_test_messages_proto3_proto_upbdefinit, true);
 #else
   protobuf_test_messages_proto2_TestAllTypesProto2_getmsgdef(symtab);
   protobuf_test_messages_proto3_TestAllTypesProto3_getmsgdef(symtab);

--- a/upb/conformance_upb.c
+++ b/upb/conformance_upb.c
@@ -323,8 +323,13 @@ bool DoTestIo(upb_DefPool* symtab) {
 int main(void) {
   upb_DefPool* symtab = upb_DefPool_New();
 
+#ifdef REBUILD_MINITABLES
+  _upb_DefPool_LoadDefInitEx(symtab, &src_google_protobuf_test_messages_proto2_proto_upbdefinit, true);
+  _upb_DefPool_LoadDefInitEx(symtab, &src_google_protobuf_test_messages_proto3_proto_upbdefinit, true);
+#else
   protobuf_test_messages_proto2_TestAllTypesProto2_getmsgdef(symtab);
   protobuf_test_messages_proto3_TestAllTypesProto3_getmsgdef(symtab);
+#endif
 
   while (1) {
     if (!DoTestIo(symtab)) {

--- a/upb/def.c
+++ b/upb/def.c
@@ -1413,7 +1413,11 @@ static uint8_t map_descriptortype(const upb_FieldDef* f) {
   if (type == kUpb_FieldType_String && f->file->syntax == kUpb_Syntax_Proto2) {
     return kUpb_FieldType_Bytes;
   } else if (type == kUpb_FieldType_Enum &&
-             f->sub.enumdef->file->syntax == kUpb_Syntax_Proto3) {
+             (f->sub.enumdef->file->syntax == kUpb_Syntax_Proto3 ||
+             // TODO(https://github.com/protocolbuffers/upb/issues/541):
+             // fix map enum values to check for unknown enum values and put
+             // them in the unknown field set.
+             upb_MessageDef_IsMapEntry(upb_FieldDef_ContainingType(f)))) {
     return kUpb_FieldType_Int32;
   }
   return type;

--- a/upb/def.c
+++ b/upb/def.c
@@ -1414,10 +1414,10 @@ static uint8_t map_descriptortype(const upb_FieldDef* f) {
     return kUpb_FieldType_Bytes;
   } else if (type == kUpb_FieldType_Enum &&
              (f->sub.enumdef->file->syntax == kUpb_Syntax_Proto3 ||
-             // TODO(https://github.com/protocolbuffers/upb/issues/541):
-             // fix map enum values to check for unknown enum values and put
-             // them in the unknown field set.
-             upb_MessageDef_IsMapEntry(upb_FieldDef_ContainingType(f)))) {
+              // TODO(https://github.com/protocolbuffers/upb/issues/541):
+              // fix map enum values to check for unknown enum values and put
+              // them in the unknown field set.
+              upb_MessageDef_IsMapEntry(upb_FieldDef_ContainingType(f)))) {
     return kUpb_FieldType_Int32;
   }
   return type;


### PR DESCRIPTION
The primary goal of this PR is to reproduce and fix the crash observed in https://github.com/protocolbuffers/upb/issues/540

However, to do so, we (temporarily) further entrench some incorrect behavior. Maps with unrecognized proto2 enum values should put the map entry into the unknown field set, but we do not currently do this.

A follow-up fix will implement the correct behavior for proto2 maps.

pair: @esorot 