### PR TITLE
Add upb_Arena_SpaceAllocated function

### DIFF
--- a/upb/arena.c
+++ b/upb/arena.c
@@ -69,6 +69,24 @@ static upb_Arena* arena_findroot(upb_Arena* a) {
   return a;
 }
 
+size_t upb_Arena_SpaceAllocated(upb_Arena* arena) {
+  arena = arena_findroot(arena);
+  size_t memsize = 0;
+
+  mem_block* block = arena->freelist;
+
+  while (block) {
+    memsize += sizeof(mem_block) + block->size;
+    block = block->next;
+  }
+
+  return memsize;
+}
+
+uint32_t upb_Arena_DebugRefCount(upb_Arena* arena) {
+  return arena_findroot(arena)->refcount;
+}
+
 static void upb_Arena_addblock(upb_Arena* a, upb_Arena* root, void* ptr,
                                size_t size) {
   mem_block* block = ptr;

--- a/upb/arena.h
+++ b/upb/arena.h
@@ -72,6 +72,8 @@ void upb_Arena_Free(upb_Arena* a);
 bool upb_Arena_AddCleanup(upb_Arena* a, void* ud, upb_CleanupFunc* func);
 bool upb_Arena_Fuse(upb_Arena* a, upb_Arena* b);
 void* _upb_Arena_SlowMalloc(upb_Arena* a, size_t size);
+size_t upb_Arena_SpaceAllocated(upb_Arena* arena);
+uint32_t upb_Arena_DebugRefCount(upb_Arena* arena);
 
 UPB_INLINE upb_alloc* upb_Arena_Alloc(upb_Arena* a) { return (upb_alloc*)a; }
 


### PR DESCRIPTION
Ref: https://github.com/protocolbuffers/protobuf/pull/10291

Ruby types defined though native extensions should register
a function that report their memory footprint in bytes.

This feature is used by various memory profiling tools.

As suggested by @haberman.

NB: the implementation is a bit simpler than what we had in https://github.com/protocolbuffers/protobuf/pull/10291, here we return the arena allocated size, but we don't care about fused arenas. I think dividing by the number of fused arena is an implementation detail of the Ruby extension.