### PR TITLE
Put map entries into unknown fields when unknown enum values are encountered

### DIFF
--- a/upb/decode.c
+++ b/upb/decode.c
@@ -416,19 +416,15 @@ static bool decode_checkenum_slow(upb_Decoder* d, const char* ptr,
   return false;
 }
 
-#include <stdio.h>
 UPB_FORCEINLINE
 static bool decode_checkenum(upb_Decoder* d, const char* ptr, upb_Message* msg,
                              const upb_MiniTable_Enum* e,
                              const upb_MiniTable_Field* field, wireval* val) {
   uint32_t v = val->uint32_val;
 
-  // printf("@test:we are here\n");
   if (UPB_LIKELY(v < 64) && UPB_LIKELY(((1ULL << v) & e->mask))) return true;
 
-  // printf("@test:we are here 2\n");
   bool ans =  decode_checkenum_slow(d, ptr, msg, e, field, v);
-  // printf("@test:%d\n", (int)ans);
   return ans;
 }
 

--- a/upb/decode.c
+++ b/upb/decode.c
@@ -424,8 +424,7 @@ static bool decode_checkenum(upb_Decoder* d, const char* ptr, upb_Message* msg,
 
   if (UPB_LIKELY(v < 64) && UPB_LIKELY(((1ULL << v) & e->mask))) return true;
 
-  bool ans =  decode_checkenum_slow(d, ptr, msg, e, field, v);
-  return ans;
+  return decode_checkenum_slow(d, ptr, msg, e, field, v);
 }
 
 UPB_NOINLINE

--- a/upb/decode.c
+++ b/upb/decode.c
@@ -636,7 +636,7 @@ static const char* decode_tomap(upb_Decoder* d, const char* ptr,
   // check if ent had any unknown fields
   size_t size;
   upb_Message_GetUnknown(&ent.k, &size);
-  if(size != 0) {
+  if (size != 0) {
     uint32_t tag = ((uint32_t)field->number << 3) | kUpb_WireType_Delimited;
     upb_Decode_AddUnknownVarints(d, msg, tag, (uint32_t)(ptr - start));
     if (!_upb_Message_AddUnknown(msg, start, ptr - start, &d->arena)) {

--- a/upb/decode.c
+++ b/upb/decode.c
@@ -385,6 +385,18 @@ static char* encode_varint32(uint32_t val, char* ptr) {
   return ptr;
 }
 
+static void upb_Decode_AddUnknownVarints(upb_Decoder* d, upb_Message* msg,
+                                         uint32_t val1, uint32_t val2) {
+  char buf[20];
+  char* end = buf;
+  end = encode_varint32(val1, end);
+  end = encode_varint32(val2, end);
+
+  if (!_upb_Message_AddUnknown(msg, buf, end - buf, &d->arena)) {
+    decode_err(d, kUpb_DecodeStatus_OutOfMemory);
+  }
+}
+
 UPB_NOINLINE
 static bool decode_checkenum_slow(upb_Decoder* d, const char* ptr,
                                   upb_Message* msg, const upb_MiniTable_Enum* e,
@@ -398,17 +410,9 @@ static bool decode_checkenum_slow(upb_Decoder* d, const char* ptr,
 
   // Unrecognized enum goes into unknown fields.
   // For packed fields the tag could be arbitrarily far in the past, so we
-  // just re-encode the tag here.
-  char buf[20];
-  char* end = buf;
+  // just re-encode the tag and value here.
   uint32_t tag = ((uint32_t)field->number << 3) | kUpb_WireType_Varint;
-  end = encode_varint32(tag, end);
-  end = encode_varint32(v, end);
-
-  if (!_upb_Message_AddUnknown(msg, buf, end - buf, &d->arena)) {
-    decode_err(d, kUpb_DecodeStatus_OutOfMemory);
-  }
-
+  upb_Decode_AddUnknownVarints(d, msg, tag, v);
   return false;
 }
 
@@ -419,12 +423,12 @@ static bool decode_checkenum(upb_Decoder* d, const char* ptr, upb_Message* msg,
                              const upb_MiniTable_Field* field, wireval* val) {
   uint32_t v = val->uint32_val;
 
-  printf("@test:we are here\n");
+  // printf("@test:we are here\n");
   if (UPB_LIKELY(v < 64) && UPB_LIKELY(((1ULL << v) & e->mask))) return true;
 
-  printf("@test:we are here 2\n");
+  // printf("@test:we are here 2\n");
   bool ans =  decode_checkenum_slow(d, ptr, msg, e, field, v);
-  printf("@test:%d\n", (int)ans);
+  // printf("@test:%d\n", (int)ans);
   return ans;
 }
 
@@ -632,13 +636,17 @@ static const char* decode_tomap(upb_Decoder* d, const char* ptr,
         upb_value_ptr(_upb_Message_New(entry->subs[0].submsg, &d->arena));
   }
 
+  const char* start = ptr;
   ptr = decode_tosubmsg(d, ptr, &ent.k, subs, field, val->size);
   // check if ent had any unknown fields
   size_t size;
-  const char* unknown = upb_Message_GetUnknown(&ent.k, &size);
-  printf("@test:size = %d %p\n", (int)size, unknown);
+  upb_Message_GetUnknown(&ent.k, &size);
   if(size != 0) {
-
+    uint32_t tag = ((uint32_t)field->number << 3) | kUpb_WireType_Delimited;
+    upb_Decode_AddUnknownVarints(d, msg, tag, (uint32_t)(ptr - start));
+    if (!_upb_Message_AddUnknown(msg, start, ptr - start, &d->arena)) {
+      decode_err(d, kUpb_DecodeStatus_OutOfMemory);
+    }
   } else {
     _upb_Map_Set(map, &ent.k, map->key_size, &ent.v, map->val_size, &d->arena);
   }

--- a/upb/decode.c
+++ b/upb/decode.c
@@ -412,15 +412,20 @@ static bool decode_checkenum_slow(upb_Decoder* d, const char* ptr,
   return false;
 }
 
+#include <stdio.h>
 UPB_FORCEINLINE
 static bool decode_checkenum(upb_Decoder* d, const char* ptr, upb_Message* msg,
                              const upb_MiniTable_Enum* e,
                              const upb_MiniTable_Field* field, wireval* val) {
   uint32_t v = val->uint32_val;
 
+  printf("@test:we are here\n");
   if (UPB_LIKELY(v < 64) && UPB_LIKELY(((1ULL << v) & e->mask))) return true;
 
-  return decode_checkenum_slow(d, ptr, msg, e, field, v);
+  printf("@test:we are here 2\n");
+  bool ans =  decode_checkenum_slow(d, ptr, msg, e, field, v);
+  printf("@test:%d\n", (int)ans);
+  return ans;
 }
 
 UPB_NOINLINE
@@ -628,7 +633,15 @@ static const char* decode_tomap(upb_Decoder* d, const char* ptr,
   }
 
   ptr = decode_tosubmsg(d, ptr, &ent.k, subs, field, val->size);
-  _upb_Map_Set(map, &ent.k, map->key_size, &ent.v, map->val_size, &d->arena);
+  // check if ent had any unknown fields
+  size_t size;
+  const char* unknown = upb_Message_GetUnknown(&ent.k, &size);
+  printf("@test:size = %d %p\n", (int)size, unknown);
+  if(size != 0) {
+
+  } else {
+    _upb_Map_Set(map, &ent.k, map->key_size, &ent.v, map->val_size, &d->arena);
+  }
   return ptr;
 }
 

--- a/upb/msg_test.cc
+++ b/upb/msg_test.cc
@@ -404,7 +404,8 @@ TEST(MessageTest, MapField) {
   upb_test_TestMapFieldExtra* test_msg_extra =
       upb_test_TestMapFieldExtra_new(arena.ptr());
 
-  ASSERT_TRUE(upb_test_TestMapFieldExtra_map_field_set(test_msg_extra, 0, upb_test_TestMapFieldExtra_THREE, arena.ptr()));
+  ASSERT_TRUE(upb_test_TestMapFieldExtra_map_field_set(
+      test_msg_extra, 0, upb_test_TestMapFieldExtra_THREE, arena.ptr()));
 
   size_t size;
   char* serialized = upb_test_TestMapFieldExtra_serialize_ex(
@@ -412,15 +413,17 @@ TEST(MessageTest, MapField) {
   ASSERT_NE(nullptr, serialized);
   ASSERT_NE(0, size);
 
-  upb_test_TestMapField* test_msg = upb_test_TestMapField_parse(serialized, size, arena.ptr());
+  upb_test_TestMapField* test_msg =
+      upb_test_TestMapField_parse(serialized, size, arena.ptr());
   ASSERT_NE(nullptr, test_msg);
 
   ASSERT_FALSE(upb_test_TestMapField_map_field_get(test_msg, 0, nullptr));
-  serialized = upb_test_TestMapField_serialize_ex(
-      test_msg, 0, arena.ptr(), &size);
+  serialized =
+      upb_test_TestMapField_serialize_ex(test_msg, 0, arena.ptr(), &size);
   ASSERT_NE(0, size);
   // parse into second instance
   upb_test_TestMapFieldExtra* test_msg_extra2 =
       upb_test_TestMapFieldExtra_parse(serialized, size, arena.ptr());
-  ASSERT_TRUE(upb_test_TestMapFieldExtra_map_field_get(test_msg_extra2, 0, nullptr));
+  ASSERT_TRUE(
+      upb_test_TestMapFieldExtra_map_field_get(test_msg_extra2, 0, nullptr));
 }

--- a/upb/msg_test.cc
+++ b/upb/msg_test.cc
@@ -398,3 +398,29 @@ TEST(MessageTest, MaxRequiredFields) {
       test_msg, kUpb_Encode_CheckRequired, arena.ptr(), &size);
   ASSERT_TRUE(serialized != nullptr);
 }
+
+TEST(MessageTest, MapField) {
+  upb::Arena arena;
+  upb_test_TestMapFieldExtra* test_msg_extra =
+      upb_test_TestMapFieldExtra_new(arena.ptr());
+
+  ASSERT_TRUE(upb_test_TestMapFieldExtra_map_field_set(test_msg_extra, 0, upb_test_TestMapFieldExtra_THREE, arena.ptr()));
+
+  size_t size;
+  char* serialized = upb_test_TestMapFieldExtra_serialize_ex(
+      test_msg_extra, 0, arena.ptr(), &size);
+  ASSERT_NE(nullptr, serialized);
+  ASSERT_NE(0, size);
+
+  upb_test_TestMapField* test_msg = upb_test_TestMapField_parse(serialized, size, arena.ptr());
+  ASSERT_NE(nullptr, test_msg);
+
+  ASSERT_FALSE(upb_test_TestMapField_map_field_get(test_msg, 0, nullptr));
+  serialized = upb_test_TestMapField_serialize_ex(
+      test_msg, 0, arena.ptr(), &size);
+  ASSERT_NE(0, size);
+  // parse into second instance
+  upb_test_TestMapFieldExtra* test_msg_extra2 =
+      upb_test_TestMapFieldExtra_parse(serialized, size, arena.ptr());
+  ASSERT_TRUE(upb_test_TestMapFieldExtra_map_field_get(test_msg_extra2, 0, nullptr));
+}

--- a/upb/msg_test.proto
+++ b/upb/msg_test.proto
@@ -158,3 +158,22 @@ message TestMaxRequiredFields {
   required int32 required_int32_61 = 61;
   required int32 required_int32_62 = 62;
 }
+
+message TestMapField {
+  enum EnumMap {
+    ZERO = 0;
+    ONE = 1;
+    TWO = 2;
+  }
+  map<int32, EnumMap> map_field = 1;
+}
+
+message TestMapFieldExtra {
+  enum EnumMap {
+    ZERO = 0;
+    ONE = 1;
+    TWO = 2;
+    THREE = 3;
+  }
+  map<int32, EnumMap> map_field = 1;
+}


### PR DESCRIPTION
This implements the expected proto2 functionality:

1. For any `map<ANY, FooEnum>`, with value type enum (and any key type)
2. Given a value UnknownVal that is *not* declared in `FooEnum`
3. Given a map entry `{Key: ANY, Val: UnknownVal}`
4. The entire map entry should be placed into unknown fields, instead of into the map.

However we currently implement a somewhat more sweeping test for (3). Currently we trigger this logic if if the map entry has any unknown fields whatsoever.

This is a gray area of the spec: it's not entirely clear what should happen if a map entry contains unknown fields (ie. key/value with the wrong wire type, or field numbers other than `1` and `2`). This is unlikely to occur in real code.