### PR TITLE
Update dependency on com_google_googletest to use the newly added googletest_deps to install transitive dependencies

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -23,16 +23,6 @@ http_archive(
 )
 
 http_archive(
-    name = "com_google_googletest",
-    sha256 = "81964fe578e9bd7c94dfdb09c8e4d6e6759e19967e397dbea48d1c10e45d0df2",
-    strip_prefix = "googletest-release-1.12.1",
-    urls = [
-        "https://mirror.bazel.build/github.com/google/googletest/archive/refs/tags/release-1.12.1.tar.gz",
-        "https://github.com/google/googletest/archive/refs/tags/release-1.12.1.tar.gz",
-    ],
-)
-
-http_archive(
     name = "com_github_google_benchmark",
     urls = ["https://github.com/google/benchmark/archive/0baacde3618ca617da95375e0af13ce1baadea47.zip"],
     strip_prefix = "benchmark-0baacde3618ca617da95375e0af13ce1baadea47",
@@ -70,6 +60,19 @@ rules_fuzzing_dependencies()
 load("@rules_fuzzing//fuzzing:init.bzl", "rules_fuzzing_init")
 
 rules_fuzzing_init()
+
+http_archive(
+    name = "com_google_googletest",
+    sha256 = "730215d76eace9dd49bf74ce044e8daa065d175f1ac891cc1d6bb184ef94e565",
+    strip_prefix = "googletest-f53219cdcb7b084ef57414efea92ee5b71989558",
+    urls = [
+        "https://github.com/google/googletest/archive/f53219cdcb7b084ef57414efea92ee5b71989558.tar.gz" # 2023-03-16
+    ],
+)
+
+load("@com_google_googletest//:googletest_deps.bzl", "googletest_deps")
+
+googletest_deps()
 
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 

--- a/cmake/make_cmakelists.py
+++ b/cmake/make_cmakelists.py
@@ -277,6 +277,9 @@ class WorkspaceFileFunctions(object):
   def fuzzing_py_install_deps(self):
     pass
 
+  def googletest_deps(self):
+    pass
+
 
 class Converter(object):
   def __init__(self):

--- a/upbc/code_generator_request.proto
+++ b/upbc/code_generator_request.proto
@@ -2,7 +2,7 @@ syntax = "proto2";
 
 package upbc;
 
-import "src/google/protobuf/compiler/plugin.proto";
+import "google/protobuf/compiler/plugin.proto";
 
 message CodeGeneratorRequest {
   // The pb sent by protoc to its plugins.


### PR DESCRIPTION
Cherrypick of https://github.com/protocolbuffers/upb/commit/1043eee8910b282fd46b1a4513b192be64233852

Fixes https://github.com/protocolbuffers/upb/issues/1200#issuecomment-1463568571

PiperOrigin-RevId: 517217973