### PR TITLE
[C++20 build failure, Clang 15] Fix ambiguous-reversed-operator warning

### DIFF
--- a/upb/reflection/def.hpp
+++ b/upb/reflection/def.hpp
@@ -318,8 +318,14 @@ class MessageDefPtr {
     FieldDefPtr operator*() {
       return FieldDefPtr(upb_MessageDef_Field(m_, i_));
     }
-    bool operator!=(const FieldIter& other) { return i_ != other.i_; }
-    bool operator==(const FieldIter& other) { return i_ == other.i_; }
+
+    friend bool operator==(const FieldIter& lhs, const FieldIter& rhs) {
+      return lhs.i_ == rhs.i_;
+    }
+    
+    friend bool operator!=(const FieldIter& lhs, const FieldIter& rhs) {
+      return !(lhs == rhs);
+    }
 
    private:
     const upb_MessageDef* m_;


### PR DESCRIPTION
external/upb/upbc/names.cc:89:26: error: ISO C++20 considers use of overloaded operator '!=' (with operand types 'upb::MessageDefPtr::FieldIter' and 'upb::MessageDefPtr::FieldIter') to be ambiguous despite there being a unique best viable function with non-reversed arguments [-Werror,-Wambiguous-reversed-operator]
  for (const auto& field : message.fields()) {
                         ^
external/upb/upb/reflection/def.hpp:321:10: note: candidate function with non-reversed arguments
    bool operator!=(const FieldIter& other) { return i_ != other.i_; }
         ^
external/upb/upb/reflection/def.hpp:322:10: note: ambiguous candidate function with reversed arguments
    bool operator==(const FieldIter& other) { return i_ == other.i_; }
         ^

Move to a friend nonmember functions taking both arguments by reference-to-const.