### PR TITLE
Update abseil and protobuf dependencies

### DIFF
--- a/bazel/protobuf.patch
+++ b/bazel/protobuf.patch
@@ -38,33 +38,3 @@
  
    # Search internally.
    path = '.'
-
---- python/internal.bzl
-+++ python/internal.bzl
-@@ -1,5 +1,11 @@
- # Internal helpers for building the Python protobuf runtime.
- 
-+def _remove_cross_repo_path(path):
-+    components = path.split("/")
-+    if components[0] == "..":
-+        return "/".join(components[2:])
-+    return path
-+
- def _internal_copy_files_impl(ctx):
-     strip_prefix = ctx.attr.strip_prefix
-     if strip_prefix[-1] != "/":
-@@ -7,10 +13,11 @@ def _internal_copy_files_impl(ctx):
- 
-     src_dests = []
-     for src in ctx.files.srcs:
--        if src.short_path[:len(strip_prefix)] != strip_prefix:
-+        short_path = _remove_cross_repo_path(src.short_path)
-+        if short_path[:len(strip_prefix)] != strip_prefix:
-             fail("Source does not start with %s: %s" %
--                 (strip_prefix, src.short_path))
--        dest = ctx.actions.declare_file(src.short_path[len(strip_prefix):])
-+                 (strip_prefix, short_path))
-+        dest = ctx.actions.declare_file(short_path[len(strip_prefix):])
-         src_dests.append([src, dest])
- 
-     if ctx.attr.is_windows:

--- a/bazel/workspace_deps.bzl
+++ b/bazel/workspace_deps.bzl
@@ -15,16 +15,16 @@ def upb_deps():
         _github_archive,
         name = "com_google_absl",
         repo = "https://github.com/abseil/abseil-cpp",
-        commit = "78be63686ba732b25052be15f8d6dee891c05749",  # Abseil LTS 20230125
-        sha256 = "4f356a07b9ec06ef51f943928508566e992f621ed5fa4dd588865d7bed1284cd",
+        commit = "b971ac5250ea8de900eae9f95e06548d14cd95fe",  # Abseil LTS 20230125.2
+        sha256 = "f7c2cb2c5accdcbbbd5c0c59f241a988c0b1da2a3b7134b823c0bd613b1a6880",
     )
 
     maybe(
         _github_archive,
         name = "com_google_protobuf",
         repo = "https://github.com/protocolbuffers/protobuf",
-        commit = "21b4fd581f236c38bd2f00f667b1fade0da266f3",
-        sha256 = "576fc916a982bc6465eefa0645ad5295e93c3958221d965150136710131bf903",
+        commit = "585583316e42a255202d8d567692a6c46d077a57",
+        sha256 = "09138c0cec5a41bf61585c0bd65922119a03d34549649fd806a4c30afe3320ea",
         patches = ["@upb//bazel:protobuf.patch"],
     )
 


### PR DESCRIPTION
Also removes patch to internal protobuf rules now that it's implemented in the proto repository.

https://github.com/protocolbuffers/protobuf/commit/859410bccc59aeeef1c48e34960fe93827767bac moved the patch to the protobuf repository.

PiperOrigin-RevId: 528804550