### PR TITLE
Fix upb proto libraries for default strip_import_prefix

### DIFF
--- a/bazel/py_proto_library.bzl
+++ b/bazel/py_proto_library.bzl
@@ -78,7 +78,7 @@ def _generate_output_file(ctx, src, extension):
     package = ctx.label.package
     if not _is_google3:
         strip_import_prefix = ctx.rule.attr.strip_import_prefix
-        if strip_import_prefix:
+        if strip_import_prefix and strip_import_prefix != "/":
             if not package.startswith(strip_import_prefix[1:]):
                 fail("%s does not begin with prefix %s" % (package, strip_import_prefix))
             package = package[len(strip_import_prefix):]

--- a/bazel/upb_proto_library.bzl
+++ b/bazel/upb_proto_library.bzl
@@ -81,7 +81,7 @@ def _generate_output_file(ctx, src, extension):
     package = ctx.label.package
     if not _is_google3:
         strip_import_prefix = ctx.rule.attr.strip_import_prefix
-        if strip_import_prefix:
+        if strip_import_prefix and strip_import_prefix != "/":
             if not package.startswith(strip_import_prefix[1:]):
                 fail("%s does not begin with prefix %s" % (package, strip_import_prefix))
             package = package[len(strip_import_prefix):]

--- a/upb/bindings/lua/lua_proto_library.bzl
+++ b/upb/bindings/lua/lua_proto_library.bzl
@@ -57,13 +57,13 @@ def _get_real_short_path(file):
 def _get_real_root(ctx, file):
     real_short_path = _get_real_short_path(file)
     root = file.path[:-len(real_short_path) - 1]
-    if not _is_google3 and ctx.rule.attr.strip_import_prefix and ctx.rule.attr.strip_import_prefix != "DO_NOT_STRIP":
+    if not _is_google3 and ctx.rule.attr.strip_import_prefix:
         root = paths.join(root, ctx.rule.attr.strip_import_prefix[1:])
     return root
 
 def _generate_output_file(ctx, src, extension):
     package = ctx.label.package
-    if not _is_google3 and ctx.rule.attr.strip_import_prefix and ctx.rule.attr.strip_import_prefix != "DO_NOT_STRIP":
+    if not _is_google3 and ctx.rule.attr.strip_import_prefix and ctx.rule.attr.strip_import_prefix != "/":
         package = package[len(ctx.rule.attr.strip_import_prefix):]
     real_short_path = _get_real_short_path(src)
     real_short_path = paths.relativize(real_short_path, package)


### PR DESCRIPTION
Changed Bazel to use "/" as default value.

Fixed all proto libraries in the repository to handle the new default value.