### PR TITLE
Rename generated_file_staleness_test() to just staleness_test()

### DIFF
--- a/cmake/BUILD.bazel
+++ b/cmake/BUILD.bazel
@@ -25,7 +25,7 @@
 
 load(
     ":build_defs.bzl",
-    "generated_file_staleness_test",
+    "staleness_test",
 )
 load(
     "//bazel:build_defs.bzl",
@@ -68,7 +68,7 @@ genrule(
     cmd = "cp $(SRCS) $(@D)/generated-in/google/protobuf",
 )
 
-generated_file_staleness_test(
+staleness_test(
     name = "test_generated_files",
     outs = [
         "CMakeLists.txt",

--- a/cmake/build_defs.bzl
+++ b/cmake/build_defs.bzl
@@ -25,7 +25,7 @@
 
 """Bazel support functions related to CMake support."""
 
-def generated_file_staleness_test(name, outs, generated_pattern, **kwargs):
+def staleness_test(name, outs, generated_pattern, **kwargs):
     """Tests that checked-in file(s) match the contents of generated file(s).
 
     The resulting test will verify that all output files exist and have the

--- a/cmake/make_cmakelists.py
+++ b/cmake/make_cmakelists.py
@@ -152,7 +152,7 @@ class BuildFileFunctions(object):
   def cc_proto_library(self, **kwargs):
     pass
 
-  def generated_file_staleness_test(self, **kwargs):
+  def staleness_test(self, **kwargs):
     pass
 
   def upb_amalgamation(self, **kwargs):

--- a/cmake/staleness_test.py
+++ b/cmake/staleness_test.py
@@ -25,7 +25,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-"""The py_test() script for generated_file_staleness_test() rules.
+"""The py_test() script for staleness_test() rules.
 
 Note that this file is preprocessed!  The INSERT_<...> text below is replaced
 with the actual list of files before we actually run the script.

--- a/cmake/staleness_test_lib.py
+++ b/cmake/staleness_test_lib.py
@@ -25,10 +25,9 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-"""Shared code for validating generated_file_staleness_test() rules.
+"""Shared code for validating staleness_test() rules.
 
-This code is used by test scripts generated from
-generated_file_staleness_test() rules.
+This code is used by test scripts generated from staleness_test() rules.
 """
 
 from __future__ import absolute_import


### PR DESCRIPTION
This renaming is something we have been planning on doing, and I would like to do it now because I'm getting ready to rely on this staleness_test() macro from the main protobuf repo.