### PR TITLE
Fix `PyUpb_Message_MergeInternal` segfault

### DIFF
--- a/python/message.c
+++ b/python/message.c
@@ -1202,7 +1202,7 @@ static PyObject* PyUpb_Message_MergeInternal(PyObject* self, PyObject* arg,
   if (!serialized) return NULL;
   PyObject* ret = PyUpb_Message_MergeFromString(self, serialized);
   Py_DECREF(serialized);
-  Py_DECREF(ret);
+  Py_XDECREF(ret);
   Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
when `PyUpb_Message_MergeFromString` returns `NULL`, currently `PyUpb_Message_MergeInternal` will call `Py_DECREF` on `NULL` which results in a segmentation fault.

This patch switches to `Py_XDECREF` to fix the segfault.