### PR TITLE
Make staleness_test() macro usable in other Bazel workspaces

### DIFF
--- a/cmake/BUILD.bazel
+++ b/cmake/BUILD.bazel
@@ -40,6 +40,9 @@ py_library(
     name = "staleness_test_lib",
     testonly = 1,
     srcs = ["staleness_test_lib.py"],
+    # This is public only for use by the staleness_test() macro. Please do not
+    # depend on this target directly.
+    visibility = ["//visibility:public"],
 )
 
 py_binary(

--- a/cmake/build_defs.bzl
+++ b/cmake/build_defs.bzl
@@ -42,7 +42,7 @@ def staleness_test(name, outs, generated_pattern, **kwargs):
     """
 
     script_name = name + ".py"
-    script_src = ":staleness_test.py"
+    script_src = Label("//cmake:staleness_test.py")
 
     # Filter out non-existing rules so Blaze doesn't error out before we even
     # run the test.
@@ -57,7 +57,7 @@ def staleness_test(name, outs, generated_pattern, **kwargs):
         outs = [script_name],
         srcs = [script_src],
         testonly = 1,
-        cmd = "cat $(location " + script_src + ") > $@; " +
+        cmd = "cp $< $@; " +
               "sed -i.bak -e 's|INSERT_FILE_LIST_HERE|" + "\\\n  ".join(file_list) + "|' $@",
     )
 
@@ -67,7 +67,7 @@ def staleness_test(name, outs, generated_pattern, **kwargs):
         data = existing_outs + [generated_pattern % file for file in outs],
         python_version = "PY3",
         deps = [
-            ":staleness_test_lib",
+            Label("//cmake:staleness_test_lib"),
         ],
         **kwargs
     )


### PR DESCRIPTION
This commit makes a couple changes to allow staleness_test() to be used from outside the upb repo:
- Fully qualify references to upb targets and wrap them in a Label() constructor. See here for details: https://bazel.build/extending/macros#label-resolution
- Make the :staleness_test_lib target public.