### PR TITLE
Delete upb CopyFrom() in 24.X

### DIFF
--- a/python/message.c
+++ b/python/message.c
@@ -1655,11 +1655,9 @@ static PyMethodDef PyUpb_Message_Methods[] = {
     {"ClearExtension", PyUpb_Message_ClearExtension, METH_O,
      "Clears a message field."},
     {"ClearField", PyUpb_Message_ClearField, METH_O, "Clears a message field."},
-#ifndef PROTO2_OPENSOURCE
     // TODO(b/296078718): add the CopyFrom back in 25.0 fro OSS
-    {"CopyFrom", PyUpb_Message_CopyFrom, METH_O,
-     "Copies a protocol message into the current message."},
-#endif  // !PROTO2_OPENSOURCE
+    // {"CopyFrom", PyUpb_Message_CopyFrom, METH_O,
+    //  "Copies a protocol message into the current message."},
     {"DiscardUnknownFields", (PyCFunction)PyUpb_Message_DiscardUnknownFields,
      METH_NOARGS, "Discards the unknown fields."},
     {"FindInitializationErrors", PyUpb_Message_FindInitializationErrors,


### PR DESCRIPTION
Delete upb CopyFrom() and back to serialize/parse wrap in 24.X to unblock https://github.com/protocolbuffers/protobuf/issues/13485

CopyFrom() by memory should back in 25.0