### PR TITLE
Use _fileno(stdin) instead of STDIN_FILENO on Windows

### DIFF
--- a/upbc/plugin.h
+++ b/upbc/plugin.h
@@ -163,8 +163,8 @@ class Plugin {
   std::string ReadAllStdinBinary() {
     std::string data;
 #ifdef _WIN32
-    setmode(STDIN_FILENO, _O_BINARY);
-    setmode(STDOUT_FILENO, _O_BINARY);
+    _setmode(_fileno(stdin), _O_BINARY);
+    _setmode(_fileno(stdout), _O_BINARY);
 #endif
     char buf[4096];
     while (size_t len = fread(buf, 1, sizeof(buf), stdin)) {


### PR DESCRIPTION
The `*_FILENO` constants don't exist on Windows.

PiperOrigin-RevId: 518553512

Fixes: https://github.com/protocolbuffers/upb/issues/1204