### PR TITLE
Disambiguate release and local `config_settings` via a release flag.

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -39,7 +39,7 @@ jobs:
         name: Set up Bazel caching
         uses: ./.github/actions/setup-bazel-cache
       - name: Build Wheels
-        run: cd ${{ github.workspace }} && docker run -e GOOGLE_APPLICATION_CREDENTIALS=/workspace/$(basename $GOOGLE_APPLICATION_CREDENTIALS) -v$PWD:/workspace $DOCKER_IMAGE build $BAZEL_CACHE --crosstool_top=@com_google_protobuf//toolchain:clang_suite --symlink_prefix=/ -c dbg python/dist ${{ steps.bazel-cache.outputs.cache_args }} python/dist:test_wheel python/dist:source_wheel
+        run: cd ${{ github.workspace }} && docker run -e GOOGLE_APPLICATION_CREDENTIALS=/workspace/$(basename $GOOGLE_APPLICATION_CREDENTIALS) -v$PWD:/workspace $DOCKER_IMAGE build $BAZEL_CACHE --crosstool_top=@com_google_protobuf//toolchain:clang_suite --@com_google_protobuf//toolchain:release=true --symlink_prefix=/ -c dbg python/dist ${{ steps.bazel-cache.outputs.cache_args }} python/dist:test_wheel python/dist:source_wheel
       - name: Move Wheels
         run: mkdir wheels && find _build/out \( -name 'protobuf*.whl' -o -name 'protobuf-*.tar.gz' \) -exec mv '{}' wheels ';'
       - uses: actions/upload-artifact@v3

--- a/bazel/workspace_deps.bzl
+++ b/bazel/workspace_deps.bzl
@@ -23,8 +23,8 @@ def upb_deps():
         _github_archive,
         name = "com_google_protobuf",
         repo = "https://github.com/protocolbuffers/protobuf",
-        commit = "64d9df70c60b02ab7c4d869973cd49cdee4c24c8",
-        sha256 = "8bf034558ba9d7672a372acb8e36daf119144d768cd90dc28c519fa097d823ea",
+        commit = "6a04b215a8d206062b4477f2fb8199592693d971",
+        sha256 = "c83b454382f4fe7e51e43c539e6201387f8cf7432c3ae95ce3ca5d5164cd517d",
         patches = ["@upb//bazel:protobuf.patch"],
     )
 

--- a/python/dist/BUILD.bazel
+++ b/python/dist/BUILD.bazel
@@ -64,6 +64,9 @@ py_proto_library(
 
 config_setting(
     name = "linux_aarch64_release",
+    flag_values = {
+        "@com_google_protobuf//toolchain:release": "True",
+    },
     values = {"cpu": "linux-aarch_64"},
 )
 
@@ -73,10 +76,16 @@ config_setting(
         "@platforms//os:linux",
         "@platforms//cpu:aarch64",
     ],
+    flag_values = {
+        "@com_google_protobuf//toolchain:release": "False",
+    },
 )
 
 config_setting(
     name = "linux_x86_64_release",
+    flag_values = {
+        "@com_google_protobuf//toolchain:release": "True",
+    },
     values = {"cpu": "linux-x86_64"},
 )
 
@@ -86,10 +95,16 @@ config_setting(
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",
     ],
+    flag_values = {
+        "@com_google_protobuf//toolchain:release": "False",
+    },
 )
 
 config_setting(
     name = "osx_x86_64_release",
+    flag_values = {
+        "@com_google_protobuf//toolchain:release": "True",
+    },
     values = {"cpu": "osx-x86_64"},
 )
 
@@ -99,6 +114,9 @@ config_setting(
         "@platforms//os:osx",
         "@platforms//cpu:x86_64",
     ],
+    flag_values = {
+        "@com_google_protobuf//toolchain:release": "False",
+    },
 )
 
 selects.config_setting_group(
@@ -111,6 +129,9 @@ selects.config_setting_group(
 
 config_setting(
     name = "osx_aarch64_release",
+    flag_values = {
+        "@com_google_protobuf//toolchain:release": "True",
+    },
     values = {"cpu": "osx-aarch_64"},
 )
 
@@ -120,6 +141,9 @@ config_setting(
         "@platforms//os:osx",
         "@platforms//cpu:aarch64",
     ],
+    flag_values = {
+        "@com_google_protobuf//toolchain:release": "False",
+    },
 )
 
 selects.config_setting_group(
@@ -137,6 +161,9 @@ config_setting(
 
 config_setting(
     name = "windows_x86_32_release",
+    flag_values = {
+        "@com_google_protobuf//toolchain:release": "True",
+    },
     values = {"cpu": "win32"},
 )
 
@@ -146,6 +173,9 @@ config_setting(
         "@platforms//os:windows",
         "@platforms//cpu:x86_32",
     ],
+    flag_values = {
+        "@com_google_protobuf//toolchain:release": "False",
+    },
 )
 
 selects.config_setting_group(
@@ -158,6 +188,9 @@ selects.config_setting_group(
 
 config_setting(
     name = "windows_x86_64_release",
+    flag_values = {
+        "@com_google_protobuf//toolchain:release": "True",
+    },
     values = {"cpu": "win64"},
 )
 
@@ -167,6 +200,9 @@ config_setting(
         "@platforms//os:windows",
         "@platforms//cpu:x86_64",
     ],
+    flag_values = {
+        "@com_google_protobuf//toolchain:release": "False",
+    },
 )
 
 selects.config_setting_group(


### PR DESCRIPTION
This flag was added to Protobuf and submitted separately due to version skew between repos.

This attempts to fix the following error from local and release settings both matching.
```
ERROR: /workspace/_build/out/external/upb/python/dist/BUILD.bazel:251:9: Illegal ambiguous match on configurable attribute "platform" in @upb//python/dist:binary_wheel:
@upb//python/dist:linux_x86_64_local
@upb//python/dist:windows_x86_64
Multiple matches are not allowed unless one is unambiguously more specialized or they resolve to the same value. See https://bazel.build/reference/be/functions#select.
```

This is a cherry-pick of https://github.com/protocolbuffers/upb/commit/629764bacfcc41a25d56faf9f44d46f38cd47573

PiperOrigin-RevId: 553226261