### PR TITLE
Add license file to pypi wheels.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -56,3 +56,27 @@ rules_fuzzing_dependencies()
 load("@rules_fuzzing//fuzzing:init.bzl", "rules_fuzzing_init")
 
 rules_fuzzing_init()
+
+load("//bazel:system_python.bzl", "system_python")
+system_python(
+    name = "system_python",
+    minimum_python_version = "3.7",
+)
+
+load("@system_python//:register.bzl", "register_system_python")
+register_system_python()
+
+load("@system_python//:pip.bzl", "pip_parse", "fuzzing_py_install_deps")
+
+pip_parse(
+    name="pip_deps",
+    requirements = "//python:requirements.txt",
+    requirements_overrides = {
+        "3.11": "//python:requirements_311.txt",
+    },
+)
+
+load("@pip_deps//:requirements.bzl", "install_deps")
+install_deps()
+
+fuzzing_py_install_deps()

--- a/bazel/system_python.bzl
+++ b/bazel/system_python.bzl
@@ -25,6 +25,65 @@
 
 """Repository rule for using Python 3.x headers from the system."""
 
+# Mock out rules_python's pip.bzl for cases where no system python is found.
+_mock_pip = """
+def fuzzing_py_install_deps():
+    print("WARNING: could not install fuzzing_py dependencies")
+
+def _pip_install_impl(repository_ctx):
+    repository_ctx.file("BUILD.bazel", '''
+py_library(
+    name = "noop",
+    visibility = ["//visibility:public"],
+)
+''')
+    repository_ctx.file("requirements.bzl", '''
+def install_deps(*args, **kwargs):
+    print("WARNING: could not install pip dependencies")
+
+def requirement(*args, **kwargs):
+    return "@{}//:noop"
+'''.format(repository_ctx.attr.name))
+pip_install = repository_rule(
+    implementation = _pip_install_impl,
+    attrs = {
+        "requirements": attr.string(),
+        "requirements_overrides": attr.string_dict(),
+        "python_interpreter_target": attr.string(),
+    },
+)
+pip_parse = pip_install
+"""
+
+# Alias rules_python's pip.bzl for cases where a system python is found.
+_alias_pip = """
+load("@rules_python//python:pip.bzl", _pip_install = "pip_install", _pip_parse = "pip_parse")
+load("@fuzzing_py_deps//:requirements.bzl", _fuzzing_py_install_deps = "install_deps")
+
+def _get_requirements(requirements, requirements_overrides):
+    for version, override in requirements_overrides.items():
+        if version in "{python_version}":
+            requirements = override
+            break
+    return requirements
+
+def pip_install(requirements, requirements_overrides={{}}, **kwargs):
+    _pip_install(
+        python_interpreter_target = "@{repo}//:interpreter",
+        requirements = _get_requirements(requirements, requirements_overrides),
+        **kwargs,
+    )
+def pip_parse(requirements, requirements_overrides={{}}, **kwargs):
+    _pip_parse(
+        python_interpreter_target = "@{repo}//:interpreter",
+        requirements = _get_requirements(requirements, requirements_overrides),
+        **kwargs,
+    )
+
+def fuzzing_py_install_deps():
+    _fuzzing_py_install_deps()
+"""
+
 _build_file = """
 load("@bazel_tools//tools/python:toolchain.bzl", "py_runtime_pair")
 

--- a/bazel/workspace_deps.bzl
+++ b/bazel/workspace_deps.bzl
@@ -29,14 +29,14 @@ def upb_deps():
         sha256 = "328bc917118da38656be0cdeb49b261adc133628f5f114ee287a1d31dc33cfc1",
     )
 
-    rules_python_version = "0.12.0"  # Latest @ August 31, 2022
+    rules_python_version = "0.14.0"  # Latest @ November 20, 2022
 
     maybe(
         http_archive,
         name = "rules_python",
         strip_prefix = "rules_python-{}".format(rules_python_version),
         url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/{}.tar.gz".format(rules_python_version),
-        sha256 = "b593d13bb43c94ce94b483c2858e53a9b811f6f10e1e0eedc61073bd90e58d9c",
+        sha256 = "a868059c8c6dd6ad45a205cca04084c652cfe1852e6df2d5aca036f6e5438380",
     )
 
     maybe(

--- a/cmake/make_cmakelists.py
+++ b/cmake/make_cmakelists.py
@@ -200,7 +200,7 @@ class WorkspaceFileFunctions(object):
   def __init__(self, converter):
     self.converter = converter
 
-  def load(self, *args):
+  def load(self, *args, **kwargs):
     pass
 
   def workspace(self, **kwargs):
@@ -225,6 +225,12 @@ class WorkspaceFileFunctions(object):
   def protobuf_deps(self):
     pass
 
+  def utf8_range_deps(self):
+    pass
+
+  def pip_parse(self, **kwargs):
+    pass
+
   def rules_fuzzing_dependencies(self):
     pass
 
@@ -241,6 +247,12 @@ class WorkspaceFileFunctions(object):
     pass
 
   def python_nuget_package(self, **kwargs):
+    pass
+
+  def install_deps(self):
+    pass
+
+  def fuzzing_py_install_deps(self):
     pass
 
 

--- a/python/dist/BUILD.bazel
+++ b/python/dist/BUILD.bazel
@@ -110,6 +110,9 @@ py_wheel(
         "Programming Language :: Python :: 3.10",
     ],
     distribution = "protobuf",
+    extra_distinfo_files = {
+        "//:LICENSE": "LICENSE",
+    },
     homepage = "https://developers.google.com/protocol-buffers/",
     license = "3-Clause BSD License",
     platform = select({
@@ -154,6 +157,9 @@ py_wheel(
         "Programming Language :: Python :: 3.10",
     ],
     distribution = "protobuf",
+    extra_distinfo_files = {
+        "//:LICENSE": "LICENSE",
+    },
     homepage = "https://developers.google.com/protocol-buffers/",
     license = "3-Clause BSD License",
     platform = "any",
@@ -173,6 +179,9 @@ py_wheel(
     name = "test_wheel",
     abi = "none",
     distribution = "protobuftests",
+    extra_distinfo_files = {
+        "//:LICENSE": "LICENSE",
+    },
     platform = "any",
     python_tag = "py3",
     strip_path_prefixes = ["python/"],


### PR DESCRIPTION
Addresses https://github.com/protocolbuffers/protobuf/issues/10936.

This requires updating to the newest version of rules_python to use the new py_wheel API that includes a parameter for extra distinfo files

PiperOrigin-RevId: 493060514