### PR TITLE
Use python3 setup.py sdist to build the source distribution for python.

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-large
     if: ${{ github.event.pull_request.head.repo.full_name == 'protocolbuffers/upb' }}
     env:
-      DOCKER_IMAGE: us-docker.pkg.dev/protobuf-build/release-containers/linux@sha256:51eed1ced211cdcb3cae7733dbc7f2b28e195dfe0bbfb596794e52de4402fe1b
+      DOCKER_IMAGE: us-docker.pkg.dev/protobuf-build/release-containers/linux/apple@sha256:8f5ae27bccb454068b14a6fe50628adf2ce867ddf3b15807aaf1d9d4affcbc51
 
     steps:
       - uses: actions/checkout@v2
@@ -38,7 +38,7 @@ jobs:
       - name: Build Wheels
         run: cd ${{ github.workspace }} && docker run -e GOOGLE_APPLICATION_CREDENTIALS=/workspace/$(basename $GOOGLE_APPLICATION_CREDENTIALS) -v$PWD:/workspace $DOCKER_IMAGE build $BAZEL_CACHE --crosstool_top=@com_google_protobuf//toolchain:clang_suite --symlink_prefix=/ -c dbg python/dist ${{ steps.bazel-cache.outputs.cache_args }} python/dist:test_wheel python/dist:source_wheel
       - name: Move Wheels
-        run: mkdir wheels && find _build/out \( -name 'protobuf*.whl' -o -name 'protobuf*.tar.gz' \) -exec mv '{}' wheels ';'
+        run: mkdir wheels && find _build/out \( -name 'protobuf*.whl' -o -name 'protobuf-*.tar.gz' \) -exec mv '{}' wheels ';'
       - uses: actions/upload-artifact@v3
         with:
           name: python-wheels

--- a/python/dist/BUILD.bazel
+++ b/python/dist/BUILD.bazel
@@ -204,8 +204,9 @@ pkg_files(
 # NOTE: This package currently only works for macos and ubuntu, MSVC users
 # should use a binary wheel.
 pkg_tar(
-    name = "source_wheel",
+    name = "source_tarball",
     srcs = [
+        "MANIFEST.in",
         "setup.py",
         ":generated_wkt",
         ":generated_wkt_compiler",
@@ -217,8 +218,22 @@ pkg_tar(
         "@com_google_protobuf//python:python_source_files",
     ],
     extension = "tar.gz",
-    package_dir = "protobuf-%s" % PROTOBUF_PYTHON_VERSION,
-    package_file_name = "protobuf-%s.tar.gz" % PROTOBUF_PYTHON_VERSION,
+    package_dir = "protobuf",
+    package_file_name = "protobuf.tar.gz",
+)
+
+genrule(
+    name = "source_wheel",
+    srcs = [":source_tarball"],
+    outs = ["protobuf-%s.tar.gz" % PROTOBUF_PYTHON_VERSION],
+    cmd = """
+        set -eux
+        tar -xzvf $(location :source_tarball)
+        cd protobuf/
+        python3 setup.py sdist
+        cd ..
+        mv protobuf/dist/*.tar.gz $@
+    """,
 )
 
 py_wheel(

--- a/python/dist/MANIFEST.in
+++ b/python/dist/MANIFEST.in
@@ -1,0 +1,2 @@
+global-include *.h
+global-include *.inc


### PR DESCRIPTION
Our pkg_tar rule was missing a few template files for python. Using setup.py will guarantee conformance with python package requirements.

Adds MANIFEST.in to include c header/inc files in the source distribution.

This is a cherrypick of https://github.com/protocolbuffers/upb/commit/f775d4929935acfc84121739b336b9a1b5674d6d