### PR TITLE
Manual replication for 24.x of patch which fixes Python ByteSize()

### DIFF
--- a/python/message.c
+++ b/python/message.c
@@ -1422,9 +1422,10 @@ static PyObject* PyUpb_Message_FindInitializationErrors(PyObject* _self,
   upb_Message* msg = PyUpb_Message_GetIfReified(_self);
   const upb_MessageDef* msgdef = _PyUpb_Message_GetMsgdef(self);
   const upb_DefPool* ext_pool = upb_FileDef_Pool(upb_MessageDef_File(msgdef));
-  upb_FieldPathEntry* fields;
+  upb_FieldPathEntry* fields_base;
   PyObject* ret = PyList_New(0);
-  if (upb_util_HasUnsetRequired(msg, msgdef, ext_pool, &fields)) {
+  if (upb_util_HasUnsetRequired(msg, msgdef, ext_pool, &fields_base)) {
+    upb_FieldPathEntry* fields = fields_base;
     char* buf = NULL;
     size_t size = 0;
     assert(fields->field);
@@ -1444,6 +1445,7 @@ static PyObject* PyUpb_Message_FindInitializationErrors(PyObject* _self,
       Py_DECREF(str);
     }
     free(buf);
+    free(fields_base);
   }
   return ret;
 }

--- a/upb/util/required_fields.c
+++ b/upb/util/required_fields.c
@@ -300,11 +300,13 @@ bool upb_util_HasUnsetRequired(const upb_Message* msg, const upb_MessageDef* m,
   upb_FieldPathVector_Init(&ctx.out_fields);
   upb_util_FindUnsetRequiredInternal(&ctx, msg, m);
   free(ctx.stack.path);
-  if (fields) {
+
+  if (ctx.has_unset_required && fields) {
     upb_FieldPathVector_Reserve(&ctx, &ctx.out_fields, 1);
     ctx.out_fields.path[ctx.out_fields.size] =
         (upb_FieldPathEntry){.field = NULL};
     *fields = ctx.out_fields.path;
   }
+
   return ctx.has_unset_required;
 }

--- a/upb/util/required_fields_test.cc
+++ b/upb/util/required_fields_test.cc
@@ -27,6 +27,8 @@
 
 #include "upb/util/required_fields.h"
 
+#include <stdlib.h>
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "absl/strings/string_view.h"
@@ -69,11 +71,13 @@ void CheckRequired(absl::string_view json,
   EXPECT_TRUE(upb_JsonDecode(json.data(), json.size(), test_msg, m.ptr(),
                              defpool.ptr(), 0, arena.ptr(), status.ptr()))
       << status.error_message();
-  upb_FieldPathEntry* entries;
+  upb_FieldPathEntry* entries = nullptr;
   EXPECT_EQ(!missing.empty(), upb_util_HasUnsetRequired(
                                   test_msg, m.ptr(), defpool.ptr(), &entries));
-  EXPECT_EQ(missing, PathsToText(entries));
-  free(entries);
+  if (entries) {
+    EXPECT_EQ(missing, PathsToText(entries));
+    free(entries);
+  }
 
   // Verify that we can pass a NULL pointer to entries when we don't care about
   // them.


### PR DESCRIPTION
Necessary because the patch occurred post-monorepo but 24.x is pre-monorepo so everything is in a different location