### PR TITLE
Remove src prefix from proto import

### DIFF
--- a/upbc/code_generator_request.proto
+++ b/upbc/code_generator_request.proto
@@ -2,7 +2,7 @@ syntax = "proto2";
 
 package upbc;
 
-import "src/google/protobuf/compiler/plugin.proto";
+import "google/protobuf/compiler/plugin.proto";
 
 message CodeGeneratorRequest {
   // The pb sent by protoc to its plugins.


### PR DESCRIPTION
We erroneously changed plugin.proto to not strip the src prefix in protobuf which caused the path to require the prefix. https://github.com/protocolbuffers/protobuf/pull/11991 fixed the problem in protobuf, and now UPB needs to be changed back to match.

This is currently causing failures on 22.x