### PR TITLE
Build with incompatible_disallow_empty_glob

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -4,9 +4,13 @@ tasks:
     platform: ubuntu2004
     shell_commands:
     - "sudo apt -y update && sudo apt -y install libreadline-dev cmake rsync"
+    build_flags:
+    - "--incompatible_disallow_empty_glob"
     test_targets:
     - //...
   macos:
     platform: macos
+    build_flags:
+    - "--incompatible_disallow_empty_glob"
     test_targets:
     - //...


### PR DESCRIPTION
In order to flip the flag, all downstream projects should be adapted. However, it is hard to fix them all if there are constant regressions. Adding it to the CI will ensure that once the project can build with incompatible_disallow_empty_glob it can keep building like that.
See: https://github.com/bazelbuild/bazel/pull/15327