### PR TITLE
Fixed comparison of maps in Python.

### DIFF
--- a/python/map.c
+++ b/python/map.c
@@ -386,7 +386,6 @@ static PyType_Slot PyUpb_ScalarMapContainer_Slots[] = {
     {Py_tp_methods, PyUpb_ScalarMapContainer_Methods},
     {Py_tp_iter, PyUpb_MapIterator_New},
     {Py_tp_repr, PyUpb_MapContainer_Repr},
-    {Py_tp_hash, PyObject_HashNotImplemented},
     {0, NULL},
 };
 
@@ -432,7 +431,6 @@ static PyType_Slot PyUpb_MessageMapContainer_Slots[] = {
     {Py_tp_methods, PyUpb_MessageMapContainer_Methods},
     {Py_tp_iter, PyUpb_MapIterator_New},
     {Py_tp_repr, PyUpb_MapContainer_Repr},
-    {Py_tp_hash, PyObject_HashNotImplemented},
     {0, NULL}};
 
 static PyType_Spec PyUpb_MessageMapContainer_Spec = {


### PR DESCRIPTION
The `__eq__` method from our base class was not getting called, because we defined `tp_hash` as `NotImplemented`.  Per [the docs on `tp_hash`](https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_hash), `tp_hash` and `tp_richcompare` are inherited together, so defining `tp_hash` was inhibiting the inheritance of `tp_richcompare`.

PiperOrigin-RevId: 465184018