### PR TITLE
Expose methods needed by Ruby FFI using UPB_API

### DIFF
--- a/upb/collections/map.h
+++ b/upb/collections/map.h
@@ -120,16 +120,18 @@ UPB_API void upb_Map_SetEntryValue(upb_Map* map, size_t iter,
  */
 
 // Advances to the next entry. Returns false if no more entries are present.
-bool upb_MapIterator_Next(const upb_Map* map, size_t* iter);
+UPB_API_INLINE bool upb_MapIterator_Next(const upb_Map* map, size_t* iter);
 
 // Returns true if the iterator still points to a valid entry, or false if the
 // iterator is past the last element. It is an error to call this function with
 // kUpb_Map_Begin (you must call next() at least once first).
-bool upb_MapIterator_Done(const upb_Map* map, size_t iter);
+UPB_API_INLINE bool upb_MapIterator_Done(const upb_Map* map, size_t iter);
 
 // Returns the key and value for this entry of the map.
-upb_MessageValue upb_MapIterator_Key(const upb_Map* map, size_t iter);
-upb_MessageValue upb_MapIterator_Value(const upb_Map* map, size_t iter);
+UPB_API_INLINE upb_MessageValue upb_MapIterator_Key(const upb_Map* map,
+                                                    size_t iter);
+UPB_API_INLINE upb_MessageValue upb_MapIterator_Value(const upb_Map* map,
+                                                      size_t iter);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/upb/collections/map.h
+++ b/upb/collections/map.h
@@ -120,18 +120,16 @@ UPB_API void upb_Map_SetEntryValue(upb_Map* map, size_t iter,
  */
 
 // Advances to the next entry. Returns false if no more entries are present.
-UPB_API_INLINE bool upb_MapIterator_Next(const upb_Map* map, size_t* iter);
+UPB_API bool upb_MapIterator_Next(const upb_Map* map, size_t* iter);
 
 // Returns true if the iterator still points to a valid entry, or false if the
 // iterator is past the last element. It is an error to call this function with
 // kUpb_Map_Begin (you must call next() at least once first).
-UPB_API_INLINE bool upb_MapIterator_Done(const upb_Map* map, size_t iter);
+UPB_API bool upb_MapIterator_Done(const upb_Map* map, size_t iter);
 
 // Returns the key and value for this entry of the map.
-UPB_API_INLINE upb_MessageValue upb_MapIterator_Key(const upb_Map* map,
-                                                    size_t iter);
-UPB_API_INLINE upb_MessageValue upb_MapIterator_Value(const upb_Map* map,
-                                                      size_t iter);
+UPB_API upb_MessageValue upb_MapIterator_Key(const upb_Map* map, size_t iter);
+UPB_API upb_MessageValue upb_MapIterator_Value(const upb_Map* map, size_t iter);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/upb/hash/common.h
+++ b/upb/hash/common.h
@@ -189,7 +189,7 @@ UPB_INLINE size_t upb_table_size(const upb_table* t) {
 
 UPB_INLINE bool upb_tabent_isempty(const upb_tabent* e) { return e->key == 0; }
 
-UPB_API_INLINE uint32_t _upb_Hash(const void* p, size_t n, uint64_t seed);
+UPB_API uint32_t _upb_Hash(const void* p, size_t n, uint64_t seed);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/upb/hash/common.h
+++ b/upb/hash/common.h
@@ -189,7 +189,7 @@ UPB_INLINE size_t upb_table_size(const upb_table* t) {
 
 UPB_INLINE bool upb_tabent_isempty(const upb_tabent* e) { return e->key == 0; }
 
-UPB_API uint32_t _upb_Hash(const void* p, size_t n, uint64_t seed);
+uint32_t _upb_Hash(const void* p, size_t n, uint64_t seed);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/upb/hash/common.h
+++ b/upb/hash/common.h
@@ -189,7 +189,7 @@ UPB_INLINE size_t upb_table_size(const upb_table* t) {
 
 UPB_INLINE bool upb_tabent_isempty(const upb_tabent* e) { return e->key == 0; }
 
-uint32_t _upb_Hash(const void* p, size_t n, uint64_t seed);
+UPB_API_INLINE uint32_t _upb_Hash(const void* p, size_t n, uint64_t seed);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/upb/json/decode.h
+++ b/upb/json/decode.h
@@ -39,10 +39,9 @@ extern "C" {
 
 enum { upb_JsonDecode_IgnoreUnknown = 1 };
 
-UPB_API_INLINE bool upb_JsonDecode(const char* buf, size_t size,
-                    upb_Message* msg, const upb_MessageDef* m,
-                    const upb_DefPool* symtab, int options, upb_Arena* arena,
-                    upb_Status* status);
+UPB_API bool upb_JsonDecode(const char* buf, size_t size, upb_Message* msg,
+                            const upb_MessageDef* m, const upb_DefPool* symtab,
+                            int options, upb_Arena* arena, upb_Status* status);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/upb/json/decode.h
+++ b/upb/json/decode.h
@@ -39,9 +39,10 @@ extern "C" {
 
 enum { upb_JsonDecode_IgnoreUnknown = 1 };
 
-bool upb_JsonDecode(const char* buf, size_t size, upb_Message* msg,
-                    const upb_MessageDef* m, const upb_DefPool* symtab,
-                    int options, upb_Arena* arena, upb_Status* status);
+UPB_API_INLINE bool upb_JsonDecode(const char* buf, size_t size,
+                    upb_Message* msg, const upb_MessageDef* m,
+                    const upb_DefPool* symtab, int options, upb_Arena* arena,
+                    upb_Status* status);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/upb/json/encode.h
+++ b/upb/json/encode.h
@@ -57,11 +57,9 @@ enum {
  * size (excluding NULL) is returned.  This means that a return value >= |size|
  * implies that the output was truncated.  (These are the same semantics as
  * snprintf()). */
-UPB_API_INLINE size_t upb_JsonEncode(const upb_Message* msg,
-                                     const upb_MessageDef* m,
-                                     const upb_DefPool* ext_pool, int options,
-                                     char* buf, size_t size,
-                                     upb_Status* status);
+UPB_API size_t upb_JsonEncode(const upb_Message* msg, const upb_MessageDef* m,
+                              const upb_DefPool* ext_pool, int options,
+                              char* buf, size_t size, upb_Status* status);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/upb/json/encode.h
+++ b/upb/json/encode.h
@@ -57,9 +57,11 @@ enum {
  * size (excluding NULL) is returned.  This means that a return value >= |size|
  * implies that the output was truncated.  (These are the same semantics as
  * snprintf()). */
-size_t upb_JsonEncode(const upb_Message* msg, const upb_MessageDef* m,
-                      const upb_DefPool* ext_pool, int options, char* buf,
-                      size_t size, upb_Status* status);
+UPB_API_INLINE size_t upb_JsonEncode(const upb_Message* msg,
+                                     const upb_MessageDef* m,
+                                     const upb_DefPool* ext_pool, int options,
+                                     char* buf, size_t size,
+                                     upb_Status* status);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/upb/reflection/def_pool.h
+++ b/upb/reflection/def_pool.h
@@ -42,20 +42,18 @@
 extern "C" {
 #endif
 
-UPB_API_INLINE void upb_DefPool_Free(upb_DefPool* s);
+UPB_API void upb_DefPool_Free(upb_DefPool* s);
 
-UPB_API_INLINE upb_DefPool* upb_DefPool_New(void);
+UPB_API upb_DefPool* upb_DefPool_New(void);
 
-UPB_API_INLINE const upb_MessageDef* upb_DefPool_FindMessageByName(
-                                                    const upb_DefPool* s,
-                                                    const char* sym);
+UPB_API const upb_MessageDef* upb_DefPool_FindMessageByName(
+    const upb_DefPool* s,const char* sym);
 
 const upb_MessageDef* upb_DefPool_FindMessageByNameWithSize(
     const upb_DefPool* s, const char* sym, size_t len);
 
-UPB_API_INLINE const upb_EnumDef* upb_DefPool_FindEnumByName(
-                                              const upb_DefPool* s,
-                                              const char* sym);
+UPB_API const upb_EnumDef* upb_DefPool_FindEnumByName(const upb_DefPool* s,
+                                                      const char* sym);
 
 const upb_EnumValueDef* upb_DefPool_FindEnumByNameval(const upb_DefPool* s,
                                                       const char* sym);
@@ -89,7 +87,7 @@ const upb_ServiceDef* upb_DefPool_FindServiceByNameWithSize(
 const upb_FileDef* upb_DefPool_FindFileContainingSymbol(const upb_DefPool* s,
                                                         const char* name);
 
-UPB_API_INLINE const upb_FileDef* upb_DefPool_AddFile(upb_DefPool* s,
+UPB_API const upb_FileDef* upb_DefPool_AddFile(upb_DefPool* s,
                                        const UPB_DESC(FileDescriptorProto) *
                                            file_proto,
                                        upb_Status* status);

--- a/upb/reflection/def_pool.h
+++ b/upb/reflection/def_pool.h
@@ -42,17 +42,19 @@
 extern "C" {
 #endif
 
-void upb_DefPool_Free(upb_DefPool* s);
+UPB_API_INLINE void upb_DefPool_Free(upb_DefPool* s);
 
-upb_DefPool* upb_DefPool_New(void);
+UPB_API_INLINE upb_DefPool* upb_DefPool_New(void);
 
-const upb_MessageDef* upb_DefPool_FindMessageByName(const upb_DefPool* s,
+UPB_API_INLINE const upb_MessageDef* upb_DefPool_FindMessageByName(
+                                                    const upb_DefPool* s,
                                                     const char* sym);
 
 const upb_MessageDef* upb_DefPool_FindMessageByNameWithSize(
     const upb_DefPool* s, const char* sym, size_t len);
 
-const upb_EnumDef* upb_DefPool_FindEnumByName(const upb_DefPool* s,
+UPB_API_INLINE const upb_EnumDef* upb_DefPool_FindEnumByName(
+                                              const upb_DefPool* s,
                                               const char* sym);
 
 const upb_EnumValueDef* upb_DefPool_FindEnumByNameval(const upb_DefPool* s,
@@ -87,7 +89,7 @@ const upb_ServiceDef* upb_DefPool_FindServiceByNameWithSize(
 const upb_FileDef* upb_DefPool_FindFileContainingSymbol(const upb_DefPool* s,
                                                         const char* name);
 
-const upb_FileDef* upb_DefPool_AddFile(upb_DefPool* s,
+UPB_API_INLINE const upb_FileDef* upb_DefPool_AddFile(upb_DefPool* s,
                                        const UPB_DESC(FileDescriptorProto) *
                                            file_proto,
                                        upb_Status* status);

--- a/upb/reflection/enum_def.h
+++ b/upb/reflection/enum_def.h
@@ -43,14 +43,14 @@ extern "C" {
 bool upb_EnumDef_CheckNumber(const upb_EnumDef* e, int32_t num);
 const upb_MessageDef* upb_EnumDef_ContainingType(const upb_EnumDef* e);
 int32_t upb_EnumDef_Default(const upb_EnumDef* e);
-UPB_API_INLINE const upb_FileDef* upb_EnumDef_File(const upb_EnumDef* e);
+UPB_API const upb_FileDef* upb_EnumDef_File(const upb_EnumDef* e);
 const upb_EnumValueDef* upb_EnumDef_FindValueByName(const upb_EnumDef* e,
                                                     const char* name);
-UPB_API_INLINE const upb_EnumValueDef* upb_EnumDef_FindValueByNameWithSize(
+UPB_API const upb_EnumValueDef* upb_EnumDef_FindValueByNameWithSize(
     const upb_EnumDef* e, const char* name, size_t size);
-UPB_API_INLINE const upb_EnumValueDef* upb_EnumDef_FindValueByNumber(
+UPB_API const upb_EnumValueDef* upb_EnumDef_FindValueByNumber(
     const upb_EnumDef* e, int32_t num);
-UPB_API_INLINE const char* upb_EnumDef_FullName(const upb_EnumDef* e);
+UPB_API const char* upb_EnumDef_FullName(const upb_EnumDef* e);
 bool upb_EnumDef_HasOptions(const upb_EnumDef* e);
 bool upb_EnumDef_IsClosed(const upb_EnumDef* e);
 
@@ -68,9 +68,9 @@ const upb_EnumReservedRange* upb_EnumDef_ReservedRange(const upb_EnumDef* e,
                                                        int i);
 int upb_EnumDef_ReservedRangeCount(const upb_EnumDef* e);
 
-UPB_API_INLINE const upb_EnumValueDef* upb_EnumDef_Value(const upb_EnumDef* e,
+UPB_API const upb_EnumValueDef* upb_EnumDef_Value(const upb_EnumDef* e,
                                                          int i);
-UPB_API_INLINE int upb_EnumDef_ValueCount(const upb_EnumDef* e);
+UPB_API int upb_EnumDef_ValueCount(const upb_EnumDef* e);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/upb/reflection/enum_def.h
+++ b/upb/reflection/enum_def.h
@@ -43,14 +43,14 @@ extern "C" {
 bool upb_EnumDef_CheckNumber(const upb_EnumDef* e, int32_t num);
 const upb_MessageDef* upb_EnumDef_ContainingType(const upb_EnumDef* e);
 int32_t upb_EnumDef_Default(const upb_EnumDef* e);
-const upb_FileDef* upb_EnumDef_File(const upb_EnumDef* e);
+UPB_API_INLINE const upb_FileDef* upb_EnumDef_File(const upb_EnumDef* e);
 const upb_EnumValueDef* upb_EnumDef_FindValueByName(const upb_EnumDef* e,
                                                     const char* name);
-const upb_EnumValueDef* upb_EnumDef_FindValueByNameWithSize(
+UPB_API_INLINE const upb_EnumValueDef* upb_EnumDef_FindValueByNameWithSize(
     const upb_EnumDef* e, const char* name, size_t size);
-const upb_EnumValueDef* upb_EnumDef_FindValueByNumber(const upb_EnumDef* e,
-                                                      int32_t num);
-const char* upb_EnumDef_FullName(const upb_EnumDef* e);
+UPB_API_INLINE const upb_EnumValueDef* upb_EnumDef_FindValueByNumber(
+    const upb_EnumDef* e, int32_t num);
+UPB_API_INLINE const char* upb_EnumDef_FullName(const upb_EnumDef* e);
 bool upb_EnumDef_HasOptions(const upb_EnumDef* e);
 bool upb_EnumDef_IsClosed(const upb_EnumDef* e);
 
@@ -68,8 +68,9 @@ const upb_EnumReservedRange* upb_EnumDef_ReservedRange(const upb_EnumDef* e,
                                                        int i);
 int upb_EnumDef_ReservedRangeCount(const upb_EnumDef* e);
 
-const upb_EnumValueDef* upb_EnumDef_Value(const upb_EnumDef* e, int i);
-int upb_EnumDef_ValueCount(const upb_EnumDef* e);
+UPB_API_INLINE const upb_EnumValueDef* upb_EnumDef_Value(const upb_EnumDef* e,
+                                                         int i);
+UPB_API_INLINE int upb_EnumDef_ValueCount(const upb_EnumDef* e);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/upb/reflection/enum_value_def.h
+++ b/upb/reflection/enum_value_def.h
@@ -43,8 +43,8 @@ const upb_EnumDef* upb_EnumValueDef_Enum(const upb_EnumValueDef* v);
 const char* upb_EnumValueDef_FullName(const upb_EnumValueDef* v);
 bool upb_EnumValueDef_HasOptions(const upb_EnumValueDef* v);
 uint32_t upb_EnumValueDef_Index(const upb_EnumValueDef* v);
-UPB_API_INLINE const char* upb_EnumValueDef_Name(const upb_EnumValueDef* v);
-UPB_API_INLINE int32_t upb_EnumValueDef_Number(const upb_EnumValueDef* v);
+UPB_API const char* upb_EnumValueDef_Name(const upb_EnumValueDef* v);
+UPB_API int32_t upb_EnumValueDef_Number(const upb_EnumValueDef* v);
 const UPB_DESC(EnumValueOptions) *
     upb_EnumValueDef_Options(const upb_EnumValueDef* v);
 

--- a/upb/reflection/enum_value_def.h
+++ b/upb/reflection/enum_value_def.h
@@ -43,8 +43,8 @@ const upb_EnumDef* upb_EnumValueDef_Enum(const upb_EnumValueDef* v);
 const char* upb_EnumValueDef_FullName(const upb_EnumValueDef* v);
 bool upb_EnumValueDef_HasOptions(const upb_EnumValueDef* v);
 uint32_t upb_EnumValueDef_Index(const upb_EnumValueDef* v);
-const char* upb_EnumValueDef_Name(const upb_EnumValueDef* v);
-int32_t upb_EnumValueDef_Number(const upb_EnumValueDef* v);
+UPB_API_INLINE const char* upb_EnumValueDef_Name(const upb_EnumValueDef* v);
+UPB_API_INLINE int32_t upb_EnumValueDef_Number(const upb_EnumValueDef* v);
 const UPB_DESC(EnumValueOptions) *
     upb_EnumValueDef_Options(const upb_EnumValueDef* v);
 

--- a/upb/reflection/field_def.h
+++ b/upb/reflection/field_def.h
@@ -45,46 +45,44 @@ extern "C" {
 #endif
 
 const upb_OneofDef* upb_FieldDef_ContainingOneof(const upb_FieldDef* f);
-UPB_API_INLINE const upb_MessageDef* upb_FieldDef_ContainingType(
+UPB_API const upb_MessageDef* upb_FieldDef_ContainingType(
     const upb_FieldDef* f);
-UPB_API_INLINE upb_CType upb_FieldDef_CType(const upb_FieldDef* f);
-UPB_API_INLINE upb_MessageValue upb_FieldDef_Default(const upb_FieldDef* f);
-UPB_API_INLINE const upb_EnumDef* upb_FieldDef_EnumSubDef(const upb_FieldDef*
-                                                          f);
+UPB_API upb_CType upb_FieldDef_CType(const upb_FieldDef* f);
+UPB_API upb_MessageValue upb_FieldDef_Default(const upb_FieldDef* f);
+UPB_API const upb_EnumDef* upb_FieldDef_EnumSubDef(const upb_FieldDef* f);
 const upb_MessageDef* upb_FieldDef_ExtensionScope(const upb_FieldDef* f);
-UPB_API_INLINE const upb_FileDef* upb_FieldDef_File(const upb_FieldDef* f);
+UPB_API const upb_FileDef* upb_FieldDef_File(const upb_FieldDef* f);
 const char* upb_FieldDef_FullName(const upb_FieldDef* f);
 bool upb_FieldDef_HasDefault(const upb_FieldDef* f);
 bool upb_FieldDef_HasJsonName(const upb_FieldDef* f);
 bool upb_FieldDef_HasOptions(const upb_FieldDef* f);
-UPB_API_INLINE bool upb_FieldDef_HasPresence(const upb_FieldDef* f);
+UPB_API bool upb_FieldDef_HasPresence(const upb_FieldDef* f);
 bool upb_FieldDef_HasSubDef(const upb_FieldDef* f);
 uint32_t upb_FieldDef_Index(const upb_FieldDef* f);
 bool upb_FieldDef_IsExtension(const upb_FieldDef* f);
-UPB_API_INLINE bool upb_FieldDef_IsMap(const upb_FieldDef* f);
+UPB_API bool upb_FieldDef_IsMap(const upb_FieldDef* f);
 bool upb_FieldDef_IsOptional(const upb_FieldDef* f);
 bool upb_FieldDef_IsPacked(const upb_FieldDef* f);
 bool upb_FieldDef_IsPrimitive(const upb_FieldDef* f);
-UPB_API_INLINE bool upb_FieldDef_IsRepeated(const upb_FieldDef* f);
+UPB_API bool upb_FieldDef_IsRepeated(const upb_FieldDef* f);
 bool upb_FieldDef_IsRequired(const upb_FieldDef* f);
 bool upb_FieldDef_IsString(const upb_FieldDef* f);
-UPB_API_INLINE bool upb_FieldDef_IsSubMessage(const upb_FieldDef* f);
-UPB_API_INLINE const char* upb_FieldDef_JsonName(const upb_FieldDef* f);
-UPB_API_INLINE upb_Label upb_FieldDef_Label(const upb_FieldDef* f);
-UPB_API_INLINE const upb_MessageDef* upb_FieldDef_MessageSubDef(
-    const upb_FieldDef* f);
+UPB_API bool upb_FieldDef_IsSubMessage(const upb_FieldDef* f);
+UPB_API const char* upb_FieldDef_JsonName(const upb_FieldDef* f);
+UPB_API upb_Label upb_FieldDef_Label(const upb_FieldDef* f);
+UPB_API const upb_MessageDef* upb_FieldDef_MessageSubDef(const upb_FieldDef* f);
 
 // Creates a mini descriptor string for a field, returns true on success.
 bool upb_FieldDef_MiniDescriptorEncode(const upb_FieldDef* f, upb_Arena* a,
                                        upb_StringView* out);
 
 const upb_MiniTableField* upb_FieldDef_MiniTable(const upb_FieldDef* f);
-UPB_API_INLINE const char* upb_FieldDef_Name(const upb_FieldDef* f);
-UPB_API_INLINE uint32_t upb_FieldDef_Number(const upb_FieldDef* f);
+UPB_API const char* upb_FieldDef_Name(const upb_FieldDef* f);
+UPB_API uint32_t upb_FieldDef_Number(const upb_FieldDef* f);
 const UPB_DESC(FieldOptions) * upb_FieldDef_Options(const upb_FieldDef* f);
-UPB_API_INLINE const upb_OneofDef* upb_FieldDef_RealContainingOneof(
+UPB_API const upb_OneofDef* upb_FieldDef_RealContainingOneof(
     const upb_FieldDef* f);
-UPB_API_INLINE upb_FieldType upb_FieldDef_Type(const upb_FieldDef* f);
+UPB_API upb_FieldType upb_FieldDef_Type(const upb_FieldDef* f);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/upb/reflection/field_def.h
+++ b/upb/reflection/field_def.h
@@ -45,42 +45,46 @@ extern "C" {
 #endif
 
 const upb_OneofDef* upb_FieldDef_ContainingOneof(const upb_FieldDef* f);
-const upb_MessageDef* upb_FieldDef_ContainingType(const upb_FieldDef* f);
-upb_CType upb_FieldDef_CType(const upb_FieldDef* f);
-upb_MessageValue upb_FieldDef_Default(const upb_FieldDef* f);
-const upb_EnumDef* upb_FieldDef_EnumSubDef(const upb_FieldDef* f);
+UPB_API_INLINE const upb_MessageDef* upb_FieldDef_ContainingType(
+    const upb_FieldDef* f);
+UPB_API_INLINE upb_CType upb_FieldDef_CType(const upb_FieldDef* f);
+UPB_API_INLINE upb_MessageValue upb_FieldDef_Default(const upb_FieldDef* f);
+UPB_API_INLINE const upb_EnumDef* upb_FieldDef_EnumSubDef(const upb_FieldDef*
+                                                          f);
 const upb_MessageDef* upb_FieldDef_ExtensionScope(const upb_FieldDef* f);
-const upb_FileDef* upb_FieldDef_File(const upb_FieldDef* f);
+UPB_API_INLINE const upb_FileDef* upb_FieldDef_File(const upb_FieldDef* f);
 const char* upb_FieldDef_FullName(const upb_FieldDef* f);
 bool upb_FieldDef_HasDefault(const upb_FieldDef* f);
 bool upb_FieldDef_HasJsonName(const upb_FieldDef* f);
 bool upb_FieldDef_HasOptions(const upb_FieldDef* f);
-bool upb_FieldDef_HasPresence(const upb_FieldDef* f);
+UPB_API_INLINE bool upb_FieldDef_HasPresence(const upb_FieldDef* f);
 bool upb_FieldDef_HasSubDef(const upb_FieldDef* f);
 uint32_t upb_FieldDef_Index(const upb_FieldDef* f);
 bool upb_FieldDef_IsExtension(const upb_FieldDef* f);
-bool upb_FieldDef_IsMap(const upb_FieldDef* f);
+UPB_API_INLINE bool upb_FieldDef_IsMap(const upb_FieldDef* f);
 bool upb_FieldDef_IsOptional(const upb_FieldDef* f);
 bool upb_FieldDef_IsPacked(const upb_FieldDef* f);
 bool upb_FieldDef_IsPrimitive(const upb_FieldDef* f);
-bool upb_FieldDef_IsRepeated(const upb_FieldDef* f);
+UPB_API_INLINE bool upb_FieldDef_IsRepeated(const upb_FieldDef* f);
 bool upb_FieldDef_IsRequired(const upb_FieldDef* f);
 bool upb_FieldDef_IsString(const upb_FieldDef* f);
-bool upb_FieldDef_IsSubMessage(const upb_FieldDef* f);
-const char* upb_FieldDef_JsonName(const upb_FieldDef* f);
-upb_Label upb_FieldDef_Label(const upb_FieldDef* f);
-const upb_MessageDef* upb_FieldDef_MessageSubDef(const upb_FieldDef* f);
+UPB_API_INLINE bool upb_FieldDef_IsSubMessage(const upb_FieldDef* f);
+UPB_API_INLINE const char* upb_FieldDef_JsonName(const upb_FieldDef* f);
+UPB_API_INLINE upb_Label upb_FieldDef_Label(const upb_FieldDef* f);
+UPB_API_INLINE const upb_MessageDef* upb_FieldDef_MessageSubDef(
+    const upb_FieldDef* f);
 
 // Creates a mini descriptor string for a field, returns true on success.
 bool upb_FieldDef_MiniDescriptorEncode(const upb_FieldDef* f, upb_Arena* a,
                                        upb_StringView* out);
 
 const upb_MiniTableField* upb_FieldDef_MiniTable(const upb_FieldDef* f);
-const char* upb_FieldDef_Name(const upb_FieldDef* f);
-uint32_t upb_FieldDef_Number(const upb_FieldDef* f);
+UPB_API_INLINE const char* upb_FieldDef_Name(const upb_FieldDef* f);
+UPB_API_INLINE uint32_t upb_FieldDef_Number(const upb_FieldDef* f);
 const UPB_DESC(FieldOptions) * upb_FieldDef_Options(const upb_FieldDef* f);
-const upb_OneofDef* upb_FieldDef_RealContainingOneof(const upb_FieldDef* f);
-upb_FieldType upb_FieldDef_Type(const upb_FieldDef* f);
+UPB_API_INLINE const upb_OneofDef* upb_FieldDef_RealContainingOneof(
+    const upb_FieldDef* f);
+UPB_API_INLINE upb_FieldType upb_FieldDef_Type(const upb_FieldDef* f);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/upb/reflection/file_def.h
+++ b/upb/reflection/file_def.h
@@ -42,11 +42,11 @@ extern "C" {
 const upb_FileDef* upb_FileDef_Dependency(const upb_FileDef* f, int i);
 int upb_FileDef_DependencyCount(const upb_FileDef* f);
 bool upb_FileDef_HasOptions(const upb_FileDef* f);
-const char* upb_FileDef_Name(const upb_FileDef* f);
+UPB_API_INLINE const char* upb_FileDef_Name(const upb_FileDef* f);
 const UPB_DESC(FileOptions) * upb_FileDef_Options(const upb_FileDef* f);
 const char* upb_FileDef_Package(const upb_FileDef* f);
 const char* upb_FileDef_Edition(const upb_FileDef* f);
-const upb_DefPool* upb_FileDef_Pool(const upb_FileDef* f);
+UPB_API_INLINE const upb_DefPool* upb_FileDef_Pool(const upb_FileDef* f);
 
 const upb_FileDef* upb_FileDef_PublicDependency(const upb_FileDef* f, int i);
 int upb_FileDef_PublicDependencyCount(const upb_FileDef* f);
@@ -54,7 +54,7 @@ int upb_FileDef_PublicDependencyCount(const upb_FileDef* f);
 const upb_ServiceDef* upb_FileDef_Service(const upb_FileDef* f, int i);
 int upb_FileDef_ServiceCount(const upb_FileDef* f);
 
-upb_Syntax upb_FileDef_Syntax(const upb_FileDef* f);
+UPB_API_INLINE upb_Syntax upb_FileDef_Syntax(const upb_FileDef* f);
 
 const upb_EnumDef* upb_FileDef_TopLevelEnum(const upb_FileDef* f, int i);
 int upb_FileDef_TopLevelEnumCount(const upb_FileDef* f);

--- a/upb/reflection/file_def.h
+++ b/upb/reflection/file_def.h
@@ -42,11 +42,11 @@ extern "C" {
 const upb_FileDef* upb_FileDef_Dependency(const upb_FileDef* f, int i);
 int upb_FileDef_DependencyCount(const upb_FileDef* f);
 bool upb_FileDef_HasOptions(const upb_FileDef* f);
-UPB_API_INLINE const char* upb_FileDef_Name(const upb_FileDef* f);
+UPB_API const char* upb_FileDef_Name(const upb_FileDef* f);
 const UPB_DESC(FileOptions) * upb_FileDef_Options(const upb_FileDef* f);
 const char* upb_FileDef_Package(const upb_FileDef* f);
 const char* upb_FileDef_Edition(const upb_FileDef* f);
-UPB_API_INLINE const upb_DefPool* upb_FileDef_Pool(const upb_FileDef* f);
+UPB_API const upb_DefPool* upb_FileDef_Pool(const upb_FileDef* f);
 
 const upb_FileDef* upb_FileDef_PublicDependency(const upb_FileDef* f, int i);
 int upb_FileDef_PublicDependencyCount(const upb_FileDef* f);
@@ -54,7 +54,7 @@ int upb_FileDef_PublicDependencyCount(const upb_FileDef* f);
 const upb_ServiceDef* upb_FileDef_Service(const upb_FileDef* f, int i);
 int upb_FileDef_ServiceCount(const upb_FileDef* f);
 
-UPB_API_INLINE upb_Syntax upb_FileDef_Syntax(const upb_FileDef* f);
+UPB_API upb_Syntax upb_FileDef_Syntax(const upb_FileDef* f);
 
 const upb_EnumDef* upb_FileDef_TopLevelEnum(const upb_FileDef* f, int i);
 int upb_FileDef_TopLevelEnumCount(const upb_FileDef* f);

--- a/upb/reflection/message.h
+++ b/upb/reflection/message.h
@@ -41,34 +41,38 @@ extern "C" {
 // Returns a mutable pointer to a map, array, or submessage value. If the given
 // arena is non-NULL this will construct a new object if it was not previously
 // present. May not be called for primitive fields.
-upb_MutableMessageValue upb_Message_Mutable(upb_Message* msg,
+UPB_API_INLINE upb_MutableMessageValue upb_Message_Mutable(upb_Message* msg,
                                             const upb_FieldDef* f,
                                             upb_Arena* a);
 
 // Returns the field that is set in the oneof, or NULL if none are set.
-const upb_FieldDef* upb_Message_WhichOneof(const upb_Message* msg,
-                                           const upb_OneofDef* o);
+UPB_API_INLINE const upb_FieldDef* upb_Message_WhichOneof(
+    const upb_Message* msg, const upb_OneofDef* o);
 
 // Clear all data and unknown fields.
 void upb_Message_ClearByDef(upb_Message* msg, const upb_MessageDef* m);
 
 // Clears any field presence and sets the value back to its default.
-void upb_Message_ClearFieldByDef(upb_Message* msg, const upb_FieldDef* f);
+UPB_API_INLINE void upb_Message_ClearFieldByDef(upb_Message* msg,
+                                                const upb_FieldDef* f);
 
 // May only be called for fields where upb_FieldDef_HasPresence(f) == true.
-bool upb_Message_HasFieldByDef(const upb_Message* msg, const upb_FieldDef* f);
+UPB_API_INLINE bool upb_Message_HasFieldByDef(const upb_Message* msg,
+                                              const upb_FieldDef* f);
 
 // Returns the value in the message associated with this field def.
-upb_MessageValue upb_Message_GetFieldByDef(const upb_Message* msg,
-                                           const upb_FieldDef* f);
+UPB_API_INLINE upb_MessageValue upb_Message_GetFieldByDef(
+    const upb_Message* msg, const upb_FieldDef* f);
 
 // Sets the given field to the given value. For a msg/array/map/string, the
 // caller must ensure that the target data outlives |msg| (by living either in
 // the same arena or a different arena that outlives it).
 //
 // Returns false if allocation fails.
-bool upb_Message_SetFieldByDef(upb_Message* msg, const upb_FieldDef* f,
-                               upb_MessageValue val, upb_Arena* a);
+UPB_API_INLINE bool upb_Message_SetFieldByDef(upb_Message* msg,
+                                              const upb_FieldDef* f,
+                                              upb_MessageValue val,
+                                              upb_Arena* a);
 
 // Iterate over present fields.
 //
@@ -90,8 +94,9 @@ bool upb_Message_Next(const upb_Message* msg, const upb_MessageDef* m,
                       upb_MessageValue* val, size_t* iter);
 
 // Clears all unknown field data from this message and all submessages.
-bool upb_Message_DiscardUnknown(upb_Message* msg, const upb_MessageDef* m,
-                                int maxdepth);
+UPB_API_INLINE bool upb_Message_DiscardUnknown(upb_Message* msg,
+                                               const upb_MessageDef* m,
+                                               int maxdepth);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/upb/reflection/message.h
+++ b/upb/reflection/message.h
@@ -41,38 +41,36 @@ extern "C" {
 // Returns a mutable pointer to a map, array, or submessage value. If the given
 // arena is non-NULL this will construct a new object if it was not previously
 // present. May not be called for primitive fields.
-UPB_API_INLINE upb_MutableMessageValue upb_Message_Mutable(upb_Message* msg,
-                                            const upb_FieldDef* f,
-                                            upb_Arena* a);
+UPB_API upb_MutableMessageValue upb_Message_Mutable(upb_Message* msg,
+                                                    const upb_FieldDef* f,
+                                                    upb_Arena* a);
 
 // Returns the field that is set in the oneof, or NULL if none are set.
-UPB_API_INLINE const upb_FieldDef* upb_Message_WhichOneof(
-    const upb_Message* msg, const upb_OneofDef* o);
+UPB_API const upb_FieldDef* upb_Message_WhichOneof(const upb_Message* msg,
+                                                   const upb_OneofDef* o);
 
 // Clear all data and unknown fields.
 void upb_Message_ClearByDef(upb_Message* msg, const upb_MessageDef* m);
 
 // Clears any field presence and sets the value back to its default.
-UPB_API_INLINE void upb_Message_ClearFieldByDef(upb_Message* msg,
-                                                const upb_FieldDef* f);
+UPB_API void upb_Message_ClearFieldByDef(upb_Message* msg,
+                                         const upb_FieldDef* f);
 
 // May only be called for fields where upb_FieldDef_HasPresence(f) == true.
-UPB_API_INLINE bool upb_Message_HasFieldByDef(const upb_Message* msg,
-                                              const upb_FieldDef* f);
+UPB_API bool upb_Message_HasFieldByDef(const upb_Message* msg,
+                                       const upb_FieldDef* f);
 
 // Returns the value in the message associated with this field def.
-UPB_API_INLINE upb_MessageValue upb_Message_GetFieldByDef(
-    const upb_Message* msg, const upb_FieldDef* f);
+UPB_API upb_MessageValue upb_Message_GetFieldByDef(const upb_Message* msg,
+                                                   const upb_FieldDef* f);
 
 // Sets the given field to the given value. For a msg/array/map/string, the
 // caller must ensure that the target data outlives |msg| (by living either in
 // the same arena or a different arena that outlives it).
 //
 // Returns false if allocation fails.
-UPB_API_INLINE bool upb_Message_SetFieldByDef(upb_Message* msg,
-                                              const upb_FieldDef* f,
-                                              upb_MessageValue val,
-                                              upb_Arena* a);
+UPB_API bool upb_Message_SetFieldByDef(upb_Message* msg, const upb_FieldDef* f,
+                                       upb_MessageValue val, upb_Arena* a);
 
 // Iterate over present fields.
 //
@@ -94,9 +92,8 @@ bool upb_Message_Next(const upb_Message* msg, const upb_MessageDef* m,
                       upb_MessageValue* val, size_t* iter);
 
 // Clears all unknown field data from this message and all submessages.
-UPB_API_INLINE bool upb_Message_DiscardUnknown(upb_Message* msg,
-                                               const upb_MessageDef* m,
-                                               int maxdepth);
+UPB_API bool upb_Message_DiscardUnknown(upb_Message* msg,
+                                        const upb_MessageDef* m, int maxdepth);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/upb/reflection/message_def.h
+++ b/upb/reflection/message_def.h
@@ -89,10 +89,11 @@ const upb_ExtensionRange* upb_MessageDef_ExtensionRange(const upb_MessageDef* m,
                                                         int i);
 int upb_MessageDef_ExtensionRangeCount(const upb_MessageDef* m);
 
-const upb_FieldDef* upb_MessageDef_Field(const upb_MessageDef* m, int i);
-int upb_MessageDef_FieldCount(const upb_MessageDef* m);
+UPB_API_INLINE const upb_FieldDef* upb_MessageDef_Field(const upb_MessageDef* m,
+                                                        int i);
+UPB_API_INLINE int upb_MessageDef_FieldCount(const upb_MessageDef* m);
 
-const upb_FileDef* upb_MessageDef_File(const upb_MessageDef* m);
+UPB_API_INLINE const upb_FileDef* upb_MessageDef_File(const upb_MessageDef* m);
 
 // Returns a field by either JSON name or regular proto name.
 const upb_FieldDef* upb_MessageDef_FindByJsonNameWithSize(
@@ -105,10 +106,11 @@ UPB_INLINE const upb_FieldDef* upb_MessageDef_FindByJsonName(
 // Lookup of either field or oneof by name. Returns whether either was found.
 // If the return is true, then the found def will be set, and the non-found
 // one set to NULL.
-bool upb_MessageDef_FindByNameWithSize(const upb_MessageDef* m,
-                                       const char* name, size_t size,
-                                       const upb_FieldDef** f,
-                                       const upb_OneofDef** o);
+UPB_API_INLINE bool upb_MessageDef_FindByNameWithSize(const upb_MessageDef* m,
+                                                      const char* name,
+                                                      size_t size,
+                                                      const upb_FieldDef** f,
+                                                      const upb_OneofDef** o);
 UPB_INLINE bool upb_MessageDef_FindByName(const upb_MessageDef* m,
                                           const char* name,
                                           const upb_FieldDef** f,
@@ -118,15 +120,15 @@ UPB_INLINE bool upb_MessageDef_FindByName(const upb_MessageDef* m,
 
 const upb_FieldDef* upb_MessageDef_FindFieldByName(const upb_MessageDef* m,
                                                    const char* name);
-const upb_FieldDef* upb_MessageDef_FindFieldByNameWithSize(
+UPB_API_INLINE const upb_FieldDef* upb_MessageDef_FindFieldByNameWithSize(
     const upb_MessageDef* m, const char* name, size_t size);
-const upb_FieldDef* upb_MessageDef_FindFieldByNumber(const upb_MessageDef* m,
-                                                     uint32_t i);
+UPB_API_INLINE const upb_FieldDef* upb_MessageDef_FindFieldByNumber(
+    const upb_MessageDef* m, uint32_t i);
 const upb_OneofDef* upb_MessageDef_FindOneofByName(const upb_MessageDef* m,
                                                    const char* name);
-const upb_OneofDef* upb_MessageDef_FindOneofByNameWithSize(
+UPB_API_INLINE const upb_OneofDef* upb_MessageDef_FindOneofByNameWithSize(
     const upb_MessageDef* m, const char* name, size_t size);
-const char* upb_MessageDef_FullName(const upb_MessageDef* m);
+UPB_API_INLINE const char* upb_MessageDef_FullName(const upb_MessageDef* m);
 bool upb_MessageDef_HasOptions(const upb_MessageDef* m);
 bool upb_MessageDef_IsMapEntry(const upb_MessageDef* m);
 bool upb_MessageDef_IsMessageSet(const upb_MessageDef* m);
@@ -135,7 +137,8 @@ bool upb_MessageDef_IsMessageSet(const upb_MessageDef* m);
 bool upb_MessageDef_MiniDescriptorEncode(const upb_MessageDef* m, upb_Arena* a,
                                          upb_StringView* out);
 
-const upb_MiniTable* upb_MessageDef_MiniTable(const upb_MessageDef* m);
+UPB_API_INLINE const upb_MiniTable* upb_MessageDef_MiniTable(
+    const upb_MessageDef* m);
 const char* upb_MessageDef_Name(const upb_MessageDef* m);
 
 const upb_EnumDef* upb_MessageDef_NestedEnum(const upb_MessageDef* m, int i);
@@ -148,8 +151,9 @@ int upb_MessageDef_NestedEnumCount(const upb_MessageDef* m);
 int upb_MessageDef_NestedExtensionCount(const upb_MessageDef* m);
 int upb_MessageDef_NestedMessageCount(const upb_MessageDef* m);
 
-const upb_OneofDef* upb_MessageDef_Oneof(const upb_MessageDef* m, int i);
-int upb_MessageDef_OneofCount(const upb_MessageDef* m);
+UPB_API_INLINE const upb_OneofDef* upb_MessageDef_Oneof(const upb_MessageDef* m,
+                                                        int i);
+UPB_API_INLINE int upb_MessageDef_OneofCount(const upb_MessageDef* m);
 int upb_MessageDef_RealOneofCount(const upb_MessageDef* m);
 
 const UPB_DESC(MessageOptions) *
@@ -162,8 +166,9 @@ const upb_MessageReservedRange* upb_MessageDef_ReservedRange(
     const upb_MessageDef* m, int i);
 int upb_MessageDef_ReservedRangeCount(const upb_MessageDef* m);
 
-upb_Syntax upb_MessageDef_Syntax(const upb_MessageDef* m);
-upb_WellKnown upb_MessageDef_WellKnownType(const upb_MessageDef* m);
+UPB_API_INLINE upb_Syntax upb_MessageDef_Syntax(const upb_MessageDef* m);
+UPB_API_INLINE upb_WellKnown upb_MessageDef_WellKnownType(const upb_MessageDef*
+                                                          m);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/upb/reflection/message_def.h
+++ b/upb/reflection/message_def.h
@@ -89,11 +89,11 @@ const upb_ExtensionRange* upb_MessageDef_ExtensionRange(const upb_MessageDef* m,
                                                         int i);
 int upb_MessageDef_ExtensionRangeCount(const upb_MessageDef* m);
 
-UPB_API_INLINE const upb_FieldDef* upb_MessageDef_Field(const upb_MessageDef* m,
-                                                        int i);
-UPB_API_INLINE int upb_MessageDef_FieldCount(const upb_MessageDef* m);
+UPB_API const upb_FieldDef* upb_MessageDef_Field(const upb_MessageDef* m,
+                                                 int i);
+UPB_API int upb_MessageDef_FieldCount(const upb_MessageDef* m);
 
-UPB_API_INLINE const upb_FileDef* upb_MessageDef_File(const upb_MessageDef* m);
+UPB_API const upb_FileDef* upb_MessageDef_File(const upb_MessageDef* m);
 
 // Returns a field by either JSON name or regular proto name.
 const upb_FieldDef* upb_MessageDef_FindByJsonNameWithSize(
@@ -106,11 +106,10 @@ UPB_INLINE const upb_FieldDef* upb_MessageDef_FindByJsonName(
 // Lookup of either field or oneof by name. Returns whether either was found.
 // If the return is true, then the found def will be set, and the non-found
 // one set to NULL.
-UPB_API_INLINE bool upb_MessageDef_FindByNameWithSize(const upb_MessageDef* m,
-                                                      const char* name,
-                                                      size_t size,
-                                                      const upb_FieldDef** f,
-                                                      const upb_OneofDef** o);
+UPB_API bool upb_MessageDef_FindByNameWithSize(const upb_MessageDef* m,
+                                               const char* name, size_t size,
+                                               const upb_FieldDef** f,
+                                               const upb_OneofDef** o);
 UPB_INLINE bool upb_MessageDef_FindByName(const upb_MessageDef* m,
                                           const char* name,
                                           const upb_FieldDef** f,
@@ -120,15 +119,15 @@ UPB_INLINE bool upb_MessageDef_FindByName(const upb_MessageDef* m,
 
 const upb_FieldDef* upb_MessageDef_FindFieldByName(const upb_MessageDef* m,
                                                    const char* name);
-UPB_API_INLINE const upb_FieldDef* upb_MessageDef_FindFieldByNameWithSize(
+UPB_API const upb_FieldDef* upb_MessageDef_FindFieldByNameWithSize(
     const upb_MessageDef* m, const char* name, size_t size);
-UPB_API_INLINE const upb_FieldDef* upb_MessageDef_FindFieldByNumber(
+UPB_API const upb_FieldDef* upb_MessageDef_FindFieldByNumber(
     const upb_MessageDef* m, uint32_t i);
 const upb_OneofDef* upb_MessageDef_FindOneofByName(const upb_MessageDef* m,
                                                    const char* name);
-UPB_API_INLINE const upb_OneofDef* upb_MessageDef_FindOneofByNameWithSize(
+UPB_API const upb_OneofDef* upb_MessageDef_FindOneofByNameWithSize(
     const upb_MessageDef* m, const char* name, size_t size);
-UPB_API_INLINE const char* upb_MessageDef_FullName(const upb_MessageDef* m);
+UPB_API const char* upb_MessageDef_FullName(const upb_MessageDef* m);
 bool upb_MessageDef_HasOptions(const upb_MessageDef* m);
 bool upb_MessageDef_IsMapEntry(const upb_MessageDef* m);
 bool upb_MessageDef_IsMessageSet(const upb_MessageDef* m);
@@ -137,8 +136,7 @@ bool upb_MessageDef_IsMessageSet(const upb_MessageDef* m);
 bool upb_MessageDef_MiniDescriptorEncode(const upb_MessageDef* m, upb_Arena* a,
                                          upb_StringView* out);
 
-UPB_API_INLINE const upb_MiniTable* upb_MessageDef_MiniTable(
-    const upb_MessageDef* m);
+UPB_API const upb_MiniTable* upb_MessageDef_MiniTable(const upb_MessageDef* m);
 const char* upb_MessageDef_Name(const upb_MessageDef* m);
 
 const upb_EnumDef* upb_MessageDef_NestedEnum(const upb_MessageDef* m, int i);
@@ -151,9 +149,9 @@ int upb_MessageDef_NestedEnumCount(const upb_MessageDef* m);
 int upb_MessageDef_NestedExtensionCount(const upb_MessageDef* m);
 int upb_MessageDef_NestedMessageCount(const upb_MessageDef* m);
 
-UPB_API_INLINE const upb_OneofDef* upb_MessageDef_Oneof(const upb_MessageDef* m,
-                                                        int i);
-UPB_API_INLINE int upb_MessageDef_OneofCount(const upb_MessageDef* m);
+UPB_API const upb_OneofDef* upb_MessageDef_Oneof(const upb_MessageDef* m,
+                                                 int i);
+UPB_API int upb_MessageDef_OneofCount(const upb_MessageDef* m);
 int upb_MessageDef_RealOneofCount(const upb_MessageDef* m);
 
 const UPB_DESC(MessageOptions) *
@@ -166,9 +164,8 @@ const upb_MessageReservedRange* upb_MessageDef_ReservedRange(
     const upb_MessageDef* m, int i);
 int upb_MessageDef_ReservedRangeCount(const upb_MessageDef* m);
 
-UPB_API_INLINE upb_Syntax upb_MessageDef_Syntax(const upb_MessageDef* m);
-UPB_API_INLINE upb_WellKnown upb_MessageDef_WellKnownType(const upb_MessageDef*
-                                                          m);
+UPB_API upb_Syntax upb_MessageDef_Syntax(const upb_MessageDef* m);
+UPB_API upb_WellKnown upb_MessageDef_WellKnownType(const upb_MessageDef* m);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/upb/reflection/oneof_def.h
+++ b/upb/reflection/oneof_def.h
@@ -39,9 +39,11 @@
 extern "C" {
 #endif
 
-const upb_MessageDef* upb_OneofDef_ContainingType(const upb_OneofDef* o);
-const upb_FieldDef* upb_OneofDef_Field(const upb_OneofDef* o, int i);
-int upb_OneofDef_FieldCount(const upb_OneofDef* o);
+UPB_API_INLINE const upb_MessageDef* upb_OneofDef_ContainingType(
+    const upb_OneofDef* o);
+UPB_API_INLINE const upb_FieldDef* upb_OneofDef_Field(const upb_OneofDef* o,
+                                                      int i);
+UPB_API_INLINE int upb_OneofDef_FieldCount(const upb_OneofDef* o);
 const char* upb_OneofDef_FullName(const upb_OneofDef* o);
 bool upb_OneofDef_HasOptions(const upb_OneofDef* o);
 uint32_t upb_OneofDef_Index(const upb_OneofDef* o);
@@ -53,7 +55,7 @@ const upb_FieldDef* upb_OneofDef_LookupNameWithSize(const upb_OneofDef* o,
                                                     size_t size);
 const upb_FieldDef* upb_OneofDef_LookupNumber(const upb_OneofDef* o,
                                               uint32_t num);
-const char* upb_OneofDef_Name(const upb_OneofDef* o);
+UPB_API_INLINE const char* upb_OneofDef_Name(const upb_OneofDef* o);
 int upb_OneofDef_numfields(const upb_OneofDef* o);
 const UPB_DESC(OneofOptions) * upb_OneofDef_Options(const upb_OneofDef* o);
 

--- a/upb/reflection/oneof_def.h
+++ b/upb/reflection/oneof_def.h
@@ -39,11 +39,10 @@
 extern "C" {
 #endif
 
-UPB_API_INLINE const upb_MessageDef* upb_OneofDef_ContainingType(
+UPB_API const upb_MessageDef* upb_OneofDef_ContainingType(
     const upb_OneofDef* o);
-UPB_API_INLINE const upb_FieldDef* upb_OneofDef_Field(const upb_OneofDef* o,
-                                                      int i);
-UPB_API_INLINE int upb_OneofDef_FieldCount(const upb_OneofDef* o);
+UPB_API const upb_FieldDef* upb_OneofDef_Field(const upb_OneofDef* o, int i);
+UPB_API int upb_OneofDef_FieldCount(const upb_OneofDef* o);
 const char* upb_OneofDef_FullName(const upb_OneofDef* o);
 bool upb_OneofDef_HasOptions(const upb_OneofDef* o);
 uint32_t upb_OneofDef_Index(const upb_OneofDef* o);
@@ -55,7 +54,7 @@ const upb_FieldDef* upb_OneofDef_LookupNameWithSize(const upb_OneofDef* o,
                                                     size_t size);
 const upb_FieldDef* upb_OneofDef_LookupNumber(const upb_OneofDef* o,
                                               uint32_t num);
-UPB_API_INLINE const char* upb_OneofDef_Name(const upb_OneofDef* o);
+UPB_API const char* upb_OneofDef_Name(const upb_OneofDef* o);
 int upb_OneofDef_numfields(const upb_OneofDef* o);
 const UPB_DESC(OneofOptions) * upb_OneofDef_Options(const upb_OneofDef* o);
 

--- a/upb/wire/encode.h
+++ b/upb/wire/encode.h
@@ -79,10 +79,9 @@ UPB_INLINE int upb_Encode_LimitDepth(uint32_t encode_options, uint32_t limit) {
   return upb_EncodeOptions_MaxDepth(max_depth) | (encode_options & 0xffff);
 }
 
-UPB_API_INLINE upb_EncodeStatus upb_Encode(const void* msg,
-                                           const upb_MiniTable* l, int options,
-                                           upb_Arena* arena, char** buf,
-                                           size_t* size);
+UPB_API upb_EncodeStatus upb_Encode(const void* msg, const upb_MiniTable* l,
+                                    int options, upb_Arena* arena, char** buf,
+                                    size_t* size);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/upb/wire/encode.h
+++ b/upb/wire/encode.h
@@ -79,9 +79,10 @@ UPB_INLINE int upb_Encode_LimitDepth(uint32_t encode_options, uint32_t limit) {
   return upb_EncodeOptions_MaxDepth(max_depth) | (encode_options & 0xffff);
 }
 
-upb_EncodeStatus upb_Encode(const void* msg, const upb_MiniTable* l,
-                            int options, upb_Arena* arena, char** buf,
-                            size_t* size);
+UPB_API_INLINE upb_EncodeStatus upb_Encode(const void* msg,
+                                           const upb_MiniTable* l, int options,
+                                           upb_Arena* arena, char** buf,
+                                           size_t* size);
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
Once merged, the changes to ~`upb-ruby.h`~ `glue.c` in https://github.com/protocolbuffers/protobuf/pull/11483 can be reverted without breaking the FFI feature branch.