### PR TITLE
fix: add shebang in python interpreter

### DIFF
--- a/bazel/system_python.bzl
+++ b/bazel/system_python.bzl
@@ -205,7 +205,7 @@ def _populate_package(ctx, path, python3, python_version):
         support = "Supported" if supported else "Unsupported",
     )
 
-    ctx.file("interpreter", "exec {} \"$@\"".format(python3))
+    ctx.file("interpreter", "#!/bin/sh\nexec {} \"$@\"".format(python3))
     ctx.file("BUILD.bazel", build_file)
     ctx.file("version.bzl", "SYSTEM_PYTHON_VERSION = '{}{}'".format(python_version[0], python_version[1]))
     ctx.file("register.bzl", _register.format(ctx.attr.name))


### PR DESCRIPTION
This fixes cases where the interpreter cannot be executed, as there is no indication about how to execute it.

Fixes #1212