### PR TITLE
Add missing darwin_x86_64 CPU

### DIFF
--- a/python/dist/dist.bzl
+++ b/python/dist/dist.bzl
@@ -22,6 +22,7 @@ def _get_suffix(limited_api, python_version, cpu):
             python_version += "m"
         abis = {
             "darwin_arm64": "darwin",
+            "darwin_x86_64": "darwin",
             "darwin": "darwin",
             "osx-x86_64": "darwin",
             "osx-aarch_64": "darwin",


### PR DESCRIPTION
This CPU is often used when cross compiling from M1 machines. I'm also hoping we can remove the legacy 'darwin' CPU.