### PR TITLE
Bazel 6.0: Fix config_setting visibility failure on bazel CI

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -78,6 +78,7 @@ upb_fasttable_enabled(
 config_setting(
     name = "fasttable_enabled_setting",
     flag_values = {"//:fasttable_enabled": "true"},
+    visibility = ["//visibility:public"],
 )
 
 upb_proto_library_copts(


### PR DESCRIPTION
See bazelbuild/bazel#12933.

Repro: `$ USE_BAZEL_VERSION=a05276fea75d47370b363125a074c38cb2badc74 bazelisk build --nobuild --incompatible_config_setting_private_default_visibility //upb/bindings/lua:lupb`

Discovered in failing Bazel CI with `--incompatible_config_setting_private_default_visibility` flipped:

https://buildkite.com/bazel/bazelisk-plus-incompatible-flags/builds/1297#0183cee1-5570-4382-b720-68daaad9feed