### PR TITLE
install rsync on Bazel CI before running tests

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -3,7 +3,7 @@ tasks:
   ubuntu:
     platform: ubuntu1804
     shell_commands:
-    - "sudo apt -y update && sudo apt -y install libreadline-dev cmake"
+    - "sudo apt -y update && sudo apt -y install libreadline-dev cmake rsync"
     test_targets:
     - //...
   macos:


### PR DESCRIPTION
`//cmake:cmake_build` needs this: https://buildkite.com/bazel/upb/builds/1210#0182b0dc-2131-43f2-8b9d-0b9fba807be8