### PR TITLE
Remove patter that does not glob anything

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -716,7 +716,6 @@ exports_files(
 filegroup(
     name = "cmake_files",
     srcs = glob([
-        "upbc/**/*",
         "upb/**/*",
         "third_party/**/*",
     ]),


### PR DESCRIPTION
This pattern does not glob anything because inside the upbc folder there is a BUILD file. Removing this allows to build upb with the flag incompatible_disallow_empty_glob

(cherry picked from commit 9a02d16ceea6e2eb06f221fa35767ce8a259b559)