### PR TITLE
Update protobuf deps for 24.3 + cherry pick malloc_trim

### DIFF
--- a/bazel/workspace_deps.bzl
+++ b/bazel/workspace_deps.bzl
@@ -23,8 +23,8 @@ def upb_deps():
         _github_archive,
         name = "com_google_protobuf",
         repo = "https://github.com/protocolbuffers/protobuf",
-        commit = "22e845e279bd79ad013bff4b79660b8c8b72d935",
-        sha256 = "276215041e767973f274299783b5d7b7de1a3c55628b9890bd9eb064dfa5daaf",
+        commit = "3465661aece8b9c754dcb3d4f0432bb89374e738",
+	sha256 = "1a59e28a55cc46fa444c976460799f6d76b69a6831fdb7da870ff9031fc40617",
         patches = ["@upb//bazel:protobuf.patch"],
     )
 


### PR DESCRIPTION
Updated to HEAD of 24.x:
https://github.com/protocolbuffers/protobuf/tree/24.x

Cherry-picked PR: 
https://github.com/protocolbuffers/protobuf/commit/56e9f2b4e467a7df5989a61eec142df7c72ab796