### PR TITLE
Build with incompatible_disallow_empty_glob

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,6 +4,9 @@ build --features=-debug_prefix_map_pwd_is_dot
 # Pin to C++17
 build --cxxopt=-std=c++17 --host_cxxopt=-std=c++17
 
+# Fail if a glob doesn't match anything (https://github.com/bazelbuild/bazel/issues/8195)
+build --incompatible_disallow_empty_glob
+
 # Use our custom-configured c++ toolchain.
 
 build:m32 --copt=-m32 --linkopt=-m32


### PR DESCRIPTION
In order to flip the flag, all downstream projects should be adapted. However, it is hard to fix them all if there are constant regressions. Adding it to the CI will ensure that once the project can build with incompatible_disallow_empty_glob it can keep building like that.
See: https://github.com/bazelbuild/bazel/pull/15327