### PR TITLE
names.cc: Add missing constinit

### DIFF
--- a/upbc/names.cc
+++ b/upbc/names.cc
@@ -46,8 +46,8 @@ static constexpr absl::string_view kDeleteMethodPrefix = "delete_";
 static constexpr absl::string_view kAddToRepeatedMethodPrefix = "add_";
 static constexpr absl::string_view kResizeArrayMethodPrefix = "resize_";
 
-const absl::string_view kRepeatedFieldArrayGetterPostfix = "upb_array";
-const absl::string_view kRepeatedFieldMutableArrayGetterPostfix =
+ABSL_CONST_INIT const absl::string_view kRepeatedFieldArrayGetterPostfix = "upb_array";
+ABSL_CONST_INIT const absl::string_view kRepeatedFieldMutableArrayGetterPostfix =
     "mutable_upb_array";
 
 // List of generated accessor prefixes to check against.


### PR DESCRIPTION
```
external/upb/upbc/names.cc:49:25: error: 'constinit' specifier missing on initializing declaration of 'kRepeatedFieldArrayGetterPostfix' [-Werror,-Wmissing-constinit]
const absl::string_view kRepeatedFieldArrayGetterPostfix = "upb_array";
                        ^
ABSL_CONST_INIT
external/upb/upbc/names.h:64:1: note: variable declared constinit here
ABSL_CONST_INIT extern const absl::string_view kRepeatedFieldArrayGetterPostfix;
^
external/com_google_absl/absl/base/attributes.h:712:25: note: expanded from macro 'ABSL_CONST_INIT'
#define ABSL_CONST_INIT constinit
                        ^
external/upb/upbc/names.cc:50:25: error: 'constinit' specifier missing on initializing declaration of 'kRepeatedFieldMutableArrayGetterPostfix' [-Werror,-Wmissing-constinit]
const absl::string_view kRepeatedFieldMutableArrayGetterPostfix =
                        ^
ABSL_CONST_INIT
external/upb/upbc/names.h:65:1: note: variable declared constinit here
ABSL_CONST_INIT extern const absl::string_view
^
external/com_google_absl/absl/base/attributes.h:712:25: note: expanded from macro 'ABSL_CONST_INIT'
#define ABSL_CONST_INIT constinit
                        ^
```