### PR TITLE
Enabled Bazel tests on the release branch.

### DIFF
--- a/.github/workflows/bazel_tests.yml
+++ b/.github/workflows/bazel_tests.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - '[0-9]+.x'
   pull_request:
     branches:
       - main
+      - '[0-9]+.x'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This change was previously committed on the main branch in https://github.com/protocolbuffers/upb/commit/b31b52939f7b624dadec5967ce1f959ae60f1187

However it doesn't seem to be taking effect.  Perhaps the GHA config for each branch is taken from that branch, instead of from main.