### PR TITLE
Remove none existing folders

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -681,10 +681,8 @@ exports_files(
 filegroup(
     name = "cmake_files",
     srcs = glob([
-        "google/**/*",
         "upbc/**/*",
         "upb/**/*",
-        "tests/**/*",
         "third_party/**/*",
     ]),
     visibility = ["//cmake:__pkg__"],


### PR DESCRIPTION
This folders do not exist and this prevents to build with --incompatible_disallow_empty_glob
https://github.com/bazelbuild/bazel/issues/8195