### PR TITLE
Make trivial change to CMakeLists.txt to test auto-generation

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -63,8 +63,8 @@ enable_testing()
 
 add_library(port INTERFACE)
 add_library(upb
-  ../upb/alloc.c
   ../upb/arena.c
+  ../upb/alloc.c
   ../upb/array.c
   ../upb/decode.c
   ../upb/encode.c


### PR DESCRIPTION
If the auto-generation is working correctly, then CMakeLists.txt should be quickly auto-updated with a change that undoes this one.