### PR TITLE
Use proto_common module in lua_proto_library

### DIFF
--- a/bazel/workspace_deps.bzl
+++ b/bazel/workspace_deps.bzl
@@ -21,6 +21,16 @@ def upb_deps():
     )
 
     maybe(
+        http_archive,
+        name = "rules_proto",
+        sha256 = "80d3a4ec17354cccc898bfe32118edd934f851b03029d63ef3fc7c8663a7415c",
+        strip_prefix = "rules_proto-5.3.0-21.5",
+        urls = [
+            "https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.5.tar.gz",
+        ],
+    )
+
+    maybe(
         _github_archive,
         name = "com_google_protobuf",
         repo = "https://github.com/protocolbuffers/protobuf",

--- a/upb/bindings/lua/BUILD.bazel
+++ b/upb/bindings/lua/BUILD.bazel
@@ -35,6 +35,15 @@ load(
 
 licenses(["notice"])
 
+proto_lang_toolchain(
+    name = "lua_proto_toolchain",
+    command_line = "--lua_out=%s",
+    plugin = ":protoc-gen-lua",
+    plugin_format_flag = "--plugin=protoc-gen-lua=%s",
+    progress_message = "Generating Lua protos for: %{label}",
+    visibility = ["//visibility:public"],
+)
+
 cc_library(
     name = "lupb",
     srcs = [

--- a/upb/bindings/lua/lua_proto_library.bzl
+++ b/upb/bindings/lua/lua_proto_library.bzl
@@ -44,7 +44,7 @@ def _compile_upb_protos(ctx, proto_info, proto_sources):
         proto_info,
         ctx.attr._lua_proto_toolchain[proto_common.ProtoLangToolchainInfo],
         generated_files = files,
-        plugin_output = proto_info.proto_source_root if proto_info.proto_source_root != '.' else ctx.bin_dir.path,
+        plugin_output = proto_info.proto_source_root if proto_info.proto_source_root != "." else ctx.bin_dir.path,
     )
     return files
 


### PR DESCRIPTION
This handles all the paths correctly and reduces the code size. It should work correctly also internally.

Fixes: https://github.com/protocolbuffers/upb/issues/784