### PR TITLE
Fixed a bug in `upb_Map_Delete()` that caused crashes in map.delete(k…

### DIFF
--- a/upb/collections/map.c
+++ b/upb/collections/map.c
@@ -73,9 +73,9 @@ upb_MapInsertStatus upb_Map_Insert(upb_Map* map, upb_MessageValue key,
 
 bool upb_Map_Delete(upb_Map* map, upb_MessageValue key, upb_MessageValue* val) {
   upb_value v;
-  const bool ok = _upb_Map_Delete(map, &key, map->key_size, &v);
-  if (val) val->uint64_val = v.val;
-  return ok;
+  const bool removed = _upb_Map_Delete(map, &key, map->key_size, &v);
+  if (val) _upb_map_fromvalue(v, val, map->val_size);
+  return removed;
 }
 
 bool upb_Map_Next(const upb_Map* map, upb_MessageValue* key,


### PR DESCRIPTION
…) for Ruby when string-keyed maps were in use.

Fixes: https://github.com/protocolbuffers/protobuf/issues/12580

When `upb_Map_Delete(map, k, &v)` was called for a string-keyed map, the returned value `v` contained garbage data instead of the true string length.

Since `map.delete(k)` in Ruby returns the deleted value, this was causing a garbage length to be used when allocating and copying data.

PiperOrigin-RevId: 535261609