### PR TITLE
Fixed GitHub Actions tests for pull requests that come from other repos.

### DIFF
--- a/.github/workflows/bazel_tests.yml
+++ b/.github/workflows/bazel_tests.yml
@@ -36,13 +36,13 @@ jobs:
         with:
           credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
           export_environment_variables: true
-        if: ${{ github.repository_owner == 'protocolbuffers' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == 'protocolbuffers/upb' }}
       - name: Set up Bazel read/write caching
         run: echo "BAZEL_CACHE_AUTH=--google_default_credentials" >> $GITHUB_ENV
-        if: ${{ github.repository_owner == 'protocolbuffers' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == 'protocolbuffers/upb' }}
       - name: Set up Bazel read-only caching
         run: echo "BAZEL_CACHE_AUTH=--remote_upload_local_results=false" >> $GITHUB_ENV
-        if: ${{ github.repository_owner != 'protocolbuffers' }}
+        if: ${{ github.event.pull_request.head.repo.full_name != 'protocolbuffers/upb' }}
       - name: Setup Python venv
         run: rm -rf /tmp/venv && python3 -m venv /tmp/venv
       - name: Install dependencies

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -13,7 +13,7 @@ jobs:
   build_wheels:
     name: Build Wheels
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'protocolbuffers' }}
+    if: ${{ github.event.pull_request.head.repo.full_name == 'protocolbuffers/upb' }}
     env:
       DOCKER_IMAGE: gcr.io/protobuf-build/bazel/linux@sha256:2bfd061284eff8234f2fcca16d71d43c69ccf3a22206628b54c204a6a9aac277
       BAZEL_CACHE: --remote_cache=https://storage.googleapis.com/protobuf-bazel-cache --google_default_credentials


### PR DESCRIPTION
Previously GitHub Actions would fail if they did not have access to
repository secrets.  The code attempted to have graceful fallback, but
the graceful fallback was not working properly.

This PR fixes the graceful fallback:

- Bazel tests will use read-only caching instead of read-write.
- We unfortunately need to skip the Python wheel tests, as they require
  our private Docker image to run.