### PR TITLE
Drop Bazel 4 support in upb.

### DIFF
--- a/.github/workflows/bazel_tests.yml
+++ b/.github/workflows/bazel_tests.yml
@@ -32,8 +32,8 @@ jobs:
           # Current github runners are all Intel based, so just build/compile for Apple Silicon to detect issues there.
           - { NAME: "macOS ARM (build only)", BAZEL: bazel, BAZEL_CMD: build, CC: clang, os: macos-11, flags: "--cpu=darwin_arm64"}
           # We support two Bazel versions back per https://opensource.google/documentation/policies/cplusplus-support
-          - { NAME: "Bazel 4.1.0", BAZEL: bazel-4.1.0-linux-x86_64, CC: clang, os: ubuntu-20-large }
           - { NAME: "Bazel 5.3.0", BAZEL: bazel-5.3.0-linux-x86_64, CC: clang, os: ubuntu-20-large }
+          - { NAME: "Bazel 6.1.0", BAZEL: bazel-6.1.0-linux-x86_64, CC: clang, os: ubuntu-20-large }
 
     name: ${{ matrix.NAME }}
 


### PR DESCRIPTION
This has already been dropped in the protobuf repo, which now supports Bazel 5 and 6.

PiperOrigin-RevId: 546996976