### PR TITLE
Update abseil and protobuf deps for 23.0-rc3

### DIFF
--- a/bazel/protobuf.patch
+++ b/bazel/protobuf.patch
@@ -38,33 +38,3 @@
  
    # Search internally.
    path = '.'
-
---- python/internal.bzl
-+++ python/internal.bzl
-@@ -1,5 +1,11 @@
- # Internal helpers for building the Python protobuf runtime.
- 
-+def _remove_cross_repo_path(path):
-+    components = path.split("/")
-+    if components[0] == "..":
-+        return "/".join(components[2:])
-+    return path
-+
- def _internal_copy_files_impl(ctx):
-     strip_prefix = ctx.attr.strip_prefix
-     if strip_prefix[-1] != "/":
-@@ -7,10 +13,11 @@ def _internal_copy_files_impl(ctx):
- 
-     src_dests = []
-     for src in ctx.files.srcs:
--        if src.short_path[:len(strip_prefix)] != strip_prefix:
-+        short_path = _remove_cross_repo_path(src.short_path)
-+        if short_path[:len(strip_prefix)] != strip_prefix:
-             fail("Source does not start with %s: %s" %
--                 (strip_prefix, src.short_path))
--        dest = ctx.actions.declare_file(src.short_path[len(strip_prefix):])
-+                 (strip_prefix, short_path))
-+        dest = ctx.actions.declare_file(short_path[len(strip_prefix):])
-         src_dests.append([src, dest])
- 
-     if ctx.attr.is_windows:

--- a/bazel/workspace_deps.bzl
+++ b/bazel/workspace_deps.bzl
@@ -15,16 +15,16 @@ def upb_deps():
         _github_archive,
         name = "com_google_absl",
         repo = "https://github.com/abseil/abseil-cpp",
-        commit = "78be63686ba732b25052be15f8d6dee891c05749",  # Abseil LTS 20230125
-        sha256 = "4f356a07b9ec06ef51f943928508566e992f621ed5fa4dd588865d7bed1284cd",
+        commit = "b971ac5250ea8de900eae9f95e06548d14cd95fe",  # Abseil LTS 20230125.2
+        sha256 = "f7c2cb2c5accdcbbbd5c0c59f241a988c0b1da2a3b7134b823c0bd613b1a6880",
     )
 
     maybe(
         _github_archive,
         name = "com_google_protobuf",
         repo = "https://github.com/protocolbuffers/protobuf",
-        commit = "0b73dd44a3257c788f930bbb068ffdcb98679456",
-        sha256 = "75f03baf65d181cddd2f18e3438ca186bac0914a1b4d99df7a02d3b01aae41a8",
+        commit = "e01953476c583a9bea34ab24bbcb6e6028a77f1f",
+        sha256 = "facf99f7aabe0f26928e60511dbe16eb8c3c947c51d30c97cbe2327aa47b69b5",
         patches = ["@upb//bazel:protobuf.patch"],
     )
 


### PR DESCRIPTION
Also removes patch to internal protobuf rules now that it's implemented in the proto repository.

https://github.com/protocolbuffers/protobuf/commit/859410bccc59aeeef1c48e34960fe93827767bac moved the patch to the protobuf repository.

PiperOrigin-RevId: 528804550