### PR TITLE
Cherrypick ruby flake fix into 22.x

### DIFF
--- a/upbc/protoc-gen-upb.cc
+++ b/upbc/protoc-gen-upb.cc
@@ -880,10 +880,6 @@ void WriteHeader(const DefPoolPair& pools, upb::FileDefPtr file,
   }
 
   std::vector<upb::EnumDefPtr> this_file_enums = SortedEnums(file);
-  std::sort(this_file_enums.begin(), this_file_enums.end(),
-            [](upb::EnumDefPtr a, upb::EnumDefPtr b) {
-              return a.full_name() < b.full_name();
-            });
 
   for (auto enumdesc : this_file_enums) {
     output("typedef enum {\n");


### PR DESCRIPTION
We're already doing a proper string sort in SortedEnums as of cl/503574792, but then we follow it up with a sort on the char* pointers.

PiperOrigin-RevId: 506778694