### PR TITLE
Update hash for 21.8 release

### DIFF
--- a/bazel/workspace_deps.bzl
+++ b/bazel/workspace_deps.bzl
@@ -26,7 +26,7 @@ def upb_deps():
         repo = "https://github.com/protocolbuffers/protobuf",
         commit = "3a0ae1d1ebe5c4a5e6320c0b024ec2e11c8d9329",
         patches = ["//bazel:protobuf.patch"],
-        sha256 = "ef9221b914b49821364c5e67b8e3f1e2c04dc544924eff7ab9d0f9a6eddf8b99",
+        sha256 = "328bc917118da38656be0cdeb49b261adc133628f5f114ee287a1d31dc33cfc1",
     )
 
     rules_python_version = "0.12.0"  # Latest @ August 31, 2022

--- a/bazel/workspace_deps.bzl
+++ b/bazel/workspace_deps.bzl
@@ -26,6 +26,7 @@ def upb_deps():
         repo = "https://github.com/protocolbuffers/protobuf",
         commit = "3a0ae1d1ebe5c4a5e6320c0b024ec2e11c8d9329",
         patches = ["//bazel:protobuf.patch"],
+        sha256 = "ef9221b914b49821364c5e67b8e3f1e2c04dc544924eff7ab9d0f9a6eddf8b99",
     )
 
     rules_python_version = "740825b7f74930c62f44af95c9a4c1bd428d2c53"  # Latest @ 2021-06-23

--- a/bazel/workspace_deps.bzl
+++ b/bazel/workspace_deps.bzl
@@ -29,14 +29,14 @@ def upb_deps():
         sha256 = "ef9221b914b49821364c5e67b8e3f1e2c04dc544924eff7ab9d0f9a6eddf8b99",
     )
 
-    rules_python_version = "740825b7f74930c62f44af95c9a4c1bd428d2c53"  # Latest @ 2021-06-23
+    rules_python_version = "0.12.0"  # Latest @ August 31, 2022
 
     maybe(
         http_archive,
         name = "rules_python",
         strip_prefix = "rules_python-{}".format(rules_python_version),
-        url = "https://github.com/bazelbuild/rules_python/archive/{}.zip".format(rules_python_version),
-        sha256 = "09a3c4791c61b62c2cbc5b2cbea4ccc32487b38c7a2cc8f87a794d7a659cc742",
+        url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/{}.tar.gz".format(rules_python_version),
+        sha256 = "b593d13bb43c94ce94b483c2858e53a9b811f6f10e1e0eedc61073bd90e58d9c",
     )
 
     maybe(

--- a/bazel/workspace_deps.bzl
+++ b/bazel/workspace_deps.bzl
@@ -24,7 +24,7 @@ def upb_deps():
         _github_archive,
         name = "com_google_protobuf",
         repo = "https://github.com/protocolbuffers/protobuf",
-        commit = "14803e6f63d4785ecd95adeeae3ac42a728b3857",
+        commit = "3a0ae1d1ebe5c4a5e6320c0b024ec2e11c8d9329",
         patches = ["//bazel:protobuf.patch"],
     )
 

--- a/upb/def.c
+++ b/upb/def.c
@@ -1526,6 +1526,10 @@ static void make_layout(symtab_addctx* ctx, const upb_MessageDef* m) {
      * elegant. */
     const upb_FieldDef* key = upb_MessageDef_FindFieldByNumber(m, 1);
     const upb_FieldDef* val = upb_MessageDef_FindFieldByNumber(m, 2);
+    if (key == NULL || val == NULL) {
+      symtab_errf(ctx, "Malformed map entry from message: %s",
+                  upb_MessageDef_FullName(m));
+    }
     fields[0].number = 1;
     fields[1].number = 2;
     fields[0].mode = kUpb_FieldMode_Scalar;

--- a/upb/msg.c
+++ b/upb/msg.c
@@ -397,6 +397,10 @@ bool _upb_extreg_add(upb_ExtensionRegistry* r,
   for (; e < end; e++) {
     const upb_MiniTable_Extension* ext = *e;
     extreg_key(buf, ext->extendee, ext->field.number);
+    upb_value v;
+    if (upb_strtable_lookup2(&r->exts, buf, EXTREG_KEY_SIZE, &v)) {
+      goto failure;
+    }
     if (!upb_strtable_insert(&r->exts, buf, EXTREG_KEY_SIZE,
                              upb_value_constptr(ext), r->arena)) {
       goto failure;


### PR DESCRIPTION
protobuf 21.8 release process: should point at latest commit on the prototbuf 21.x branch.