### PR TITLE
Use requirements.txt in GHA tests

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -43,6 +43,10 @@ jobs:
         with:
           name: python-wheels
           path: wheels/
+      - uses: actions/upload-artifact@v3
+        with:
+          name: requirements
+          paths: python/requirements.txt
 
   test_wheels:
     name: Test Wheels
@@ -83,6 +87,11 @@ jobs:
         with:
           name: python-wheels
           path: wheels
+      - name: Download Requirements
+        uses: actions/download-artifact@v3
+        with:
+          name: requirements
+          path: requirements
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
@@ -98,8 +107,8 @@ jobs:
         run: pip install tzdata
         # Only needed on Windows, Linux ships with tzdata.
         if: ${{ contains(matrix.os, 'windows') }}
-      - name: Install numpy
-        run: pip install numpy
+      - name: Install requirements
+        run: pip install -r requirements/requirements.txt
       - name: Install Protobuf Binary Wheel
         run: pip install -vvv --no-index --find-links wheels protobuf
         if: ${{ matrix.type == 'binary' }}

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: requirements
-          paths: python/requirements.txt
+          path: python/requirements.txt
 
   test_wheels:
     name: Test Wheels

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -46,6 +46,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: requirements
+          # Tests shouldn't have access to the whole upb repo, upload the one file we need
           path: python/requirements.txt
 
   test_wheels:


### PR DESCRIPTION
We recently saw a failure pass through where requirements.txt was updated in a way that was not compatible with some python versions. This updates the tests to directly use requirements.txt to download requirements to catch issues like this in the future.