### PR TITLE
UPB python CopyFrom() back to Serialize/Parse wrap in 24.x

### DIFF
--- a/python/message.c
+++ b/python/message.c
@@ -1655,8 +1655,11 @@ static PyMethodDef PyUpb_Message_Methods[] = {
     {"ClearExtension", PyUpb_Message_ClearExtension, METH_O,
      "Clears a message field."},
     {"ClearField", PyUpb_Message_ClearField, METH_O, "Clears a message field."},
+#ifndef PROTO2_OPENSOURCE
+    // TODO(b/296078718): add the CopyFrom back in 25.0 fro OSS
     {"CopyFrom", PyUpb_Message_CopyFrom, METH_O,
      "Copies a protocol message into the current message."},
+#endif  // !PROTO2_OPENSOURCE
     {"DiscardUnknownFields", (PyCFunction)PyUpb_Message_DiscardUnknownFields,
      METH_NOARGS, "Discards the unknown fields."},
     {"FindInitializationErrors", PyUpb_Message_FindInitializationErrors,


### PR DESCRIPTION
To unblock https://github.com/protocolbuffers/protobuf/issues/13485

The main will keep the current memory copy and continue try to repro. We will go forward with memory copy in 25.0

THIS MEANS: The bug will return in 25.0 if we don't find an adequate repro in time.