### PR TITLE
Move python deps to workspace_deps

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,7 +1,6 @@
 workspace(name = "upb")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("//bazel:python_downloads.bzl", "python_source_archive", "python_nuget_package")
 load("//bazel:workspace_deps.bzl", "upb_deps")
 
 upb_deps()
@@ -57,42 +56,3 @@ rules_fuzzing_dependencies()
 load("@rules_fuzzing//fuzzing:init.bzl", "rules_fuzzing_init")
 
 rules_fuzzing_init()
-
-#Python Downloads
-
-python_source_archive(
-    name = "python-3.7.0",
-    sha256 = "85bb9feb6863e04fb1700b018d9d42d1caac178559ffa453d7e6a436e259fd0d",
-)
-python_nuget_package(
-    name = "nuget_python_i686_3.7.0",
-    sha256 = "a8bb49fa1ca62ad55430fcafaca1b58015e22943e66b1a87d5e7cef2556c6a54",
-)
-python_nuget_package(
-    name = "nuget_python_x86-64_3.7.0",
-    sha256 = "66eb796a5bdb1e6787b8f655a1237a6b6964af2115b7627cf4f0032cf068b4b2",
-)
-python_nuget_package(
-    name = "nuget_python_i686_3.8.0",
-    sha256 = "87a6481f5eef30b42ac12c93f06f73bd0b8692f26313b76a6615d1641c4e7bca",
-)
-python_nuget_package(
-    name = "nuget_python_x86-64_3.8.0",
-    sha256 = "96c61321ce90dd053c8a04f305a5f6cc6d91350b862db34440e4a4f069b708a0",
-)
-python_nuget_package(
-    name = "nuget_python_i686_3.9.0",
-    sha256 = "229abecbe49dc08fe5709e0b31e70edfb3b88f23335ebfc2904c44f940fd59b6",
-)
-python_nuget_package(
-    name = "nuget_python_x86-64_3.9.0",
-    sha256 = "6af58a733e7dfbfcdd50d55788134393d6ffe7ab8270effbf724bdb786558832",
-)
-python_nuget_package(
-    name = "nuget_python_i686_3.10.0",
-    sha256 = "e115e102eb90ce160ab0ef7506b750a8d7ecc385bde0a496f02a54337a8bc333",
-)
-python_nuget_package(
-    name = "nuget_python_x86-64_3.10.0",
-    sha256 = "4474c83c25625d93e772e926f95f4cd398a0abbb52793625fa30f39af3d2cc00",
-)

--- a/bazel/workspace_deps.bzl
+++ b/bazel/workspace_deps.bzl
@@ -1,6 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("//bazel:python_downloads.bzl", "python_source_archive", "python_nuget_package")
 load("//bazel:system_python.bzl", "system_python")
 
 def upb_deps():
@@ -38,4 +39,43 @@ def upb_deps():
 
     system_python(
         name = "system_python",
+    )
+
+    #Python Downloads
+
+    python_source_archive(
+        name = "python-3.7.0",
+        sha256 = "85bb9feb6863e04fb1700b018d9d42d1caac178559ffa453d7e6a436e259fd0d",
+    )
+    python_nuget_package(
+        name = "nuget_python_i686_3.7.0",
+        sha256 = "a8bb49fa1ca62ad55430fcafaca1b58015e22943e66b1a87d5e7cef2556c6a54",
+    )
+    python_nuget_package(
+        name = "nuget_python_x86-64_3.7.0",
+        sha256 = "66eb796a5bdb1e6787b8f655a1237a6b6964af2115b7627cf4f0032cf068b4b2",
+    )
+    python_nuget_package(
+        name = "nuget_python_i686_3.8.0",
+        sha256 = "87a6481f5eef30b42ac12c93f06f73bd0b8692f26313b76a6615d1641c4e7bca",
+    )
+    python_nuget_package(
+        name = "nuget_python_x86-64_3.8.0",
+        sha256 = "96c61321ce90dd053c8a04f305a5f6cc6d91350b862db34440e4a4f069b708a0",
+    )
+    python_nuget_package(
+        name = "nuget_python_i686_3.9.0",
+        sha256 = "229abecbe49dc08fe5709e0b31e70edfb3b88f23335ebfc2904c44f940fd59b6",
+    )
+    python_nuget_package(
+        name = "nuget_python_x86-64_3.9.0",
+        sha256 = "6af58a733e7dfbfcdd50d55788134393d6ffe7ab8270effbf724bdb786558832",
+    )
+    python_nuget_package(
+        name = "nuget_python_i686_3.10.0",
+        sha256 = "e115e102eb90ce160ab0ef7506b750a8d7ecc385bde0a496f02a54337a8bc333",
+    )
+    python_nuget_package(
+        name = "nuget_python_x86-64_3.10.0",
+        sha256 = "4474c83c25625d93e772e926f95f4cd398a0abbb52793625fa30f39af3d2cc00",
     )


### PR DESCRIPTION
Moving all python dependencies to workspace_deps so that repositories using UPB can get all necessary deps from `upb_deps()`