### PR TITLE
Allow 'new_local_repository' in make_cmakelists.py

### DIFF
--- a/cmake/make_cmakelists.py
+++ b/cmake/make_cmakelists.py
@@ -218,6 +218,9 @@ class WorkspaceFileFunctions(object):
   def new_git_repository(self, **kwargs):
     pass
 
+  def new_local_repository(self, **kwargs):
+    pass
+
   def bazel_version_repository(self, **kwargs):
     pass
 


### PR DESCRIPTION
'new_local_repository' can be useful for development, but trips up tests due to
make_cmakelists.py.